### PR TITLE
Fix: Search bar icon

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -747,6 +747,7 @@ class AppComponent extends React.Component {
         <SearchBar
           searchString={this.state.searchBarString}
           searchPlaceholder="Search for all the things."
+          searchIconHref="/assets/svg-symbols.svg#search"
           onSearchStringChange={this.setSearchBarString}
           onSearch={this.performSearchBarSearch}
         />

--- a/src/components/adslotUi/SearchBarComponent.jsx
+++ b/src/components/adslotUi/SearchBarComponent.jsx
@@ -8,6 +8,7 @@ const SearchBarComponent = ({
   additionalClassNames,
   searchString,
   searchPlaceholder,
+  searchIconHref,
   onSearchStringChange,
   onSearch,
   dts,
@@ -41,7 +42,7 @@ const SearchBarComponent = ({
         bsStyle="primary"
         onClick={onSearch}
       >
-        <SvgSymbol classSuffixes={['search-icon']} href="/assets/svg-symbols.svg#search" />
+        <SvgSymbol classSuffixes={['search-icon']} href={searchIconHref} />
       </Button>
     </div>
   );
@@ -51,6 +52,7 @@ SearchBarComponent.propTypes = {
   additionalClassNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   searchString: PropTypes.string.isRequired,
   searchPlaceholder: PropTypes.string,
+  searchIconHref: PropTypes.string.isRequired,
   onSearchStringChange: PropTypes.func.isRequired,
   onSearch: PropTypes.func.isRequired,
   dts: PropTypes.string,


### PR DESCRIPTION
#### Changes
- Add prop to SearchBar for passing in href to SVG icon (as they're not exported with adslot-ui)