### PR TITLE
Build: Remove duplicate mock data in MultiPicker

### DIFF
--- a/.cpd.yaml
+++ b/.cpd.yaml
@@ -1,0 +1,13 @@
+exclude:
+  - "**/node_modules/**"
+files:
+  - "cfg/**/*"
+  - "src/**/*"
+  - "test/**/*"
+languages:
+  - javascript
+  - jsx
+  - css
+  - htmlmixed
+'min-tokens': 50
+'min-lines': 1

--- a/test/components/adslotUi/MultiPickerComponentTest.js
+++ b/test/components/adslotUi/MultiPickerComponentTest.js
@@ -10,13 +10,13 @@ import React from 'react';
 
 describe('MultiPickerComponent', () => {
   const {
-    itemHeaders,
-    items,
+    getInitialSelection,
+    userHeaders,
+    users,
     labelFormatter,
     teamMember1,
     teamMember2,
   } = MultiPickerMocks;
-  const getInitialSelection = () => [teamMember2];
 
   const getMultiPickerPureElement = (rootComponent) => {
     const modalBodyElement = rootComponent.props.children[1];
@@ -77,8 +77,8 @@ describe('MultiPickerComponent', () => {
     const initialSelection = getInitialSelection();
     const component = createComponent(MultiPickerComponent, {
       initialSelection,
-      itemHeaders,
-      items,
+      itemHeaders: userHeaders,
+      items: users,
       labelFormatter,
       modalDescription: 'Select users.',
       modalTitle: 'Select Users',
@@ -102,8 +102,8 @@ describe('MultiPickerComponent', () => {
 
     expect(multiPickerPureElement.props.deselectItem).to.be.a('function');
     expect(multiPickerPureElement.props.labelFormatter).to.be.a('function');
-    expect(multiPickerPureElement.props.itemHeaders).to.deep.equal(itemHeaders);
-    expect(multiPickerPureElement.props.items).to.deep.equal(items);
+    expect(multiPickerPureElement.props.itemHeaders).to.deep.equal(userHeaders);
+    expect(multiPickerPureElement.props.items).to.deep.equal(users);
     expect(multiPickerPureElement.props.selectItem).to.be.a('function');
     expect(multiPickerPureElement.props.selectedItems).to.deep.equal([teamMember2]);
   });
@@ -111,7 +111,7 @@ describe('MultiPickerComponent', () => {
   it('should disable apply button for empty selection if `allowEmptySelection` is false', () => {
     const component = createComponent(MultiPickerComponent, {
       allowEmptySelection: false,
-      items,
+      items: users,
     });
 
     const modalFooterElement = component.props.children[2];
@@ -123,7 +123,7 @@ describe('MultiPickerComponent', () => {
   it('should change `selectedItems` state after a `selectItem` action', () => {
     const component = createComponent(MultiPickerComponent, {
       initialSelection: getInitialSelection(),
-      items,
+      items: users,
     });
     const multiPickerPureElement = getMultiPickerPureElement(component);
     multiPickerPureElement.props.selectItem(teamMember1);
@@ -134,7 +134,7 @@ describe('MultiPickerComponent', () => {
   it('should change `selectedItems` state after a `deselectItem` action', () => {
     const component = createComponent(MultiPickerComponent, {
       initialSelection: getInitialSelection(),
-      items,
+      items: users,
     });
     const multiPickerPureElement = getMultiPickerPureElement(component);
     multiPickerPureElement.props.deselectItem(teamMember2);

--- a/test/components/adslotUi/MultiPickerPureComponentTest.js
+++ b/test/components/adslotUi/MultiPickerPureComponentTest.js
@@ -11,13 +11,13 @@ import { Grid, GridCell, GridRow } from 'alexandria-adslot';
 
 describe('MultiPickerPureComponent', () => {
   const {
+    getInitialSelection,
     labelFormatter,
-    teamMember2,
-    itemHeaders,
-    items,
+    userHeaders,
+    users,
   } = MultiPickerMocks;
 
-  const selectedItems = [teamMember2];
+  const selectedItems = getInitialSelection();
 
   Object.freeze(selectedItems);
 
@@ -31,8 +31,8 @@ describe('MultiPickerPureComponent', () => {
 
   it('should render with props', () => {
     const component = createComponent(MultiPickerPureComponent, {
-      itemHeaders,
-      items,
+      itemHeaders: userHeaders,
+      items: users,
       labelFormatter,
       selectedItems,
     });
@@ -58,19 +58,19 @@ describe('MultiPickerPureComponent', () => {
         expect(gridRowCellElements[0].type).to.equal((<GridCell />).type);
 
         const gridRowCellLeftText = gridRowCellElements[0].props.children;
-        expect(gridRowCellLeftText).to.equal(labelFormatter(items[index]));
+        expect(gridRowCellLeftText).to.equal(labelFormatter(users[index]));
 
         const gridRowCellCheckboxElement = gridRowCellElements[1].props.children;
         expect(gridRowCellCheckboxElement.type).to.equal((<Checkbox />).type);
 
-        expect(gridRowCellCheckboxElement.props.checked).to.equal(_.includes(selectedItems, items[index]));
+        expect(gridRowCellCheckboxElement.props.checked).to.equal(_.includes(selectedItems, users[index]));
       }
     }
   });
 
   it('should throw when we select without a `selectItem` handler', () => {
     const component = createComponent(MultiPickerPureComponent, {
-      items,
+      items: users,
       selectedItems,
     });
     expect(component.props.className).to.equal('multipickerpure-component');
@@ -87,7 +87,7 @@ describe('MultiPickerPureComponent', () => {
 
   it('should throw when we deselect without a `deselectItem` handler', () => {
     const component = createComponent(MultiPickerPureComponent, {
-      items,
+      items: users,
       selectedItems,
     });
     expect(component.props.className).to.equal('multipickerpure-component');
@@ -105,7 +105,7 @@ describe('MultiPickerPureComponent', () => {
   it('should call `selectItem` handler when we select', () => {
     let handlerCalled = 0;
     const component = createComponent(MultiPickerPureComponent, {
-      items,
+      items: users,
       selectedItems,
       selectItem: () => handlerCalled++,
     });
@@ -124,7 +124,7 @@ describe('MultiPickerPureComponent', () => {
     let handlerCalled = 0;
     const component = createComponent(MultiPickerPureComponent, {
       deselectItem: () => handlerCalled++,
-      items,
+      items: users,
       selectedItems,
     });
     expect(component.props.className).to.equal('multipickerpure-component');

--- a/test/components/adslotUi/UserMultiPickerComponentTest.js
+++ b/test/components/adslotUi/UserMultiPickerComponentTest.js
@@ -2,25 +2,17 @@
 /* global expect */
 
 import createComponent from 'testHelpers/shallowRenderHelper';
+import MultiPickerMocks from 'mocks/MultiPickerMocks';
 import React from 'react';
 import UserMultiPickerComponent from 'components/adslotUi/UserMultiPickerComponent';
 import { Avatar } from 'alexandria-adslot';
-import { deepFreeze } from 'testHelpers/deepSetObjectMutability';
 
 describe('UserMultiPickerComponent', () => {
-  const teamMember1 = { givenName: 'John', id: 1, surname: 'Smith' };
-
-  const teamMember2 = { givenName: 'Jane', id: 2, surname: 'Doe' };
-
-  const teamMember3 = { givenName: 'Jack', id: 3, surname: 'White' };
-
-  const userHeaders = { left: 'Team', right: 'Member' };
-
-  const users = [teamMember1, teamMember2, teamMember3];
-
-  const initialSelection = () => [teamMember2];
-
-  deepFreeze([teamMember1, teamMember2, teamMember3, userHeaders, users]);
+  const {
+    getInitialSelection,
+    userHeaders,
+    users,
+  } = MultiPickerMocks;
 
   it('should render with defaults', () => {
     const component = createComponent(UserMultiPickerComponent);
@@ -38,7 +30,7 @@ describe('UserMultiPickerComponent', () => {
   it('should render with props', () => {
     const component = createComponent(UserMultiPickerComponent, {
       allowEmptySelection: true,
-      initialSelection: initialSelection(),
+      initialSelection: getInitialSelection(),
       userHeaders,
       users,
       modalDescription: 'Select team members that you want.',
@@ -46,7 +38,7 @@ describe('UserMultiPickerComponent', () => {
     });
     expect(component.type.name).to.equal('MultiPickerComponent');
 
-    expect(component.props.initialSelection).to.deep.equal(initialSelection());
+    expect(component.props.initialSelection).to.deep.equal(getInitialSelection());
     expect(component.props.itemHeaders).to.deep.equal(userHeaders);
     expect(component.props.items).to.deep.equal(users);
     expect(component.props.modalClassName).to.equal('usermultipicker-component');

--- a/test/mocks/MultiPickerMocks.js
+++ b/test/mocks/MultiPickerMocks.js
@@ -8,17 +8,19 @@ const teamMember2 = { givenName: 'Jane', id: 2, surname: 'Doe' };
 
 const teamMember3 = { givenName: 'Jack', id: 3, surname: 'White' };
 
-const itemHeaders = { left: 'Team', right: 'Member' };
+const userHeaders = { left: 'Team', right: 'Member' };
 
-const items = [teamMember1, teamMember2, teamMember3];
+const users = [teamMember1, teamMember2, teamMember3];
+
+const getInitialSelection = () => [teamMember2];
 
 const MultiPickerMocks = {
+  getInitialSelection,
   labelFormatter,
   teamMember1,
   teamMember2,
-  teamMember3,
-  itemHeaders,
-  items,
+  userHeaders,
+  users,
 };
 
 deepFreeze(MultiPickerMocks);


### PR DESCRIPTION
- Add: Config file for jscpd.
  install with `npm i -g jscpd`
  run with `jscpd` from `adslot-ui/`
  it will highlight duplications in the codebase,
  use your judgement to decide whether the
  duplication is helpful for understanding
  or just more code to maintain.
- Remove duplication of mocks used between
  UserMultiPicker and MultiPicker.