### PR TITLE
Fix: AlertInput style tweaks

### DIFF
--- a/src/components/adslotUi/AlertInput/styles.scss
+++ b/src/components/adslotUi/AlertInput/styles.scss
@@ -7,7 +7,7 @@
   border: $border-lighter;
   border-radius: $border-radius;
   display: flex;
-  padding: 4px 8px;
+  padding: 4px;
 
   &.success {
     border-color: $color-positive;
@@ -28,6 +28,7 @@
   &-input {
     border: 0;
     flex: 1;
+    width: 100%;
 
     &:focus {
       outline: none;
@@ -38,11 +39,11 @@
     color: $color-text-addon;
 
     &:first-child {
-      margin-right: 4px;
+      margin-right: 2px;
     }
 
     &:last-child {
-      margin-left: 4px;
+      margin-left: 2px;
     }
   }
 
@@ -51,6 +52,12 @@
       border-radius: 4px;
       box-shadow: none;
       font-size: $font-size-small;
+
+      .popover-content {
+        color: inherit;
+        padding: 5px 10px;
+        width: auto;
+      }
 
       &.bottom {
         $arrow-width: 16px;


### PR DESCRIPTION
#### Background
There is too much spacing between the inner elements of the AlertInput component when used in direct-web (i.e. doesn't provide enough room for the input value). There are also some direct-web styles applied directly to popovers that are overriding this component's styles.

#### Changes
- Trim spacing to provide enough breathing room for input value in direct-web