### PR TITLE
New: Hide Treepicker empty on null subtree

### DIFF
--- a/src/components/adslotUi/TreePickerGridComponent.js
+++ b/src/components/adslotUi/TreePickerGridComponent.js
@@ -31,11 +31,13 @@ const TreePickerGridComponent = ({
         }}
       />
     )}
-    <Empty
-      collection={nodes}
-      svgSymbol={emptySvgSymbol}
-      text={emptyText}
-    />
+    {nodes ?
+      <Empty
+        collection={nodes}
+        svgSymbol={emptySvgSymbol}
+        text={emptyText}
+      /> :
+      null}
   </Grid>
 );
 
@@ -46,7 +48,7 @@ TreePickerGridComponent.propTypes = {
   emptyText: PropTypes.string.isRequired,
   expandNode: PropTypes.func,
   includeNode: PropTypes.func,
-  nodes: PropTypes.arrayOf(TreePickerPropTypes.node).isRequired,
+  nodes: PropTypes.arrayOf(TreePickerPropTypes.node),
   removeNode: PropTypes.func,
   selected: PropTypes.bool.isRequired,
   valueFormatter: PropTypes.func,

--- a/src/components/adslotUi/TreePickerSimplePureComponent.js
+++ b/src/components/adslotUi/TreePickerSimplePureComponent.js
@@ -84,7 +84,7 @@ TreePickerSimplePureComponent.propTypes = {
   searchPlaceholder: PropTypes.string,
   searchValue: PropTypes.string,
   selectedNodes: PropTypes.arrayOf(TreePickerPropTypes.node.isRequired).isRequired,
-  subtree: PropTypes.arrayOf(TreePickerPropTypes.node.isRequired).isRequired,
+  subtree: PropTypes.arrayOf(TreePickerPropTypes.node.isRequired),
   svgSymbolCancel: PropTypes.shape(SvgSymbol.propTypes),
   svgSymbolSearch: PropTypes.shape(SvgSymbol.propTypes),
 };

--- a/src/helpers/TreePickerHelpers.js
+++ b/src/helpers/TreePickerHelpers.js
@@ -1,7 +1,10 @@
 import _ from 'lodash';
 
-exports.removeSelected = ({ subtree, selectedNodes }) =>
-  _(subtree)
+exports.removeSelected = ({ subtree, selectedNodes }) => {
+  if (!subtree) return subtree;
+
+  return _(subtree)
     .reject(({ id }) => _.some(selectedNodes, { id }))
     .sortBy('label')
     .value();
+};

--- a/test/components/adslotUi/TreePickerGridComponentTest.js
+++ b/test/components/adslotUi/TreePickerGridComponentTest.js
@@ -36,4 +36,22 @@ describe('TreePickerGridComponent', () => {
     expect(emptyElement.prop('svgSymbol')).to.equal(props.emptySvgSymbol);
     expect(emptyElement.prop('text')).to.equal(props.emptyText);
   });
+
+  it('should not display empty with an undefined nodes list', () => {
+    const props = {
+      emptySvgSymbol: TreePickerMocks.svgSymbol,
+      emptyText: 'Empty!',
+      expandNode: _.noop,
+      includeNode: _.noop,
+      nodes: undefined,
+      removeNode: _.noop,
+      selected: false,
+      valueFormatter: TreePickerMocks.valueFormatter,
+    };
+    const component = shallow(<TreePickerGrid {...props} />);
+    const gridElement = component.find(Grid);
+    const emptyElement = gridElement.find(Empty);
+
+    expect(emptyElement).to.have.length(0);
+  });
 });

--- a/test/helpers/TreePickerHelpersTest.js
+++ b/test/helpers/TreePickerHelpersTest.js
@@ -1,0 +1,26 @@
+import { removeSelected } from '../../src/helpers/TreePickerHelpers';
+
+describe('TreePickerHelpers', () => {
+  describe('removeSelected', () => {
+    it('should remove selected nodes from a subtree', () => {
+      const subtree = [{ id: 1 }, { id: 2 }, { id: 3 }];
+      const selectedNodes = [{ id: 1 }, { id: 3 }];
+
+      expect(removeSelected({ subtree, selectedNodes })).to.deep.equal([{ id: 2 }]);
+    });
+
+    it('should return an empty array when passed an empty subtree', () => {
+      const subtree = [];
+      const selectedNodes = [{ id: 1 }, { id: 3 }];
+
+      expect(removeSelected({ subtree, selectedNodes })).to.deep.equal([]);
+    });
+
+    it('should return undefined when passed an undefined subtree', () => {
+      const subtree = undefined;
+      const selectedNodes = [{ id: 1 }, { id: 3 }];
+
+      expect(removeSelected({ subtree, selectedNodes })).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Currently there is no way to suppress the empty state of the treepicker during load. This means if the treepicker is being asynchronously populated (e.g. from REST) there will be an empty state flash.

Fix by considering a subtree of [] empty but hiding the empty state on null/undefined