### PR TITLE
Build: add commit-msg linting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+## Guidelines
+:octocat: Make sure there's an issue open for any work you take on and intend to submit as a pull request - it helps core members review your concept and direction early and is a good way to discuss what you're planning to do.
+
+:scroll: Please follow our established coding conventions (with regards to formatting, etc), please see our [style guides](#style-guides) below.
+
+:100: We strive for 100% test coverage, to run tests locally use `npm run test`.
+
+:do_not_litter: We love lint. It keeps things consistent and protects against human error. Linting will be run automatically after running `npm run test`. You can also run `npm run posttest` on its own. See [commit conventions](#commit-conventions).
+
+:speech_balloon: Ensure that your effort is aligned with the project's roadmap by talking to the maintainers, especially if you are going to spend a lot of time on it.
+
+:+1: When in doubt, ask. We're here to help.
+
+## Style guides
+
+- [Airbnb ES2015](https://github.com/airbnb/javascript)
+- [Airbnb React](https://github.com/airbnb/javascript/tree/master/react)
+
+## Commit conventions
+
+Our commit message format is as follows:
+
+```
+Tag: Short description
+
+Longer description here if necessary.
+The first line of the commit message (the summary) must have a specific format.
+This format is checked by our build tools.
+```
+
+The `Tag` is one of the following:
+
+- `Fix` - for a bug fix.
+- `New` - implemented a new feature.
+- `Update` - for a backwards-compatible enhancement.
+- `Breaking` - for a backwards-incompatible enhancement or feature.
+- `Docs` - changes to documentation only.
+- `Build` - changes to build process only.
+- `Upgrade` - for a dependency upgrade.
+
+The message summary should be a one-sentence description of the change,
+and it must be 72 characters in length or shorter.
+
+Here are some good commit message summary examples:
+
+```
+Build: Update Travis to only test Node 0.10
+Fix: Special characters in link label causing parse error
+Upgrade: through2 to 2.0.0
+```
+
+The commit message format is important because they're used to create a changelog for each release.

--- a/README.md
+++ b/README.md
@@ -26,14 +26,10 @@ Technology:
 
 -	[Autoprefixer](https://github.com/postcss/autoprefixer)
 
-Style guides:
-
--	[Airbnb ES2015](https://github.com/airbnb/javascript)
-
--	[Airbnb React](https://github.com/airbnb/javascript/tree/master/react)
-
 Development
 -----------
+
+-	Take a look at our [Contributing](CONTRIBUTING.md) guidelines
 
 -	Clone the repo: `git clone git@github.com:Adslot/adslot-ui.git`
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "karma start",
     "test:watch": "karma start --autoWatch=true --singleRun=false",
     "codecov": "cat coverage/lcov.info | codecov",
-    "posttest": "npm run lint && npm run sass-lint && npm run jscs-lint",
+    "posttest": "npm run lint && npm run sass-lint && npm run jscs-lint && npm run check-commit",
     "serve": "node server.js --env=dev",
     "serve:dist": "node server.js --env=dist",
     "dist": "webpack --env=dist",
@@ -19,6 +19,7 @@
     "jscs-lint": "jscs ./src ./test",
     "jscs-fix": "jscs ./src ./test --fix",
     "clean": "rimraf dist/*",
+    "check-commit": "./scripts/commit-msg",
     "release:major": "npm version major && npm publish && git push --follow-tags",
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:patch": "npm version patch && npm publish && git push --follow-tags"

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Based on https://github.com/eslint/eslint/blob/master/Makefile.js
+require("shelljs/make");
+
+var semver = require("semver");
+
+'use strict';
+
+// Greenkeeper commit style ('chore(package)') should be allowed until commit templates are supported.
+var TAG_REGEX = /^(?:Fix|Update|Breaking|Docs|Build|New|Upgrade|chore\(package\)):/;
+
+/**
+ * Executes a command and returns the output instead of printing it to stdout.
+ * @param {string} cmd The command string to execute.
+ * @returns {string} The result of the executed command.
+ */
+function execSilent(cmd) {
+    return exec(cmd, { silent: true }).output;
+}
+
+/**
+ * Splits a command result to separate lines.
+ * @param {string} result The command result string.
+ * @returns {array} The separated lines.
+ */
+function splitCommandResultToLines(result) {
+    return result.trim().split("\n");
+}
+
+function checkGitCommit() {
+  var commitMsgs, failed;
+
+  echo("Validating commit message…");
+
+  commitMsgs = [execSilent("git log -1 --format=format:%s --no-merges")];
+
+  // No commit since master should not cause test to fail
+  if (commitMsgs[0] === "") {
+    return;
+  }
+
+  // Check for more than one commit
+  if (commitMsgs.length > 1) {
+    echo(" - More than one commit found, please squash.");
+    failed = true;
+  }
+
+  // Only check non-release messages
+  if (!semver.valid(commitMsgs[0]) && !/^Revert /.test(commitMsgs[0])) {
+    if (commitMsgs[0].slice(0, commitMsgs[0].indexOf("\n")).length > 72) {
+      echo(" - First line of commit message must not exceed 72 characters");
+      failed = true;
+    }
+
+    // Check for tag at start of message
+    if (!TAG_REGEX.test(commitMsgs[0])) {
+      echo([" - Commit summary must start with one of:",
+        "    'Fix:'",
+        "    'Update:'",
+        "    'Breaking:'",
+        "    'Docs:'",
+        "    'Build:'",
+        "    'New:'",
+        "    'Upgrade:'",
+        "   Please refer to the contribution guidelines for more details."].join("\n"));
+      failed = true;
+    }
+  }
+
+  if (failed) {
+    exit(1);
+  }
+}
+
+checkGitCommit();


### PR DESCRIPTION
Add commit message linting which checks:

- one commit per PR
- length of first line (72 chars)
- prefix of first line of commit (`PREFIX: short message`)

Allowed commit prefixes (based on ESLint commit message style):

- `Fix` - for a bug fix. (PATCH)
- `New` - implemented a new feature. (MINOR)
- `Update` - for a backwards-compatible enhancement. (MINOR)
- `Breaking` - for a backwards-incompatible enhancement or feature. (MAJOR)
- `Docs` - changes to documentation only.
- `Build` - changes to build process only.
- `Upgrade` - for a dependency upgrade.
