### PR TITLE
Fix: Broken checkboxes

### DIFF
--- a/src/components/adslotUi/FormGroupComponent.jsx
+++ b/src/components/adslotUi/FormGroupComponent.jsx
@@ -15,8 +15,8 @@ const FormGroupComponent = ({
   return (
     <div className="form-group">
       <label htmlFor={inputId} className="control-label col-xs-3">{label}</label>
-      <div className="col-xs-9">
-        <div className="input-group col-xs-6">
+      <div className="col-xs-5">
+        <div className="input-group col-xs-12">
           {addonElement}
           <input
             className="form-control"

--- a/src/examples/components/forms.jsx
+++ b/src/examples/components/forms.jsx
@@ -54,8 +54,8 @@ const ExampleForm = ({
 
           <div className="form-group">
             <label htmlFor="exampleTextInput" className="control-label col-xs-3">Text input</label>
-            <div className="col-xs-9">
-              <div className="input-group col-xs-6">
+            <div className="col-xs-5">
+              <div className="input-group col-xs-12">
                 <input
                   className="form-control"
                   disabled={isSubmitting}
@@ -69,7 +69,7 @@ const ExampleForm = ({
               <br />
 
               <div className="form-control-static">Instruction or grouped placeholder</div>
-              <div className="input-group col-xs-6">
+              <div className="input-group col-xs-12">
                 <div className="input-group-addon">$</div>
                 <input
                   className="form-control"
@@ -92,7 +92,7 @@ const ExampleForm = ({
               Text area
               <div className="help-block">(recommended)</div>
             </label>
-            <div className="col-xs-9">
+            <div className="col-xs-5">
               <textarea
                 className="form-control"
                 disabled={isSubmitting}
@@ -107,7 +107,7 @@ const ExampleForm = ({
 
           <div className="form-group">
             <label htmlFor="fruitSelect" className="control-label col-xs-3">Select box</label>
-            <div className="col-xs-9">
+            <div className="col-xs-5">
               <Select
                 clearable={false}
                 disabled={isSubmitting}
@@ -124,7 +124,7 @@ const ExampleForm = ({
 
           <div className="form-group">
             <label htmlFor="exampleInputFile" className="control-label col-xs-3">File input</label>
-            <div className="col-xs-9">
+            <div className="col-xs-5">
               <input
                 type="file"
                 disabled={isSubmitting}
@@ -136,7 +136,7 @@ const ExampleForm = ({
 
           <div className="form-group">
             <label htmlFor="exampleFilePicker" className="control-label col-xs-3">FilePicker Component</label>
-            <div className="col-xs-9">
+            <div className="col-xs-5">
               <FilePicker
                 filter="*.*"
                 disabled={isSubmitting}
@@ -149,7 +149,7 @@ const ExampleForm = ({
           </div>
 
           <div className="form-group">
-            <div className="col-xs-9 col-xs-offset-3">
+            <div className="col-xs-5 col-xs-offset-3">
               <div className="checkbox">
                 <Checkbox
                   disabled={isSubmitting}
@@ -163,7 +163,7 @@ const ExampleForm = ({
 
           <div className="form-group">
             <label htmlFor="exampleCheckbox" className="control-label col-xs-3">Enable Some Feature</label>
-            <div className="col-xs-9">
+            <div className="col-xs-5">
               <div className="checkbox">
                 <Checkbox
                   disabled={isSubmitting}
@@ -176,7 +176,7 @@ const ExampleForm = ({
 
           <div className="form-group">
             <label htmlFor="exampleRadioGroup" className="control-label col-xs-3">RadioGroup Stacked</label>
-            <div className="col-xs-9">
+            <div className="col-xs-5">
               <RadioGroup className="radiogroup-stacked" name="testRadioGroup">
                 <Radio
                   label="Geography"

--- a/src/styles/bootstrapOverrides/Button.scss
+++ b/src/styles/bootstrapOverrides/Button.scss
@@ -146,3 +146,9 @@
     }
   }
 }
+
+.input-group-btn {
+  > .btn {
+    padding-bottom: $padding-base-vertical - 1px;
+  }
+}

--- a/src/styles/bootstrapOverrides/Checkbox.scss
+++ b/src/styles/bootstrapOverrides/Checkbox.scss
@@ -1,47 +1,53 @@
 @import '../variable';
 
-$checkbox-margin: 2px;
-$input-container-height: 18px;
+.checkbox,
+.radio,
+.radiogroup-stacked {
+  label {
+    font-weight: $font-weight-medium;
+    padding-top: 1px;
+  }
+
+  .icheckbox {
+    margin-left: -20px; // For alignment with bootstrap
+
+    > input {
+      margin-left: 0;
+    }
+  }
+
+  // When a checkbox is directly inside a .checkbox we need to ingore the -20px margin
+  > .icheckbox,
+  > .iradio {
+    margin-left: 0;
+  }
+
+  > input {
+    &[type='checkbox'],
+    &[type='radio'] {
+      margin-left: 0;
+    }
+  }
+}
 
 input {
   &[type='checkbox'],
   &[type='radio'] {
-    cursor: pointer;
-    margin: $checkbox-margin 0 0;
+    width: 16px;
+    height: 16px;
+    margin-top: 0;
   }
 }
 
-.radio + .radio,
-.checkbox + .checkbox {
-  margin-top: 5px;
-}
-
-.checkbox,
-.radio {
-  line-height: $input-container-height;
-  margin-bottom: 0;
-  margin-top: 0;
-  min-height: $input-container-height;
-
-  label {
+.icheckbox,
+.iradio {
+  + span {
     font-weight: $font-weight-medium;
-    margin-top: 5px;
+  }
 
-    .icheckbox {
-      margin-left: -20px; // align with bootstrap, which expects the checkbox element to be -20px
+  &:not(.disabled) {
+    + span {
+      cursor: pointer;
     }
-  }
-
-  > * {
-    margin-top: 5px;
-  }
-}
-
-
-.icheckbox {
-  input {
-    width: $input-container-height - $checkbox-margin;
-    height: $input-container-height - $checkbox-margin;
-    margin-left: 0; // fix bootstrap override on hidden input
   }
 }

--- a/src/styles/bootstrapOverrides/Form.scss
+++ b/src/styles/bootstrapOverrides/Form.scss
@@ -8,7 +8,8 @@
     }
 
     .checkbox {
-      padding-top: 0;
+      padding-top: 3px;
+      min-height: 16px;
     }
   }
 

--- a/test/components/adslotUi/FormGroupComponentTest.jsx
+++ b/test/components/adslotUi/FormGroupComponentTest.jsx
@@ -19,12 +19,12 @@ describe('FormGroupComponent', () => {
     expect(labelElement.prop('className')).to.equal('control-label col-xs-3');
     expect(labelElement.text()).to.equal('Sweet Caroline');
 
-    const columnElement = component.find('.col-xs-9');
+    const columnElement = component.find('.col-xs-5');
     expect(columnElement).to.have.length(1);
 
     const inputGroupElement = columnElement.find('.input-group');
     expect(inputGroupElement).to.have.length(1);
-    expect(inputGroupElement.prop('className')).to.equal('input-group col-xs-6');
+    expect(inputGroupElement.prop('className')).to.equal('input-group col-xs-12');
 
     const inputElement = inputGroupElement.find('input');
     expect(inputElement).to.have.length(1);


### PR DESCRIPTION
Checkbox alignment has been off and labels have been bold, which is not the desired behavior. Cleanup lots of `icheckbox` and bootstrap overrides. Also update the form styles to provide more breathing space.

![screen shot 2017-03-06 at 17 24 54](https://cloud.githubusercontent.com/assets/908155/23599070/cf9c1254-0292-11e7-8a0d-f01ab225ffc1.png)

![screen shot 2017-03-06 at 17 16 56](https://cloud.githubusercontent.com/assets/908155/23598781/cf043418-0290-11e7-9bb3-718168b53176.png)
