### PR TITLE
Build: Move version release out of pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,17 @@
     "lint": "npm run eslint && npm run sass-lint && npm run jscs-lint && npm run check-commit",
     "posttest": "npm run lint",
     "profile": "webpack --env=dist --profile --json > stats.json",
-    "release:major": "git checkout master && git pull && npm version major && npm publish && git push --follow-tags",
-    "release:minor": "git checkout master && git pull && npm version minor && npm publish && git push --follow-tags",
-    "release:patch": "git checkout master && git pull && npm version patch && npm publish && git push --follow-tags",
     "sass-lint": "sass-lint './src/**/*.scss' -v",
     "start": "node server.js --env=dev",
     "start:cold": "node server.js --env=dev-cold",
     "test": "karma start",
-    "test:watch": "karma start --autoWatch=true --singleRun=false"
+    "test:watch": "karma start --autoWatch=true --singleRun=false",
+    "release:major": "npm version major -m 'Release: major version %s.'",
+    "release:minor": "npm version minor -m 'Release: minor version %s.'",
+    "release:patch": "npm version patch -m 'Release: patch version %s.'",
+    "preversion": "echo 'Releasing…' && git checkout master && git pull && npm i && npm prune",
+    "version": "echo '…generating dist…' && npm run -s dist && git add dist/*",
+    "postversion": "npm publish && git push --follow-tags && echo '…released.'"
   },
   "repository": {
     "type": "git",

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,22 +1,11 @@
 #!/bin/bash
 PATH="node_modules/.bin:$PATH"
 
-# If we've only made a change to the package.json's version, it's a release and we should bypass the pre-commit check.
-isPackageJsonChange=$(git diff --cached --stat | grep "package.json | 2 +-")
-if [[ -n "${isPackageJsonChange[@]}" ]]
-then
-  isVersionChange=$(git diff --cached | grep "+  \"version\"")
-  if [[ -n "${isVersionChange[@]}" ]]
-  then
-    echo -e "---------------------\nPreparing for release\n---------------------"
-    echo "👾  Installing node modules."
-    npm install
-    echo "📑  Compiling distribution files for release."
-    npm run -s dist && git add dist/* && exit 0
-    exit 1
-  fi
+COMMIT_MSGS=`git log -1 --format=format:%s --no-merges`;
+RELEASE_REGEX="^(?:Release):";
+if [[ $COMMIT_MSGS =~ $RELEASE_REGEX ]]; then
+  exit 0
 fi
-
 
 echo -e "---------------------------\nRunning git pre-commit hook\n---------------------------"
 


### PR DESCRIPTION
Versions now get released as e.g. `Release: major version 4.3.0`
Version release now uses npm's version workflow methods rather than git and pre-commits (which aren't always set up or working).