### PR TITLE
Update: Tree picker node component to support child nodes

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -127,7 +127,7 @@ class AppComponent extends React.Component {
       ],
       treePickerPureSubtree: [],
       selectedNodes: [
-        { id: '2', label: 'Norfolk Island', path: [{ id: '11', label: 'AU' }], type: '', isSelectable: false },
+        { id: '2', label: 'Norfolk Island', path: [], type: '', isSelectable: false },
         { id: '3', label: 'Queensland', path: [{ id: '12', label: 'AU' }], type: '' },
       ],
       searchBarString: '',

--- a/src/components/adslotUi/TreePickerNodeComponent.jsx
+++ b/src/components/adslotUi/TreePickerNodeComponent.jsx
@@ -57,7 +57,7 @@ const TreePickerNodeComponent = ({
   const labelCellProps = expanderElement ? { onClick: expandNodeBound } : {};
 
   return (
-    <div className={`${baseClass}`}>
+    <div className={!_.isEmpty(node.path) || !_.isEmpty(node.ancestors) ? `${baseClass} child-node` : `${baseClass}`}>
       <GridRow dts={`${_.kebabCase(itemType)}-${node.id}`}>
         {selected ?
           <GridCell classSuffixes={['button']} dts="button-remove">

--- a/test/components/adslotUi/TreePickerNodeComponentTest.jsx
+++ b/test/components/adslotUi/TreePickerNodeComponentTest.jsx
@@ -11,7 +11,7 @@ describe('TreePickerNodeComponent', () => {
 
   it('should render a node with defaults', () => {
     const component = shallow(<TreePickerNodeComponent itemType={itemType} node={cbrNode} />);
-    expect(component.prop('className')).to.equal('treepickernode-component');
+    expect(component.prop('className')).to.equal('treepickernode-component child-node');
     expect(component.type()).to.equal('div');
 
     const rowElement = component.find(GridRow);
@@ -141,6 +141,16 @@ describe('TreePickerNodeComponent', () => {
     expect(rowElement.prop('children')).to.have.length(5);
     const valueCellElement = rowElement.prop('children')[3];
     expect(valueCellElement).to.be.a('null');
+  });
+
+  it('should not have the child node class for root nodes', () => {
+    const component = shallow(<TreePickerNodeComponent itemType={itemType} node={maleNode} />);
+    expect(component.prop('className')).to.equal('treepickernode-component');
+  });
+
+  it('should have the child node class for child nodes', () => {
+    const component = shallow(<TreePickerNodeComponent itemType={itemType} node={cbrNode} />);
+    expect(component.prop('className')).to.equal('treepickernode-component child-node');
   });
 
   it('should fire expandNode when clicking on the `expand` cell', () => {


### PR DESCRIPTION
Support tree picker node component with child nodes. If `isChildNode` property of a node is true, then it will contain a padding to indent correctly .

![screen shot 2016-11-21 at 4 02 05 pm](https://cloud.githubusercontent.com/assets/7802760/20472211/df1c9390-b00b-11e6-8587-a00494d8cb93.png)
