### PR TITLE
Breaking: change TextEllipsis component to handle generic content

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -43,7 +43,6 @@ import {
   Tab,
   Tabs,
   Tag,
-  TextEllipsis,
   TileGrid,
   Totals,
   TreePickerSimplePure,
@@ -54,6 +53,7 @@ import {
   ExampleForm,
   ExampleSelect,
   FilePickerDemo,
+  TextEllipsisDemo,
 } from '../examples/exampleEntry';
 
 import {
@@ -986,12 +986,7 @@ class AppComponent extends React.Component {
           ]}
         />
 
-        <h2>TextEllipsis</h2>
-
-        <div style={{ width: '100px' }}>
-          <TextEllipsis text="Lorem ipsum dolor sit amet, consectetuer adipiscing elit." />
-        </div>
-
+        <TextEllipsisDemo />
       </div>
     );
   }

--- a/src/components/adslotUi/TextEllipsisComponent.jsx
+++ b/src/components/adslotUi/TextEllipsisComponent.jsx
@@ -17,23 +17,21 @@ class TextEllipsisComponent extends Component {
     this.setTruncate();
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    return ((this.state.truncated !== nextState.truncated) || (this.props.text !== nextProps.text));
-  }
-
   componentDidUpdate() {
     this.setTruncate();
   }
 
   setTruncate() {
-    this.setState({
-      truncated: this.container.scrollWidth > this.container.clientWidth,
-    });
+    const nextTruncateState = this.container.scrollWidth > this.container.clientWidth;
+    if (this.state.truncated !== nextTruncateState) {
+      this.setState({
+        truncated: nextTruncateState,
+      });
+    }
   }
 
   render() {
     const {
-      text,
       popoverProps,
       overlayTriggerProps,
     } = this.props;
@@ -41,12 +39,12 @@ class TextEllipsisComponent extends Component {
 
     if (truncated) {
       const tooltip = (
-        <Popover {...popoverProps}>{text}</Popover>
+        <Popover {...popoverProps}>{this.props.children}</Popover>
       );
 
       return (
         <OverlayTrigger {...overlayTriggerProps} overlay={tooltip}>
-          <div className="text-ellipsis-component" ref={(ref) => { this.container = ref; }}>{text}</div>
+          <div className="text-ellipsis-component" ref={(ref) => { this.container = ref; }}>{this.props.children}</div>
         </OverlayTrigger>
       );
     }
@@ -56,14 +54,14 @@ class TextEllipsisComponent extends Component {
         className="text-ellipsis-component"
         ref={(ref) => { this.container = ref; }}
       >
-        {text}
+        {this.props.children}
       </div>
     );
   }
 }
 
 TextEllipsisComponent.propTypes = {
-  text: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   overlayTriggerProps: PropTypes.shape(_.omit(OverlayTrigger.propTypes, ['overlay'])).isRequired,
   popoverProps: PropTypes.shape(Popover.propTypes).isRequired,
 };

--- a/src/examples/components/TextEllipsisDemo.jsx
+++ b/src/examples/components/TextEllipsisDemo.jsx
@@ -1,0 +1,51 @@
+import moment from 'moment';
+import React, { Component } from 'react';
+import { TextEllipsis, Alert } from '../../components/distributionEntry';
+
+class TextEllipsisDemo extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      childrenData: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.' +
+        '<span style="color: red">This is English</span>',
+    };
+
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    this.setState({
+      childrenData: this.htmlCode.value,
+    });
+  }
+
+  render() {
+    return (
+      <div className="text-ellipsis-demo">
+        <h2>TextEllipsis</h2>
+        <Alert type="warning">HTML editor is only used for demo purpose</Alert>
+        <br />
+        <div className="row">
+          <div className="col-xs-6">
+            <div style={{ width: '200px' }}>
+              <TextEllipsis>
+                <span dangerouslySetInnerHTML={{ __html: this.state.childrenData }} key={moment()} />
+              </TextEllipsis>
+            </div>
+          </div>
+          <div className="col-xs-6">
+            <textarea
+              className="col-xs-12"
+              ref={(ref) => { this.htmlCode = ref; }}
+              defaultValue={this.state.childrenData}
+            />
+            <button className="btn btn-success pull-right" onClick={this.handleClick}>Change</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default TextEllipsisDemo;

--- a/src/examples/exampleEntry.js
+++ b/src/examples/exampleEntry.js
@@ -1,9 +1,11 @@
 import ExampleForm from './components/forms';
 import ExampleSelect from './components/selects';
 import FilePickerDemo from './components/FilePickerDemo';
+import TextEllipsisDemo from './components/TextEllipsisDemo';
 
 export {
   ExampleForm,
   ExampleSelect,
   FilePickerDemo,
+  TextEllipsisDemo,
 };

--- a/test/components/adslotUi/TextEllipsisComponentTest.jsx
+++ b/test/components/adslotUi/TextEllipsisComponentTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { OverlayTrigger } from 'react-bootstrap';
-import TextEllipsisComponent from 'components/adslotUi/TextEllipsisComponent';
+import TextEllipsis from 'components/adslotUi/TextEllipsisComponent';
 
 describe('TextEllipsisComponent', () => {
   let divContainer = null;
@@ -13,9 +13,8 @@ describe('TextEllipsisComponent', () => {
   });
 
   it('should render with defaults', () => {
-    const component = shallow(<TextEllipsisComponent text="Sample text" />);
+    const component = shallow(<TextEllipsis>Sample text</TextEllipsis>);
     expect(component.find('.text-ellipsis-component')).to.have.length(1);
-    expect(component.instance().props.text).to.eql('Sample text');
     expect(component.instance().props.overlayTriggerProps).to.eql({
       trigger: ['focus', 'hover'],
       placement: 'top',
@@ -28,33 +27,62 @@ describe('TextEllipsisComponent', () => {
 
   it('should render with no popover when text length is less than max length', () => {
     divContainer.setAttribute('style', 'width: 100px;');
-    const component = mount(<TextEllipsisComponent text="this is a test" />, { attachTo: divContainer });
+    const component = mount(<TextEllipsis>this is a test</TextEllipsis>, { attachTo: divContainer });
     expect(component.find(OverlayTrigger)).to.have.length(0);
   });
 
   it('should render with popover when text length is more than max length', () => {
     divContainer.setAttribute('style', 'width: 1px;');
-    const component = mount(<TextEllipsisComponent text="this is a test" />, { attachTo: divContainer });
+    const component = mount(<TextEllipsis>this is a test</TextEllipsis>, { attachTo: divContainer });
     expect(component.find(OverlayTrigger)).to.have.length(1);
   });
 
   describe('componentDidUpdate()', () => {
     it('should generate popover if text changes from short to long', () => {
       divContainer.setAttribute('style', 'width: 30px;');
-      const component = mount(<TextEllipsisComponent text="x" />, { attachTo: divContainer });
+      const component = mount(<TextEllipsis>x</TextEllipsis>, { attachTo: divContainer });
       expect(component.find(OverlayTrigger)).to.have.length(0);
 
-      component.setProps({ text: 'long text: The quick brown fox jumps over the lazy dog' });
+      component.setProps({ children: 'long text: The quick brown fox jumps over the lazy dog' });
       expect(component.find(OverlayTrigger)).to.have.length(1);
     });
 
     it('should remove popover if text changes from long to short', () => {
       divContainer.setAttribute('style', 'width: 20px;');
-      const component = mount(<TextEllipsisComponent text="this is a test 1234567" />, { attachTo: divContainer });
+      const component = mount(
+        <TextEllipsis>this is a test 1234567</TextEllipsis>,
+        { attachTo: divContainer }
+      );
       expect(component.find(OverlayTrigger)).to.have.length(1);
 
-      component.setProps({ text: 'x' });
+      component.setProps({ children: 'x' });
       expect(component.find(OverlayTrigger)).to.have.length(0);
+    });
+  });
+
+  describe('should also work on complex children', () => {
+    it('when size is small', () => {
+      divContainer.setAttribute('style', 'width: 2000px;');
+      const component = mount(
+        <TextEllipsis>
+          this is a text
+          <span>this is another text</span>
+        </TextEllipsis>,
+        { attachTo: divContainer }
+      );
+      expect(component.find(OverlayTrigger)).to.have.length(0);
+    });
+
+    it('when size is big', () => {
+      divContainer.setAttribute('style', 'width: 20px;');
+      const component = mount(
+        <TextEllipsis>
+          this is a text
+          <span>this is another text</span>
+        </TextEllipsis>,
+        { attachTo: divContainer }
+      );
+      expect(component.find(OverlayTrigger)).to.have.length(1);
     });
   });
 });


### PR DESCRIPTION
Previously, TextEllipsis can only accepts simple text as the content for popover

Now it can handle generic contents that are parsed in as children

![textellipsis](https://cloud.githubusercontent.com/assets/2588669/26481487/b0c1cda2-4224-11e7-8f28-ea6f77b58831.gif)
