### PR TITLE
Add extra chunk

### DIFF
--- a/cfg/dist.js
+++ b/cfg/dist.js
@@ -41,7 +41,9 @@ const config = _.merge(baseConfig, {
     },
   },
   entry: {
-    main: path.join(componentsPath, '/distributionEntry.js'),
+    main: path.join(componentsPath, '/distributionEntry'),
+    core: path.join(componentsPath, '/distributionEntry/core'),
+    extra: path.join(componentsPath, '/distributionEntry/extra'),
   },
   output: {
     path: path.resolve(__dirname, '../dist'),
@@ -57,7 +59,7 @@ const config = _.merge(baseConfig, {
         warnings: false,
       },
       sourceMap: false,
-      include: /main\.js$/,
+      include: /\.js$/,
     }),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.AggressiveMergingPlugin(),

--- a/src/components/core.js
+++ b/src/components/core.js
@@ -3,7 +3,6 @@ import Accordion from 'components/adslotUi/AccordionComponent';
 import SearchBar from 'components/adslotUi/SearchBarComponent';
 import Checkbox from 'react-icheck/lib/Checkbox';
 import ConfirmModal from 'components/adslotUi/ConfirmModalComponent';
-import DatePicker from 'react-datepicker/dist/react-datepicker';
 import fastStatelessWrapper from 'components/adslotUi/fastStatelessWrapper';
 import FilePicker from 'components/adslotUi/FilePickerComponent';
 import FormGroup from 'components/adslotUi/FormGroupComponent';
@@ -54,7 +53,6 @@ import {
 import 'styles/_bootstrap-custom.scss';
 import 'styles/_icheck-custom.scss';
 import 'styles/_react-select-custom.scss';
-import 'styles/_react-datepicker-custom.scss';
 
 export {
   Accordion,
@@ -66,7 +64,6 @@ export {
   Card,
   Checkbox,
   ConfirmModal,
-  DatePicker,
   Empty,
   fastStatelessWrapper,
   FilePicker,

--- a/src/components/distributionEntry/core.js
+++ b/src/components/distributionEntry/core.js
@@ -1,0 +1,1 @@
+export * from '../core';

--- a/src/components/distributionEntry/extra.js
+++ b/src/components/distributionEntry/extra.js
@@ -1,0 +1,1 @@
+export * from '../extra';

--- a/src/components/distributionEntry/index.js
+++ b/src/components/distributionEntry/index.js
@@ -1,0 +1,7 @@
+import _ from 'lodash';
+
+// es6 "import * from" is not used for upseting coverage because of unknown reason
+module.exports = _.assign(
+  require('../core'),
+  require('../extra')
+);

--- a/src/components/extra.js
+++ b/src/components/extra.js
@@ -1,0 +1,4 @@
+import 'styles/_react-datepicker-custom.scss';
+import DatePicker from 'react-datepicker/dist/react-datepicker';
+
+export { DatePicker }; // eslint-disable-line import/prefer-default-export


### PR DESCRIPTION
#Put ```react-datepicker``` to an extra chunk, halving the size

We now have 3 bundles
```adslot-ui-main```: full bundle, the name is preserved to not make this a breaking change.
```adslot-ui-core```: load if you don't need the extra stuff.
```adslot-ui-extra```: load if you need them, right now it's the ```DatePicker```, not dependent on core.

this can enable potential optimization like webpack chunking in ```direct-web``` (so pages that don't use extra stuff can load the core bundle and pages that do use can load the full one)
