### PR TITLE
Update: Add classSuffix prop to TileGrid component

### DIFF
--- a/src/components/alexandria/TileGridComponent.jsx
+++ b/src/components/alexandria/TileGridComponent.jsx
@@ -11,7 +11,7 @@ const TileGridComponent = ({ title, items, onItemClick }) => {
       <strong className={`${baseClass}-title`}>{title}</strong>
       <ul className={`${baseClass}-list`}>
         {_.map(items, (item) => (
-          <li key={item.id} className={`${baseClass}-item ${baseClass}-item-${item.id}`}>
+          <li key={item.id} className={`${baseClass}-item ${baseClass}-item-${item.classSuffix}`}>
             <a className={`${baseClass}-item-link`} onClick={() => onItemClick(item.id)}>{item.title}</a>
           </li>
         ))}
@@ -24,6 +24,7 @@ TileGridComponent.propTypes = {
   title: PropTypes.string.isRequired,
   items: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
+    classSuffix: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
   })).isRequired,
   onItemClick: PropTypes.func.isRequired,

--- a/test/components/alexandria/TileGridComponentTest.jsx
+++ b/test/components/alexandria/TileGridComponentTest.jsx
@@ -9,8 +9,8 @@ describe('TileGridComponent', () => {
   const props = {
     title: 'Lorem ipsum',
     items: [
-      { id: 'a', title: 'Alpha' },
-      { id: 'b', title: 'Beta' },
+      { id: 0, classSuffix: 'alpha', title: 'Alpha' },
+      { id: 1, classSuffix: 'beta', title: 'Beta' },
     ],
     onItemClick: _.noop,
   };
@@ -34,7 +34,7 @@ describe('TileGridComponent', () => {
     expect(list.children()).to.have.length(2);
 
     const firstTileItem = list.childAt(0);
-    expect(firstTileItem.prop('className')).to.equal('tile-grid-component-item tile-grid-component-item-a');
+    expect(firstTileItem.prop('className')).to.equal('tile-grid-component-item tile-grid-component-item-alpha');
 
     const firstTileLink = firstTileItem.find('.tile-grid-component-item-link');
     expect(firstTileLink).to.have.length(1);
@@ -42,7 +42,7 @@ describe('TileGridComponent', () => {
     expect(firstTileLink.text()).to.equal('Alpha');
 
     const secondTileItem = list.childAt(1);
-    expect(secondTileItem.prop('className')).to.equal('tile-grid-component-item tile-grid-component-item-b');
+    expect(secondTileItem.prop('className')).to.equal('tile-grid-component-item tile-grid-component-item-beta');
 
     const secondTileLink = secondTileItem.find('.tile-grid-component-item-link');
     expect(secondTileLink).to.have.length(1);
@@ -57,11 +57,11 @@ describe('TileGridComponent', () => {
     const firstTileLink = tileLinks.at(0);
     firstTileLink.simulate('click');
     expect(onItemClickSpy.callCount).to.equal(1);
-    expect(onItemClickSpy.calledWith('a')).to.equal(true);
+    expect(onItemClickSpy.calledWith(0)).to.equal(true);
 
     const secondTileLink = tileLinks.at(1);
     secondTileLink.simulate('click');
     expect(onItemClickSpy.callCount).to.equal(2);
-    expect(onItemClickSpy.calledWith('b')).to.equal(true);
+    expect(onItemClickSpy.calledWith(1)).to.equal(true);
   });
 });


### PR DESCRIPTION
#### Background
The category tiles in direct-web require unique class names for custom images to be added to them. However, the unique identifier for categories in direct-web is just an integer, leading to confusing class names like `.tile-grid-component-item-12`, `.tile-grid-component-item-19`, etc. In this PR, a `classSuffix` prop has been added to the TileGrid items independent of the item IDs.

#### Changes
- Add `classSuffix` prop to the TileGrid `items`