### PR TITLE
New: add Textarea component to support word count

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -62,6 +62,7 @@ import {
 } from '../examples/redux/reducers';
 
 import AlertInputExample from './adslotUi/AlertInput/example';
+import TextareaExample from './adslotUi/Textarea/example';
 
 require('styles/App.scss');
 
@@ -465,6 +466,8 @@ class AppComponent extends React.Component {
         </div>
 
         <AlertInputExample />
+
+        <TextareaExample />
 
         <FilePickerDemo />
 

--- a/src/components/adslotUi/Textarea/example.jsx
+++ b/src/components/adslotUi/Textarea/example.jsx
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import { Button } from 'react-bootstrap';
+
+import Textarea from '.';
+
+class TextareaExample extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      maxLength: 5,
+    };
+
+    this.toggleMaxLength = this.toggleMaxLength.bind(this);
+  }
+
+  toggleMaxLength() {
+    this.setState({
+      maxLength: this.state.maxLength === 5 ? null : 5,
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>Textarea</h2>
+        <Textarea maxLength={this.state.maxLength} statusClass="pull-right" />
+        <br />
+        <Button className="btn-inverse" bsStyle="primary" onClick={this.toggleMaxLength}>Toggle max length</Button>
+      </div>
+    );
+  }
+}
+
+export default TextareaExample;

--- a/src/components/adslotUi/Textarea/index.jsx
+++ b/src/components/adslotUi/Textarea/index.jsx
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+import React, { PropTypes } from 'react';
+import classnames from 'classnames';
+
+class Textarea extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      charCountRemaining: this.props.maxLength,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(event) {
+    this.setState({
+      charCountRemaining: this.props.maxLength - event.target.value.length,
+    });
+
+    if (this.props.onChange) {
+      this.props.onChange(event);
+    }
+  }
+
+  render() {
+    const { maxLength, statusClass } = this.props;
+    const restProps = _.omit(this.props, ['statusClass']);
+    const classNames = classnames('form-control', restProps.className);
+
+    return _.isNil(maxLength) ? (
+      <textarea {...restProps} className={classNames} />
+    ) : (
+      <div>
+        <textarea {...restProps} className={classNames} onChange={this.handleChange} />
+        <span className={statusClass}>{this.state.charCountRemaining} characters remaining</span>
+      </div>
+    );
+  }
+}
+
+Textarea.propTypes = {
+  maxLength: PropTypes.number,
+  statusClass: PropTypes.string,
+  onChange: PropTypes.func,
+};
+
+Textarea.defaultProps = {
+  statusClass: '',
+};
+
+export default Textarea;

--- a/src/components/adslotUi/Textarea/index.spec.jsx
+++ b/src/components/adslotUi/Textarea/index.spec.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable lodash/prefer-lodash-method */
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import Textarea from '.';
+
+describe('Textarea', () => {
+  it('should render a textarea element', () => {
+    const component = shallow(<Textarea />);
+    const textarea = component.find('textarea');
+    expect(textarea).to.have.length(1);
+  });
+
+  it('should render a countdown span when maxLength is specified', () => {
+    const component = shallow(<Textarea maxLength={120} statusClass="someclass" />);
+    expect(component.find('span').text()).to.equal('120 characters remaining');
+    expect(component.find('span').hasClass('someclass')).to.equal(true);
+  });
+
+  it('should give additional className to the textarea', () => {
+    const component = shallow(<Textarea maxLength={120} className="someclass" />);
+    expect(component.find('textarea').hasClass('form-control someclass')).to.equal(true);
+  });
+
+  it('should trigger onChange handler', () => {
+    const props = { onChange: sinon.spy(), maxLength: 120 };
+    const component = shallow(<Textarea {...props} />);
+    component.find('textarea').simulate('change', { target: { value: 'abcde' } });
+    expect(props.onChange.callCount).to.equal(1);
+  });
+
+  it('should update the remaining character count on textarea change', () => {
+    const setStateSpy = sinon.spy(Textarea.prototype, 'setState');
+    const component = shallow(<Textarea maxLength={120} />);
+    component.find('textarea').simulate('change', { target: { value: 'abcde' } });
+    expect(setStateSpy.callCount).to.equal(1);
+    expect(component.state('charCountRemaining')).to.equal(115);
+    setStateSpy.restore();
+  });
+
+  it('should not update the remaining character count when maxLength is not specified', () => {
+    const setStateSpy = sinon.spy(Textarea.prototype, 'setState');
+    const component = shallow(<Textarea />);
+    component.find('textarea').simulate('change', { target: { value: 'abcde' } });
+    expect(setStateSpy.callCount).to.equal(0);
+    setStateSpy.restore();
+  });
+
+  it('should pass on additional props to textarea element', () => {
+    const component = shallow(<Textarea placeholder="hello" maxLength={120} />);
+    const textarea = component.find('textarea');
+    expect(textarea.prop('maxLength')).to.equal(120);
+    expect(textarea.prop('placeholder')).to.equal('hello');
+  });
+});


### PR DESCRIPTION
New create product details are in React and we don't have a component to support textarea word countdown.

![2017-07-03_14-18-01](https://user-images.githubusercontent.com/2403390/27777935-92a2f604-5ffa-11e7-87e2-6a74f6a8bab7.gif)
