### PR TITLE
Fix: FilePicker input ref got destroyed on file select

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ coverage:
   range: 98...100
   ignore:
     - "src/components/Main.js"
+    - "src/examples/components/FilePickerDemo.js"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,6 +38,7 @@ module.exports = function configureKarma(config) {
           lines: 100,
           excludes: [
             'src/components/Main.jsx',
+            'src/examples/components/FilePickerDemo.jsx'
           ],
         },
       },

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -52,6 +52,7 @@ import {
 import {
   ExampleForm,
   ExampleSelect,
+  FilePickerDemo,
 } from '../examples/exampleEntry';
 
 import {
@@ -452,6 +453,8 @@ class AppComponent extends React.Component {
             Not spinning
           </SpinnerButton>
         </div>
+
+        <FilePickerDemo />
 
         <h2>Tabs</h2>
         <div className="btn-panel">

--- a/src/components/adslotUi/FilePickerComponent.jsx
+++ b/src/components/adslotUi/FilePickerComponent.jsx
@@ -7,29 +7,35 @@ require('styles/adslotUi/FilePicker.scss');
 const baseClass = 'filepicker-component';
 
 class FilePickerComponent extends React.Component {
-  constructor() {
-    super();
-    this.state = { fileName: '' };
+  constructor(props) {
+    super(props);
+
+    this.state = { isFileSelected: false };
+
     this.onChange = this.onChange.bind(this);
     this.removeFile = this.removeFile.bind(this);
   }
 
   onChange(changeEvent) {
-    this.setState({ fileName: changeEvent.target.files[0].name });
+    if (!this.state.isFileSelected) {
+      this.setState({ isFileSelected: true });
+    }
     this.props.onSelect(changeEvent.target.files[0]);
   }
 
   removeFile() {
-    this.setState({ fileName: '' });
-    if (this.props.onRemove) { this.props.onRemove(); }
+    if (this.state.isFileSelected) {
+      this.fileInput.value = null;
+      this.setState({ isFileSelected: false });
+      if (this.props.onRemove) { this.props.onRemove(); }
+    }
   }
 
   render() {
     const mainClass = classNames({ [`${baseClass}-highlight`]: this.props.isHighlighted }, baseClass, 'input-group');
-    const { fileName } = this.state;
-    const onClickHandler = () => {
-      this.fileInput.click();
-    };
+    const { isFileSelected } = this.state;
+    const fileName = isFileSelected && this.fileInput && this.fileInput.files.length > 0
+      ? this.fileInput.files[0].name : '';
 
     return (
       <div className={mainClass}>
@@ -43,25 +49,22 @@ class FilePickerComponent extends React.Component {
           title={fileName}
         />
         <div className="input-group-btn">
-          {fileName ? <Button className="remove-file" onClick={this.removeFile}>×</Button> : null}
-          {!fileName && !this.props.disabled ?
-            <Button className="btn-inverse" onClick={onClickHandler}>
-              <span>{this.props.label}</span>
-              <input
-                className="file-input"
-                ref={
-                  (inputElementRef) => { this.fileInput = inputElementRef; }
-                }
-
-                type="file"
-                onChange={this.onChange}
-                accept={this.props.filter}
-                data-test-selector={this.props.dts}
-              />
-            </Button>
-          :
-            <Button bsStyle="primary" disabled>{this.props.label}</Button>
-          }
+          {isFileSelected ? <Button className="remove-file" onClick={this.removeFile}>×</Button> : null}
+          <Button
+            className="btn-inverse"
+            onClick={() => { this.fileInput.click(); }}
+            disabled={this.props.disabled || isFileSelected}
+          >
+            <span>{this.props.label}</span>
+            <input
+              className="file-input"
+              ref={(ref) => { this.fileInput = ref; }}
+              type="file"
+              onChange={this.onChange}
+              accept={this.props.filter}
+              data-test-selector={this.props.dts}
+            />
+          </Button>
         </div>
       </div>
     );
@@ -83,6 +86,7 @@ FilePickerComponent.defaultProps = {
   isHighlighted: false,
   label: 'Select',
   placeholder: 'No file selected',
+  disabled: false,
 };
 
 export default FilePickerComponent;

--- a/src/examples/components/FilePickerDemo.jsx
+++ b/src/examples/components/FilePickerDemo.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { FilePicker, Button } from 'components/distributionEntry';
+
+class FilePickerDemo extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.onSelect = this.onSelect.bind(this);
+    this.onRemove = this.onRemove.bind(this);
+    this.resetFilePicker = this.resetFilePicker.bind(this);
+  }
+
+  onSelect(file) {
+    console.log(`FilePicker ${file.name} selected`);
+  }
+
+  onRemove() {
+    console.log('FilePicker file removed');
+  }
+
+  resetFilePicker() {
+    this.filePicker.removeFile();
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>FilePicker Demo</h2>
+        <FilePicker
+          onRemove={this.onRemove}
+          onSelect={this.onSelect}
+          ref={(ref) => { this.filePicker = ref; }}
+        />
+        <br />
+        <Button bsStyle="primary" onClick={this.resetFilePicker}>Reset file</Button>
+      </div>
+    );
+  }
+}
+
+export default FilePickerDemo;

--- a/src/examples/components/forms.jsx
+++ b/src/examples/components/forms.jsx
@@ -219,7 +219,7 @@ ExampleForm.propTypes = {
   formValues: PropTypes.shape({
     addonText: PropTypes.string,
     checkbox: PropTypes.bool,
-    file: PropTypes.string,
+    file: PropTypes.object,
     group: PropTypes.string,
     select: PropTypes.string,
     text: PropTypes.string,

--- a/src/examples/exampleEntry.js
+++ b/src/examples/exampleEntry.js
@@ -1,7 +1,9 @@
 import ExampleForm from './components/forms';
 import ExampleSelect from './components/selects';
+import FilePickerDemo from './components/FilePickerDemo';
 
 export {
   ExampleForm,
   ExampleSelect,
+  FilePickerDemo,
 };


### PR DESCRIPTION
#### Changes

- Fix `FilePicker` was destroying `fileInput` ref when a file is selected, due to the conditional rendering.

- Add a seperate `FilePicker` demo, make sure it works as `direct-web` requires