### PR TITLE
Fix: Add throttle to carousel navigation to prevent sliding backwards

### DIFF
--- a/src/components/adslotUi/CarouselComponent.jsx
+++ b/src/components/adslotUi/CarouselComponent.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import Carousel from 'nuka-carousel';
@@ -5,13 +6,20 @@ import Carousel from 'nuka-carousel';
 require('styles/adslotUi/Carousel.scss');
 
 const baseClass = 'carousel-component';
+const navigationDelay = 600;
 const decoratorStyles = {
   bottom: 0,
   width: '30px',
 };
 
 export const getPrevDecorator = () => {
-  const component = ({ previousSlide }) => <button className={`${baseClass}-prev`} onClick={previousSlide} />;
+  let previousSlideThrottled;
+  const component = ({ previousSlide }) => {
+    if (!previousSlideThrottled) {
+      previousSlideThrottled = _.throttle(previousSlide, navigationDelay);
+    }
+    return (<button className={`${baseClass}-prev`} onClick={previousSlideThrottled} />);
+  };
   component.propTypes = { previousSlide: PropTypes.func.isRequired };
 
   return {
@@ -22,7 +30,13 @@ export const getPrevDecorator = () => {
 };
 
 export const getNextDecorator = () => {
-  const component = ({ nextSlide }) => <button className={`${baseClass}-next`} onClick={nextSlide} />;
+  let nextSlideThrottled;
+  const component = ({ nextSlide }) => {
+    if (!nextSlideThrottled) {
+      nextSlideThrottled = _.throttle(nextSlide, navigationDelay);
+    }
+    return (<button className={`${baseClass}-next`} onClick={nextSlideThrottled} />);
+  };
   component.propTypes = { nextSlide: PropTypes.func.isRequired };
 
   return {

--- a/test/components/adslotUi/CarouselComponentTest.jsx
+++ b/test/components/adslotUi/CarouselComponentTest.jsx
@@ -44,6 +44,15 @@ describe('CarouselComponent', () => {
       expect(component.prop('className')).to.equal('carousel-component-prev');
       expect(component.prop('onClick')).to.be.a('function');
     });
+
+    it('should call the same throttled function for each onClick event', () => {
+      const decorator = getPrevDecorator();
+      const componentA = shallow(decorator.component({ previousSlide: _.noop }));
+      const onClickA = componentA.prop('onClick');
+      const componentB = shallow(decorator.component({ previousSlide: _.noop }));
+      const onClickB = componentB.prop('onClick');
+      expect(onClickA).to.equal(onClickB);
+    });
   });
 
   describe('getNextDecorator()', () => {
@@ -59,6 +68,15 @@ describe('CarouselComponent', () => {
       const component = shallow(decorator.component({ nextSlide: _.noop }));
       expect(component.prop('className')).to.equal('carousel-component-next');
       expect(component.prop('onClick')).to.be.a('function');
+    });
+
+    it('should call the same throttled function for each onClick event', () => {
+      const decorator = getNextDecorator();
+      const componentA = shallow(decorator.component({ nextSlide: _.noop }));
+      const onClickA = componentA.prop('onClick');
+      const componentB = shallow(decorator.component({ nextSlide: _.noop }));
+      const onClickB = componentB.prop('onClick');
+      expect(onClickA).to.equal(onClickB);
     });
   });
 });


### PR DESCRIPTION
#### Changes
- Add a throttle to the "previous" and "next" actions to prevent the carousel from taking the shortest path to a slide (instead moving in direction it was already going)