### PR TITLE
Fix: Pin sass-lint at 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-select": "^1.0.0-beta12",
     "react-toggle": "^2.0.1",
     "redux": "^3.3.1",
-    "sass-lint": "^1.5.1",
+    "sass-lint": "=1.5.1",
     "sass-loader": "^3.2.0",
     "seamless-immutable": "^5.1.1",
     "sinon": "^2.0.0-pre",


### PR DESCRIPTION
It appears that sass-lint 1.6.0 barfs on some adjacency (+) selectors we use without giving a useful message. Pin at 1.5.1 for now.