### PR TITLE
Fix: Pre-commit hook update

### DIFF
--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -2,7 +2,7 @@
 PATH="node_modules/.bin:$PATH"
 
 # If we've only made a change to the package.json's version, it's a release and we should bypass the pre-commit check.
-isPackageJsonChange=$(git diff --cached --stat | grep "package.json | 2 +-")
+isPackageJsonChange=$(git diff --cached --stat | grep "npm-shrinkwrap.json | 2 +-") && $(git diff --cached --stat | grep "package.json        | 2 +-")
 if [[ -n "${isPackageJsonChange[@]}" ]]
 then
   isVersionChange=$(git diff --cached | grep "+  \"version\"")


### PR DESCRIPTION
#### Changes
- Change pre-commit hook to ignore version changes in both package.json AND npm-shrinkwrap.json when adslot-ui is published