### PR TITLE
Update: Always display Group label in TreePickerGrid component

### DIFF
--- a/src/components/adslotUi/TreePicker/TreePickerGridComponent.jsx
+++ b/src/components/adslotUi/TreePicker/TreePickerGridComponent.jsx
@@ -32,13 +32,11 @@ const TreePickerGridComponent = ({
     <Grid>
       {_.map(nodesByGroupLabel, (groupedNodes, label) =>
         <div className="treepickergrid-component-group" key={_.kebabCase(label)}>
-          {_.size(nodesByGroupLabel) > 1 ?
-            <div className="treepickergrid-component-group-label">
-              <GridRow dts={`group-label-${_.kebabCase(label)}`}>
-                {label}
-              </GridRow>
-            </div> :
-            null}
+          <div className="treepickergrid-component-group-label">
+            <GridRow dts={`group-label-${_.kebabCase(label)}`}>
+              {label}
+            </GridRow>
+          </div>
           {_.map(groupedNodes, (node) =>
             <TreePickerNodeFast
               key={node.id}

--- a/test/components/adslotUi/TreePicker/TreePickerGridComponentTest.jsx
+++ b/test/components/adslotUi/TreePicker/TreePickerGridComponentTest.jsx
@@ -36,10 +36,10 @@ describe('TreePickerGridComponent', () => {
 
     const groupElement = gridElement.find('.treepickergrid-component-group');
     expect(groupElement).to.have.length(1);
-    expect(groupElement.children()).to.have.length(2); // Two nodes
+    expect(groupElement.children()).to.have.length(3); // Group label and two nodes
 
     _.forEach(props.nodes, (node, index) => {
-      const nodeElement = groupElement.childAt(index);
+      const nodeElement = groupElement.childAt(index + 1); // since index = 0 is the group label
       expect(nodeElement.prop('expandNode')).to.equal(props.expandNode);
       expect(nodeElement.prop('includeNode')).to.equal(props.includeNode);
       expect(nodeElement.prop('removeNode')).to.equal(props.removeNode);
@@ -92,6 +92,27 @@ describe('TreePickerGridComponent', () => {
     expect(emptyElement.prop('collection')).to.equal(props.nodes);
     expect(emptyElement.prop('svgSymbol')).to.equal(props.emptySvgSymbol);
     expect(emptyElement.prop('text')).to.equal(props.emptyText);
+  });
+
+  it('should display empty when there is no valid group', () => {
+    const props = {
+      emptySvgSymbol: svgSymbol,
+      emptyText: 'Empty!',
+      expandNode: _.noop,
+      groupFormatter: (node) => node.randomAttr,
+      includeNode: _.noop,
+      itemType,
+      nodes: [qldNode],
+      nodeRenderer,
+      removeNode: _.noop,
+      selected: false,
+      valueFormatter,
+    };
+    const component = shallow(<TreePickerGrid {...props} />);
+    const gridElement = component.find(Grid);
+    const emptyElement = gridElement.find(Empty);
+
+    expect(emptyElement).to.have.length(1);
   });
 
   it('should not display empty with an undefined nodes list', () => {


### PR DESCRIPTION
always display group in TreePickerGrid, if there is no group specified, display Empty element