### PR TITLE
Update: Add dts for treepicker components

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "open": "^0.0.5",
     "phantomjs-prebuilt": "^2.1.5",
     "react-addons-test-utils": "^0.14.7",
+    "react-addons-pure-render-mixin": "^0.14.7",
     "react-bootstrap": "^0.28.3",
     "react-hot-loader": "^1.3.0",
     "react-icheck": "^0.2.2",

--- a/src/components/adslotUi/SplitPaneComponent.js
+++ b/src/components/adslotUi/SplitPaneComponent.js
@@ -4,8 +4,8 @@ import React, { PropTypes } from 'react';
 
 require('styles/adslotUi/SplitPane.scss');
 
-const SplitPaneComponent = ({ children }) => (
-  <div className="splitpane-component">
+const SplitPaneComponent = ({ children, dts }) => (
+  <div className="splitpane-component" if dts data-test-selector={dts}>
     {children}
   </div>
 );
@@ -13,5 +13,6 @@ const SplitPaneComponent = ({ children }) => (
 SplitPaneComponent.displayName = 'AdslotUiSplitPaneComponent';
 SplitPaneComponent.propTypes = {
   children: PropTypes.node,
+  dts: PropTypes.string,
 };
 export default SplitPaneComponent;

--- a/src/components/adslotUi/TreePickerComponent.js
+++ b/src/components/adslotUi/TreePickerComponent.js
@@ -212,10 +212,10 @@ class TreePickerComponent extends React.Component {
           <TreePickerPure {...treePickerPureProps} />
         </Modal.Body>
         <Modal.Footer>
-          <Button className="btn-inverse" onClick={this.cancelAction}>
+          <Button className="btn-inverse" onClick={this.cancelAction} data-test-selector="treepicker-cancel-button">
             Cancel
           </Button>
-          <Button bsStyle="primary" onClick={this.applyAction}>
+          <Button bsStyle="primary" onClick={this.applyAction} data-test-selector="treepicker-apply-button">
             Apply
           </Button>
         </Modal.Footer>

--- a/src/components/adslotUi/TreePickerNodeComponent.js
+++ b/src/components/adslotUi/TreePickerNodeComponent.js
@@ -47,7 +47,7 @@ const TreePickerNodeComponent = ({
     {};
 
   return (
-    <div className={`${baseClass}`}>
+    <div className={`${baseClass}`} data-test-selector="treepicker-grid-row">
       <GridRow>
         {selected ?
           <GridCell classSuffixes={['button']}>

--- a/src/components/adslotUi/TreePickerPureComponent.js
+++ b/src/components/adslotUi/TreePickerPureComponent.js
@@ -49,12 +49,12 @@ const TreePickerPureComponent = ({
   return (
     <div className="treepickerpure-component">
 
-      <SplitPane>
+      <SplitPane dts="treepicker-splitpane-available">
 
         <ul className="nav nav-tabs">
           {rootTypes.length ? _.map(rootTypes, (rootType) =>
             <li className={(rootType.id === activeRootTypeId) ? 'active' : ''} key={rootType.id}>
-              <a onClick={changeRootTypeBound(rootType)}>
+              <a onClick={changeRootTypeBound(rootType)} data-test-selector="treepicker-nav-tab">
                 <SvgSymbol
                   href={_.get(rootType, 'svgSymbol.href')}
                   classSuffixes={_.get(rootType, 'svgSymbol.classSuffixes', ['gray-darker'])}
@@ -91,7 +91,7 @@ const TreePickerPureComponent = ({
         <FlexSpacer />
       </SplitPane>
 
-      <SplitPane>
+      <SplitPane dts="treepicker-splitpane-selected">
 
         <TreePickerSelected
           {...{

--- a/test/components/adslotUi/SplitPaneComponentTest.js
+++ b/test/components/adslotUi/SplitPaneComponentTest.js
@@ -3,14 +3,20 @@ import SplitPaneComponent from 'components/adslotUi/SplitPaneComponent';
 import { shallow } from 'enzyme';
 
 describe('SplitPaneComponent', () => {
-  it('should have its component name as default className', () => {
+  it('should have its component name as default className and no data-test-selector', () => {
     const component = shallow(<SplitPaneComponent />);
     expect(component.prop('className')).to.equal('splitpane-component');
+    expect(component.prop('data-test-selector')).to.be.an('undefined');
   });
 
   it('should transclude children', () => {
     const component = shallow(<SplitPaneComponent><div /></SplitPaneComponent>);
     expect(component.prop('className')).to.equal('splitpane-component');
     expect(component.children().type()).to.equal('div');
+  });
+
+  it('should set data-test-selector', () => {
+    const component = shallow(<SplitPaneComponent dts="please-select-me" />);
+    expect(component.prop('data-test-selector')).to.equal('please-select-me');
   });
 });

--- a/test/components/adslotUi/TreePickerComponentTest.js
+++ b/test/components/adslotUi/TreePickerComponentTest.js
@@ -106,11 +106,13 @@ describe('TreePickerComponent', () => {
 
     const modalFooterElement = component.find(Modal.Footer);
     const cancelButtonElement = modalFooterElement.find(Button).first();
+    expect(cancelButtonElement.prop('data-test-selector')).to.equal('treepicker-cancel-button');
     expect(cancelButtonElement.prop('className')).to.equal('btn-inverse');
     expect(cancelButtonElement.prop('onClick')).to.be.a('function');
     expect(cancelButtonElement.children().text()).to.equal('Cancel');
 
     const applyButtonElement = modalFooterElement.find(Button).last();
+    expect(applyButtonElement.prop('data-test-selector')).to.equal('treepicker-apply-button');
     expect(applyButtonElement.prop('bsStyle')).to.equal('primary');
     expect(applyButtonElement.prop('onClick')).to.be.a('function');
     expect(applyButtonElement.children().text()).to.equal('Apply');
@@ -332,7 +334,7 @@ describe('TreePickerComponent', () => {
     };
     const component = createAndMountComponent(<TreePickerComponent {...props} />);
     const modalFooterElement = component.find(Modal.Footer);
-    const applyButtonElement = modalFooterElement.find(Button).last();
+    const applyButtonElement = modalFooterElement.find('[data-test-selector="treepicker-apply-button"]');
     applyButtonElement.simulate('click');
     expect(applyCalls).to.deep.equal({ a: ['au-act', 'au-nt'] });
     expect(closeCalls).to.equal(1);
@@ -341,7 +343,7 @@ describe('TreePickerComponent', () => {
   it('should throw when we click Apply without a handler', () => {
     const component = createAndMountComponent(<TreePickerComponent initialSelection={initialSelection} />);
     const modalFooterElement = component.find(Modal.Footer);
-    const applyButtonElement = modalFooterElement.find(Button).last();
+    const applyButtonElement = modalFooterElement.find('[data-test-selector="treepicker-apply-button"]');
     expect(() => applyButtonElement.simulate('click')).to.throw(
       'AdslotUi TreePicker needs a modalApply handler for {"a":["au-act","au-nt"]}'
     );
@@ -362,7 +364,7 @@ describe('TreePickerComponent', () => {
     const props = { getSubtree: getSubtreeMock, modalClose: closeMock };
     const component = createAndMountComponent(<TreePickerComponent {...props} />);
     const modalFooterElement = component.find(Modal.Footer);
-    const cancelButtonElement = modalFooterElement.find(Button).first();
+    const cancelButtonElement = modalFooterElement.find('[data-test-selector="treepicker-cancel-button"]');
     expect(getSubtreeCalls).to.equal(1);
 
     const treePickerPureElement = getTreePickerPureElement(component);
@@ -388,7 +390,7 @@ describe('TreePickerComponent', () => {
     const props = { getSubtree: getSubtreeMock, modalClose: closeMock };
     const component = createAndMountComponent(<TreePickerComponent {...props} />);
     const modalFooterElement = component.find(Modal.Footer);
-    const cancelButtonElement = modalFooterElement.find(Button).first();
+    const cancelButtonElement = modalFooterElement.find('[data-test-selector="treepicker-cancel-button"]');
     expect(getSubtreeCalls).to.equal(1);
 
     const treePickerPureElement = getTreePickerPureElement(component);
@@ -405,7 +407,7 @@ describe('TreePickerComponent', () => {
   it('should throw when we click Close without a handler', () => {
     const component = shallow(<TreePickerComponent />);
     const modalFooterElement = component.find(Modal.Footer);
-    const cancelButtonElement = modalFooterElement.find(Button).first();
+    const cancelButtonElement = modalFooterElement.find('[data-test-selector="treepicker-cancel-button"]');
     expect(() => cancelButtonElement.simulate('click')).to.throw('AdslotUi TreePicker needs a modalClose handler');
   });
 

--- a/test/components/adslotUi/TreePickerNodeComponentTest.js
+++ b/test/components/adslotUi/TreePickerNodeComponentTest.js
@@ -15,6 +15,7 @@ describe('TreePickerNodeComponent', () => {
     expect(component.type()).to.equal('div');
 
     const rowElement = component.find(GridRow);
+    expect(rowElement.parent().prop('data-test-selector')).to.equal('treepicker-grid-row');
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(3); // meta data cell, value cell and include button cell
     expect(component.find(Button)).to.have.length(1);
@@ -51,7 +52,7 @@ describe('TreePickerNodeComponent', () => {
   it('should render the button first when selected is true', () => {
     const component = shallow(<TreePickerNodeComponent node={cbrNode} selected />);
 
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(3); // remove button cell, meta data cell and value cell
     expect(component.find(Button)).to.have.length(1);
@@ -68,7 +69,7 @@ describe('TreePickerNodeComponent', () => {
     const valueFormatter = (value) => `€${value / 100}`;
     const component = shallow(<TreePickerNodeComponent node={cbrNode} valueFormatter={valueFormatter} />);
 
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const valueCellElement = rowElement.prop('children')[3];
     expect(valueCellElement.props.children).to.equal('€20');
   });
@@ -78,7 +79,7 @@ describe('TreePickerNodeComponent', () => {
     delete node.value;
     const component = shallow(<TreePickerNodeComponent {...{ node }} />);
 
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     expect(rowElement.prop('children')).to.have.length(5);
     const valueCellElement = rowElement.prop('children')[3];
     expect(valueCellElement).to.be.a('null');
@@ -89,7 +90,7 @@ describe('TreePickerNodeComponent', () => {
     const expandNode = (node) => nodes.push(node);
     const component = shallow(<TreePickerNodeComponent node={cbrNode} expandNode={expandNode} />);
 
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(4); // meta data cell, expander cell, value cell and include button cell
 
@@ -105,7 +106,7 @@ describe('TreePickerNodeComponent', () => {
     const expandNode = (node) => nodes.push(node);
     const component = shallow(<TreePickerNodeComponent node={cbrNode} expandNode={expandNode} />);
 
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(4); // meta data cell, expander cell, value cell and include button cell
 
@@ -120,7 +121,7 @@ describe('TreePickerNodeComponent', () => {
     const nodes = [];
     const expandNode = (node) => nodes.push(node);
     const component = shallow(<TreePickerNodeComponent node={nonExpandableNode} expandNode={expandNode} />);
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(3); // meta data cell, value cell and include button cell
   });
@@ -129,7 +130,7 @@ describe('TreePickerNodeComponent', () => {
     const nodes = [];
     const includeNode = (node) => nodes.push(node);
     const component = shallow(<TreePickerNodeComponent node={cbrNode} includeNode={includeNode} />);
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(3); // meta data cell, value cell and include button cell
 
@@ -141,7 +142,7 @@ describe('TreePickerNodeComponent', () => {
 
   it('should error on click of `include` button without includeNode handler', () => {
     const component = shallow(<TreePickerNodeComponent node={cbrNode} />);
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(3); // meta data cell, value cell and include button cell
 
@@ -161,7 +162,7 @@ describe('TreePickerNodeComponent', () => {
       path: [],
     };
     const component = shallow(<TreePickerNodeComponent node={node} />);
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(3); // meta data cell, value cell and include button cell
 
@@ -187,7 +188,7 @@ describe('TreePickerNodeComponent', () => {
       path: [{ id: '30', label: 'Cars' }],
     };
     const component = shallow(<TreePickerNodeComponent node={node} />);
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(3); // meta data cell, value cell and include button cell
 
@@ -209,7 +210,7 @@ describe('TreePickerNodeComponent', () => {
     const removeNode = (node) => _.remove(nodes, { id: node.id });
     const props = { node: cbrNode, removeNode, selected: true };
     const component = shallow(<TreePickerNodeComponent {...props} />);
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(3); // remove button cell, meta data cell and value cell
 
@@ -223,7 +224,7 @@ describe('TreePickerNodeComponent', () => {
 
   it('should error on click of `remove` button without removeNode handler', () => {
     const component = shallow(<TreePickerNodeComponent node={cbrNode} selected />);
-    const rowElement = component.find(GridRow);
+    const rowElement = component.find('[data-test-selector="treepicker-grid-row"]').childAt(0);
     const cellElements = rowElement.find(GridCell);
     expect(cellElements).to.have.length(3); // remove button cell, meta data cell and value cell
 

--- a/test/components/adslotUi/TreePickerPureComponentTest.js
+++ b/test/components/adslotUi/TreePickerPureComponentTest.js
@@ -20,7 +20,7 @@ describe('TreePickerPureComponent', () => {
     const component = shallow(<TreePickerPureComponent changeRootType={_.noop} />);
     expect(component.prop('className')).to.equal('treepickerpure-component');
 
-    const leftPaneElement = component.find(SplitPaneComponent).first();
+    const leftPaneElement = component.find('[dts="treepicker-splitpane-available"]');
     const tabsElement = leftPaneElement.find('ul');
     expect(tabsElement.prop('className')).to.equal('nav nav-tabs');
 
@@ -78,14 +78,14 @@ describe('TreePickerPureComponent', () => {
     const component = shallow(<TreePickerPureComponent {...props} />);
     expect(component.prop('className')).to.equal('treepickerpure-component');
 
-    const leftPaneElement = component.find(SplitPaneComponent).first();
+    const leftPaneElement = component.find('[dts="treepicker-splitpane-available"]');
     const tabsElement = leftPaneElement.find('ul');
     expect(tabsElement.prop('className')).to.equal('nav nav-tabs');
 
     const firstTabElement = tabsElement.find('li').first();
     expect(firstTabElement.prop('className')).to.equal('active');
 
-    const firstTabAnchor = firstTabElement.find('a');
+    const firstTabAnchor = firstTabElement.find('[data-test-selector="treepicker-nav-tab"]').first();
     expect(firstTabAnchor.children().last().text()).to.equal(rootTypes[0].label);
 
     expect(rootTypeChanges).to.deep.equal([]);
@@ -115,7 +115,7 @@ describe('TreePickerPureComponent', () => {
     expect(treePickerGridElement.prop('emptySvgSymbol').classSuffixes).to.deep.equal(['gray-light']);
     expect(treePickerGridElement.prop('emptyText')).to.equal('No items to select.');
 
-    const rightPaneElement = component.find(SplitPaneComponent).last();
+    const rightPaneElement = component.find('[dts="treepicker-splitpane-selected"]');
     const treePickerSelectedElement = rightPaneElement.find(TreePickerSelectedComponent);
     expect(treePickerSelectedElement.prop('averageWithinRootType')).to.equal(true);
     expect(treePickerSelectedElement.prop('selectedLabel')).to.equal('Selected Targeting');


### PR DESCRIPTION
Adding dts for key treepicker components, so it can be later used in e2e test for line item targeting.