### PR TITLE
Update: Add toolTip prop to Avatar component

### DIFF
--- a/src/components/alexandria/Avatar/index.jsx
+++ b/src/components/alexandria/Avatar/index.jsx
@@ -3,10 +3,10 @@ import React, { PropTypes } from 'react';
 import './styles.scss';
 
 const baseClass = 'avatar-component';
-const Avatar = ({ color, givenName, image, surname }) => (
+const Avatar = ({ color, givenName, tooltip, image, surname }) => (
   <div
     className={color ? `${baseClass} ${baseClass}-${color}` : baseClass}
-    title={`${givenName || ''} ${surname || ''}`}
+    title={tooltip !== undefined ? tooltip : `${givenName || ''} ${surname || ''}`}
   >
 
     {image ? <img className={`${baseClass}-image`} src={image} role="presentation" /> : null}
@@ -23,6 +23,7 @@ Avatar.displayName = 'AlexandriaAvatarComponent';
 Avatar.propTypes = {
   color: PropTypes.string,
   givenName: PropTypes.string,
+  tooltip: PropTypes.string,
   image: PropTypes.string,
   surname: PropTypes.string,
 };

--- a/src/components/alexandria/Avatar/index.spec.jsx
+++ b/src/components/alexandria/Avatar/index.spec.jsx
@@ -52,4 +52,36 @@ describe('Avatar', () => {
     const initialsElement = component.find('.avatar-component-initials');
     expect(initialsElement.text()).to.equal('JD');
   });
+
+  it('should render with default title of givenName surname', () => {
+    const element = shallow(<Avatar
+      color="blue"
+      givenName="Firstname"
+      surname="Surname"
+    />);
+    const divContainer = element.find('div.avatar-component').first();
+    expect(divContainer.prop('title')).to.equal('Firstname Surname');
+  });
+
+  it('should render with custom title property when tooltip with custom text supplied', () => {
+    const element = shallow(<Avatar
+      color="blue"
+      givenName="Firstname"
+      surname="Surname"
+      tooltip="Name of logged-in user"
+    />);
+    const divContainer = element.find('div.avatar-component').first();
+    expect(divContainer.prop('title')).to.equal('Name of logged-in user');
+  });
+
+  it('should render with empty title property when tooltip with empty text supplied', () => {
+    const element = shallow(<Avatar
+      color="blue"
+      givenName="Firstname"
+      surname="Surname"
+      tooltip=""
+    />);
+    const divContainer = element.find('div.avatar-component').first();
+    expect(divContainer.prop('title')).to.equal('');
+  });
 });


### PR DESCRIPTION
Add toolTip prop to Avatar component.
When not provided, it will show user's "givenName surname" else will show provided tooltip text.
if user doesn't want to see any tooltip, he will set it to "" empty text.

