### PR TITLE
Fix: Roboto fonts

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <title>Adslot UI</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="description" content="Core Component Library. By Adslot">
-  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Roboto:500,300,100' />
+  <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Roboto:300,700' />
   <link rel='stylesheet' href='assets/adslot-ui.css' />
 </head>
 <body>

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -7,6 +7,7 @@ body {
   font-family: 'Roboto', sans-serif;
   margin: 0;
   padding-bottom: 800px;
+  -webkit-font-smoothing: antialiased;
 }
 
 .index {

--- a/src/styles/_react-datepicker-custom.scss
+++ b/src/styles/_react-datepicker-custom.scss
@@ -4,7 +4,7 @@
 
 .react-datepicker {
   $datepicker-font-family: $font-family-sans-serif;
-  $datepicker-font-weight: $font-weight-medium;
+  $datepicker-font-weight: $font-weight-light;
   $datepicker-font-size: $font-size-base;
   $datepicker-icon-size: 24px;
   $datepicker-border-color: $color-border-light;

--- a/src/styles/_react-select-custom.scss
+++ b/src/styles/_react-select-custom.scss
@@ -40,7 +40,7 @@ $select-item-padding-horizontal: 5px;
 
 .Select {
   $select-input-border-active: $color-border;
-  font-weight: $font-weight-medium;
+  font-weight: $font-weight-light;
 
   &-menu-outer {
     border-color: $select-input-border-active;

--- a/src/styles/adslotUi/PagedGrid.scss
+++ b/src/styles/adslotUi/PagedGrid.scss
@@ -18,7 +18,7 @@
 
     &-info {
       display: inline-block;
-      font-weight: $font-weight-medium;
+      font-weight: $font-weight-light;
       line-height: 28px;
       margin: 18px 10px;
     }

--- a/src/styles/adslotUi/Panel.scss
+++ b/src/styles/adslotUi/Panel.scss
@@ -38,7 +38,7 @@
   }
 
   &-content {
-    font-weight: $font-weight-medium;
+    font-weight: $font-weight-light;
   }
 
   &-header,

--- a/src/styles/bootstrapOverrides/Button.scss
+++ b/src/styles/bootstrapOverrides/Button.scss
@@ -110,7 +110,7 @@
 
 .btn-link {
   cursor: pointer;
-  font-weight: $font-weight-medium; // Overrides 'normal'
+  font-weight: $font-weight-bold; // Overrides 'normal'
 
   &,
   &:active {

--- a/src/styles/bootstrapOverrides/Checkbox.scss
+++ b/src/styles/bootstrapOverrides/Checkbox.scss
@@ -4,7 +4,7 @@
 .radio,
 .radiogroup-stacked {
   label {
-    font-weight: $font-weight-medium;
+    font-weight: $font-weight-light;
     padding-top: 1px;
   }
 
@@ -42,7 +42,7 @@ input {
 .icheckbox,
 .iradio {
   + span {
-    font-weight: $font-weight-medium;
+    font-weight: $font-weight-light;
   }
 
   &:not(.disabled) {

--- a/src/styles/bootstrapOverrides/Form.scss
+++ b/src/styles/bootstrapOverrides/Form.scss
@@ -25,7 +25,7 @@
 
     .checkbox {
       label {
-        font-weight: $font-weight-medium;
+        font-weight: $font-weight-light;
       }
     }
   }
@@ -42,7 +42,7 @@
 
     &,
     &-static {
-      font-weight: $font-weight-medium;
+      font-weight: $font-weight-light;
     }
   }
 
@@ -66,7 +66,7 @@ label {
 }
 
 .input-group-addon {
-  font-weight: $font-weight-medium;
+  font-weight: $font-weight-light;
   padding: 4px 5px;
 
   &:first-child {
@@ -80,7 +80,7 @@ label {
 
 .help-block {
   color: $color-text-placeholder;
-  font-weight: $font-weight-medium;
+  font-weight: $font-weight-light;
   margin-top: 8px;
 }
 

--- a/src/styles/bootstrapOverrides/Modal.scss
+++ b/src/styles/bootstrapOverrides/Modal.scss
@@ -7,7 +7,7 @@
   $modal-header-footer-left-padding: 15px;
   $modal-footer-padding: 6px;
 
-  font-weight: $font-weight-medium;
+  font-weight: $font-weight-light;
 
   &-title {
     font-weight: $font-weight-bold;

--- a/src/styles/bootstrapOverrides/Nav.scss
+++ b/src/styles/bootstrapOverrides/Nav.scss
@@ -21,7 +21,7 @@
       color: $color-text-light;
       cursor: pointer;
       display: inline-block;
-      font-weight: $font-weight-medium;
+      font-weight: $font-weight-light;
       margin-right: 0;
       padding: 8px 15px 7px;
       text-shadow: none;

--- a/src/styles/bootstrapOverrides/Popover.scss
+++ b/src/styles/bootstrapOverrides/Popover.scss
@@ -4,7 +4,7 @@
   $popover-shadow: 0 1px 0 rgba($color-shadow, .25);
 
   box-shadow: $popover-shadow;
-  font-weight: $font-weight-medium;
+  font-weight: $font-weight-light;
 
   &-content {
     padding: ($spacing-etalon / 6) ($spacing-etalon / 3);

--- a/src/styles/font-weight.scss
+++ b/src/styles/font-weight.scss
@@ -1,3 +1,3 @@
-$font-weight-light: 100;
+$font-weight-light: 300;
 $font-weight-medium: 300;
-$font-weight-bold: 500;
+$font-weight-bold: 700;


### PR DESCRIPTION
We only use font weights light (300) and bold (700) for maximum contrast.

 - change light from thin to light
 - remove medium (saved 180kb)
 - set bold to 700
 - set light to 300
 - add anti aliasing for chrome rendering smoothness

![screen shot 2017-03-17 at 15 45 56](https://cloud.githubusercontent.com/assets/908155/24029246/d7620ee6-0b28-11e7-8ac5-f5d6f4119bf6.png)

### OLD

![screen shot 2017-03-17 at 15 46 42](https://cloud.githubusercontent.com/assets/908155/24029263/f9216b30-0b28-11e7-9d8f-682ba904092a.png)

### NEW

![screen shot 2017-03-17 at 15 45 45](https://cloud.githubusercontent.com/assets/908155/24029247/d78943f8-0b28-11e7-8e15-749ea207c71d.png)