### PR TITLE
Fix: AlertInput focus

### DIFF
--- a/src/components/adslotUi/AlertInput/index.jsx
+++ b/src/components/adslotUi/AlertInput/index.jsx
@@ -6,6 +6,7 @@ import './styles.scss';
 export const baseClass = 'alert-input-component';
 
 const AlertInput = ({
+  defaultValue,
   value,
   prefixAddon,
   suffixAddon,
@@ -13,40 +14,41 @@ const AlertInput = ({
   alertMessage,
   popoverTrigger,
   onValueChange,
+  onBlur,
 }) => {
-  const selectAll = (event) => event.target.select();
-  const baseComponent = (
-    <div className={`${baseClass} ${alertStatus}`}>
-      {prefixAddon ? <span className={`${baseClass}-addon`}>{prefixAddon}</span> : null}
-      <input
-        className={`${baseClass}-input`}
-        type="text"
-        value={value}
-        onClick={selectAll}
-        onChange={onValueChange}
-      />
-      {suffixAddon ? <span className={`${baseClass}-addon`}>{suffixAddon}</span> : null}
-    </div>
-  );
+  let popover = <div />;
 
   if (alertMessage) {
-    const popover = (
+    popover = (
       <Popover className={`${baseClass}-popover ${alertStatus}`} id="alert-input-popover">
         <strong>{alertMessage}</strong>
       </Popover>
     );
-
-    return (
-      <OverlayTrigger trigger={popoverTrigger} placement="bottom" overlay={popover}>
-        {baseComponent}
-      </OverlayTrigger>
-    );
   }
 
-  return baseComponent;
+  const selectAll = (event) => event.target.select();
+
+  return (
+    <OverlayTrigger trigger={popoverTrigger} placement="bottom" overlay={popover}>
+      <div className={`${baseClass} ${alertStatus}`}>
+        {prefixAddon ? <span className={`${baseClass}-addon`}>{prefixAddon}</span> : null}
+        <input
+          className={`${baseClass}-input`}
+          type="text"
+          defaultValue={defaultValue}
+          value={value}
+          onClick={selectAll}
+          onChange={onValueChange}
+          onBlur={onBlur}
+        />
+        {suffixAddon ? <span className={`${baseClass}-addon`}>{suffixAddon}</span> : null}
+      </div>
+    </OverlayTrigger>
+  );
 };
 
 AlertInput.propTypes = {
+  defaultValue: PropTypes.string,
   value: PropTypes.string,
   prefixAddon: PropTypes.node,
   suffixAddon: PropTypes.node,
@@ -54,6 +56,7 @@ AlertInput.propTypes = {
   alertMessage: PropTypes.string,
   popoverTrigger: OverlayTrigger.propTypes.trigger,
   onValueChange: PropTypes.func,
+  onBlur: PropTypes.func,
 };
 
 AlertInput.defaultProps = {

--- a/src/components/adslotUi/AlertInput/index.spec.jsx
+++ b/src/components/adslotUi/AlertInput/index.spec.jsx
@@ -10,17 +10,25 @@ describe('AlertInput', () => {
     const props = {
       value: 'lorem',
       onValueChange: _.noop,
+      onBlur: _.noop,
     };
     const component = shallow(<AlertInput {...props} />);
-    expect(component.hasClass('alert-input-component')).to.equal(true);
-    expect(component.children()).to.have.length(1);
+    expect(component.prop('trigger')).to.eql(['hover', 'focus']);
+    expect(component.prop('placement')).to.equal('bottom');
+    expect(component.prop('overlay').type).to.equal('div');
+    expect(component.prop('overlay').className).to.be.an('undefined');
 
-    const inputElement = component.childAt(0);
+    const rootElement = component.childAt(0);
+    expect(rootElement.hasClass('alert-input-component')).to.equal(true);
+    expect(rootElement.children()).to.have.length(1);
+
+    const inputElement = rootElement.childAt(0);
     expect(inputElement.prop('className')).to.equal('alert-input-component-input');
     expect(inputElement.prop('type')).to.equal('text');
     expect(inputElement.prop('value')).to.equal('lorem');
     expect(inputElement.prop('onClick')).to.be.a('function');
     expect(inputElement.prop('onChange')).to.be.a('function');
+    expect(inputElement.prop('onBlur')).to.be.a('function');
   });
 
   it('should render with addons', () => {
@@ -29,12 +37,13 @@ describe('AlertInput', () => {
       suffixAddon: '.00',
     };
     const component = shallow(<AlertInput {...props} />);
-    expect(component.children()).to.have.length(3);
+    const rootElement = component.childAt(0);
+    expect(rootElement.children()).to.have.length(3);
 
-    const prefixElement = component.childAt(0);
+    const prefixElement = rootElement.childAt(0);
     expect(prefixElement.text()).to.equal('$');
 
-    const suffixElement = component.childAt(2);
+    const suffixElement = rootElement.childAt(2);
     expect(suffixElement.text()).to.equal('.00');
   });
 
@@ -43,19 +52,17 @@ describe('AlertInput', () => {
       alertStatus: 'error',
     };
     const component = shallow(<AlertInput {...props} />);
-    expect(component.prop('className')).to.equal('alert-input-component error');
-    expect(component.children()).to.have.length(1);
+    const rootElement = component.childAt(0);
+    expect(rootElement.prop('className')).to.equal('alert-input-component error');
+    expect(rootElement.children()).to.have.length(1);
   });
 
-  it('should render OverlayTrigger and Popover', () => {
+  it('should render Popover when there is an alert message', () => {
     const props = {
       alertStatus: 'error',
       alertMessage: 'Lorem ipsum dolor sit amet.',
     };
     const component = shallow(<AlertInput {...props} />);
-    expect(component.prop('trigger')).to.eql(['hover', 'focus']);
-    expect(component.prop('placement')).to.equal('bottom');
-
     const popover = component.prop('overlay');
     expect(popover.props.className).to.equal('alert-input-component-popover error');
     expect(popover.props.id).to.equal('alert-input-popover');

--- a/src/components/adslotUi/AlertInput/styles.scss
+++ b/src/components/adslotUi/AlertInput/styles.scss
@@ -4,6 +4,7 @@
 
 .alert-input-component {
   align-items: center;
+  background-color: $color-well;
   border: $border-lighter;
   border-radius: $border-radius;
   display: flex;
@@ -26,6 +27,7 @@
   }
 
   &-input {
+    background-color: $color-well;
     border: 0;
     flex: 1;
     width: 100%;


### PR DESCRIPTION
#### Background
If a change in component props causes the render function to return a different node, any element within that component that was "focused" will lose focus. This is a problem in direct-web where we validate input as it changes (i.e. as the user types) and show a popover if there is a validation message, which blurs the field and prevents the user from continuing to type in the input (requiring them to refocus on it).

#### Changes
- Change AlertInput to always render with the same root component (OverlayTrigger) so the input element doesn't lose focus if the alertMessage prop changes while the user is typing in the input.
- Add background color to component
- Add defaultValue prop for input so component can be used uncontrolled (for better visual performance)