### PR TITLE
Update: form help block margin

### DIFF
--- a/src/components/adslotUi/ListPickerComponent.js
+++ b/src/components/adslotUi/ListPickerComponent.js
@@ -105,8 +105,14 @@ class ListPickerComponent extends React.Component {
                   </GridRow>
                   {_.map(props.itemInfo.properties, (property) =>
                     <GridRow key={property.label} horizontalBorder={false}>
-                      <GridCell classSuffixes={['label']} dts={_.kebabCase(property.label)}>{property.label}</GridCell>
-                      <GridCell stretch classSuffixes={['value']}>{property.value}</GridCell>
+                      <GridCell classSuffixes={['label']}>{property.label}</GridCell>
+                      <GridCell
+                        classSuffixes={['value']}
+                        dts={_.kebabCase(property.label)}
+                        stretch
+                      >
+                        {property.value}
+                      </GridCell>
                     </GridRow>
                   )}
                 </Grid>

--- a/src/examples/components/forms.js
+++ b/src/examples/components/forms.js
@@ -77,7 +77,10 @@ const ExampleForm = ({
 
         <fieldset className="borderless">
           <div className="form-group">
-            <label htmlFor="exampleTextarea" className="control-label col-xs-3">Text area (optional)</label>
+            <label htmlFor="exampleTextarea" className="control-label col-xs-3">
+              Text area
+              <div className="help-block">(recommended)</div>
+            </label>
             <div className="col-xs-9">
               <textarea
                 className="form-control"

--- a/src/styles/bootstrapOverrides/Form.scss
+++ b/src/styles/bootstrapOverrides/Form.scss
@@ -83,6 +83,14 @@ label {
   margin-top: 8px;
 }
 
+.form-horizontal {
+  .control-label {
+    .help-block {
+      margin-top: 1px;
+    }
+  }
+}
+
 .borderedwell-component {
   .form-horizontal {
     padding: $spacing-etalon $spacing-etalon 0;


### PR DESCRIPTION
This will wrap the form help-block with the control label and will reduce the top margin space of the help block

![screen shot 2016-05-31 at 2 08 07 pm](https://cloud.githubusercontent.com/assets/7802760/15663007/6fbcb0b2-2739-11e6-863c-137488d80580.png)
