### PR TITLE
Fix: Adding gitattributes to get Git always use LF for line ending.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Adding .gitattributes to get Git always use LF for line ending. This config will resolve the line ending issue on windows.
Because git on windows will automatically convert LF to CRLF for line endings by default, which cause eslint and jscs to throw validateLineBreaks error. 