### PR TITLE
[WIP] Heading and grouping support in TreePickerSimplePure

### DIFF
--- a/src/components/adslotUi/TreePickerGridComponent.jsx
+++ b/src/components/adslotUi/TreePickerGridComponent.jsx
@@ -7,6 +7,11 @@ import { Empty, Grid, SvgSymbol } from 'alexandria-adslot';
 
 const TreePickerNodeFast = fastStatelessWrapper(TreePickerNode, ['node.id', 'disabled', 'selected']);
 
+const getRootTypeLabel = ({ rootTypes, rootTypeId }) => {
+  const rootTypeMatchingId = _.find(rootTypes, { id: rootTypeId });
+  if (rootTypeMatchingId) return rootTypeMatchingId.label;
+};
+
 const TreePickerGridComponent = ({
   disabled,
   emptySvgSymbol,
@@ -19,33 +24,55 @@ const TreePickerGridComponent = ({
   selected,
   valueFormatter,
   emptyText,
-}) => (
-  <Grid>
-    {_.map(nodes, (node) =>
-      <TreePickerNodeFast
-        key={node.id}
-        {...{
-          disabled,
-          expandNode,
-          includeNode,
-          itemType,
-          node,
-          nodeRenderer,
-          removeNode,
-          selected,
-          valueFormatter,
-        }}
-      />
-    )}
-    {nodes ?
-      <Empty
-        collection={nodes}
-        svgSymbol={emptySvgSymbol}
-        text={emptyText}
-      /> :
-      null}
-  </Grid>
-);
+
+  // from TreePickerSelectedComponent
+  // nodeGrouper,
+  rootTypes,
+  selectedNodesByRootType,
+}) => {
+
+  return (
+    <div>
+      {_.map(selectedNodesByRootType, (val, rootTypeId) => {
+        const rootTypeLabel = getRootTypeLabel({ rootTypes, rootTypeId });
+
+        return (
+          <Grid key={rootTypeId}>
+            <GridRow type="header">
+              <GridCell stretch>{rootTypeLabel}</GridCell>
+            </GridRow>
+
+            {_.map(selectedNodesByRootType[rootTypeId], (node) =>
+              <TreePickerNodeFast
+                key={node.id}
+                {...{
+                  disabled,
+                  expandNode,
+                  includeNode,
+                  itemType,
+                  node,
+                  nodeRenderer,
+                  removeNode,
+                  selected,
+                  valueFormatter,
+                }}
+              />
+            )}
+          </Grid>
+        );
+      })}
+      {nodes ?
+        <Empty
+          collection={nodes}
+          svgSymbol={emptySvgSymbol}
+          text="hardcoded empty state."
+        /> :
+        null}
+    </div>
+  );
+};
+
+// TODO: revert empty text above..
 
 TreePickerGridComponent.displayName = 'AdslotUiTreePickerGridComponent';
 
@@ -57,14 +84,21 @@ TreePickerGridComponent.propTypes = {
   includeNode: PropTypes.func,
   itemType: PropTypes.string.isRequired,
   nodes: PropTypes.arrayOf(TreePickerPropTypes.node),
+  // nodeGrouper: PropTypes.array,
   nodeRenderer: PropTypes.func,
   removeNode: PropTypes.func,
   selected: PropTypes.bool.isRequired,
   valueFormatter: PropTypes.func,
+
+  rootTypes: PropTypes.arrayOf(TreePickerPropTypes.rootType).isRequired,
+  selectedNodesByRootType: PropTypes.shape().isRequired,
 };
 
 TreePickerGridComponent.defaultProps = {
   disabled: false,
+
+  rootTypes: [],
+  selectedNodesByRootType: {},
 };
 
 export default TreePickerGridComponent;

--- a/src/components/adslotUi/TreePickerSimplePureComponent.jsx
+++ b/src/components/adslotUi/TreePickerSimplePureComponent.jsx
@@ -34,6 +34,9 @@ const TreePickerSimplePureComponent = ({
   subtree,
   svgSymbolCancel,
   svgSymbolSearch,
+
+  rootTypes,
+  selectedNodesByRootType,
 }) => {
   const selectableNodes = removeSelected({ subtree, selectedNodes });
   let searchTextNode = emptyText || 'No items to select.';
@@ -87,6 +90,9 @@ const TreePickerSimplePureComponent = ({
             nodeRenderer,
             removeNode,
             selected: true,
+
+            rootTypes,
+            selectedNodesByRootType,
           }}
         />
         <FlexibleSpacer />
@@ -122,11 +128,17 @@ TreePickerSimplePureComponent.propTypes = {
   subtree: PropTypes.arrayOf(TreePickerPropTypes.node.isRequired),
   svgSymbolCancel: PropTypes.shape(SvgSymbol.propTypes),
   svgSymbolSearch: PropTypes.shape(SvgSymbol.propTypes),
+
+  rootTypes: PropTypes.arrayOf(TreePickerPropTypes.rootType).isRequired,
+  selectedNodesByRootType: PropTypes.shape(),
 };
 
 TreePickerSimplePureComponent.defaultProps = {
   disabled: false,
   itemType: 'node',
+
+  rootTypes: [],
+  selectedNodesByRootType: {},
 };
 
 export default TreePickerSimplePureComponent;


### PR DESCRIPTION
todo:
- props passing and prop args
- testing

There is a lot of copy/paste duplication between `TreePickerSimplePure` and the `TreePickerSelectedComponent` implementation at the moment. Need to get behaviour right before refactor.
