### PR TITLE
Update: add `displayGroupHeader` props to always display group header when needed

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -641,6 +641,7 @@ class AppComponent extends React.Component {
           includeNode={_.noop}
           removeNode={_.noop}
           nodeRenderer={nodeRenderer}
+          displayGroupHeader
         />
 
         <h2>ListPicker</h2>

--- a/src/components/adslotUi/TreePicker/TreePickerGridComponent.jsx
+++ b/src/components/adslotUi/TreePicker/TreePickerGridComponent.jsx
@@ -26,17 +26,21 @@ const TreePickerGridComponent = ({
   selected,
   valueFormatter,
   emptyText,
+  displayGroupHeader,
 }) => {
   const nodesByGroupLabel = _.groupBy(nodes, groupFormatter);
   return (
     <Grid>
       {_.map(nodesByGroupLabel, (groupedNodes, label) =>
         <div className="treepickergrid-component-group" key={_.kebabCase(label)}>
-          <div className="treepickergrid-component-group-label">
-            <GridRow dts={`group-label-${_.kebabCase(label)}`}>
-              {label}
-            </GridRow>
-          </div>
+          {(displayGroupHeader) ?
+            <div className="treepickergrid-component-group-label">
+              <GridRow dts={`group-label-${_.kebabCase(label)}`}>
+                {label}
+              </GridRow>
+            </div> :
+            null
+          }
           {_.map(groupedNodes, (node) =>
             <TreePickerNodeFast
               key={node.id}
@@ -83,12 +87,14 @@ TreePickerGridComponent.propTypes = {
   removeNode: PropTypes.func,
   selected: PropTypes.bool.isRequired,
   valueFormatter: PropTypes.func,
+  displayGroupHeader: PropTypes.bool,
 };
 
 TreePickerGridComponent.defaultProps = {
   disabled: false,
   hideIcon: false,
   groupFormatter: () => 'Default Group',
+  displayGroupHeader: true,
 };
 
 export default TreePickerGridComponent;

--- a/src/components/adslotUi/TreePicker/TreePickerSimplePureComponent.jsx
+++ b/src/components/adslotUi/TreePicker/TreePickerSimplePureComponent.jsx
@@ -37,6 +37,7 @@ const TreePickerSimplePureComponent = ({
   subtree,
   svgSymbolCancel,
   svgSymbolSearch,
+  displayGroupHeader,
 }) => {
   const selectableNodes = removeSelected({ subtree, selectedNodes });
   let searchTextNode = emptyText || 'No items to select.';
@@ -75,6 +76,7 @@ const TreePickerSimplePureComponent = ({
             nodes: selectableNodes,
             nodeRenderer,
             selected: false,
+            displayGroupHeader,
           }}
         />
         <FlexibleSpacer />
@@ -92,6 +94,7 @@ const TreePickerSimplePureComponent = ({
             nodeRenderer,
             removeNode,
             selected: true,
+            displayGroupHeader,
           }}
         />
         <FlexibleSpacer />
@@ -129,11 +132,13 @@ TreePickerSimplePureComponent.propTypes = {
   subtree: PropTypes.arrayOf(TreePickerPropTypes.node.isRequired),
   svgSymbolCancel: PropTypes.shape(SvgSymbol.propTypes),
   svgSymbolSearch: PropTypes.shape(SvgSymbol.propTypes),
+  displayGroupHeader: PropTypes.bool,
 };
 
 TreePickerSimplePureComponent.defaultProps = {
   disabled: false,
   itemType: 'node',
+  displayGroupHeader: true,
 };
 
 export default TreePickerSimplePureComponent;

--- a/test/components/adslotUi/TreePicker/TreePickerGridComponentTest.jsx
+++ b/test/components/adslotUi/TreePicker/TreePickerGridComponentTest.jsx
@@ -28,6 +28,7 @@ describe('TreePickerGridComponent', () => {
       removeNode: _.noop,
       selected: false,
       valueFormatter,
+      displayGroupHeader: true,
     };
     const component = shallow(<TreePickerGrid {...props} />);
     const gridElement = component.find(Grid);
@@ -53,45 +54,66 @@ describe('TreePickerGridComponent', () => {
     expect(emptyElement.prop('text')).to.equal(props.emptyText);
   });
 
-  it('should render with groups', () => {
-    const props = {
-      emptySvgSymbol: svgSymbol,
-      emptyText: 'Empty!',
-      expandNode: _.noop,
-      groupFormatter: (node) => node.id,
-      includeNode: _.noop,
-      itemType,
-      nodes: [qldNode, saNode],
-      nodeRenderer,
-      removeNode: _.noop,
-      selected: false,
-      valueFormatter,
-    };
-    const component = shallow(<TreePickerGrid {...props} />);
-    const gridElement = component.find(Grid);
-    expect(gridElement).to.have.length(1);
-    expect(gridElement.children()).to.have.length(3); // Two group node and an Empty.
+  describe('should render with groups', () => {
+    let props = {};
 
-    const groupElements = gridElement.find('.treepickergrid-component-group');
-    expect(groupElements).to.have.length(2);
-
-    _.forEach(props.nodes, (node, index) => {
-      const groupElement = groupElements.at(index);
-      const labelElement = groupElement.find('.treepickergrid-component-group-label');
-      expect(labelElement.children().children().text()).to.equal(node.id);
-
-      const nodeElement = groupElement.find(TreePickerNodeFast);
-      expect(nodeElement.prop('expandNode')).to.equal(props.expandNode);
-      expect(nodeElement.prop('includeNode')).to.equal(props.includeNode);
-      expect(nodeElement.prop('removeNode')).to.equal(props.removeNode);
-      expect(nodeElement.prop('node')).to.equal(node);
+    beforeEach(() => {
+      props = {
+        emptySvgSymbol: svgSymbol,
+        emptyText: 'Empty!',
+        expandNode: _.noop,
+        groupFormatter: (node) => node.id,
+        includeNode: _.noop,
+        itemType,
+        nodes: [qldNode, saNode],
+        nodeRenderer,
+        removeNode: _.noop,
+        selected: false,
+        valueFormatter,
+      };
     });
 
-    const emptyElement = gridElement.find(Empty);
-    expect(emptyElement).to.have.length(1);
-    expect(emptyElement.prop('collection')).to.equal(props.nodes);
-    expect(emptyElement.prop('svgSymbol')).to.equal(props.emptySvgSymbol);
-    expect(emptyElement.prop('text')).to.equal(props.emptyText);
+    it('should render with groups by default', () => {
+      const component = shallow(<TreePickerGrid {...props} />);
+      const gridElement = component.find(Grid);
+      expect(gridElement).to.have.length(1);
+      expect(gridElement.children()).to.have.length(3); // Two group node and an Empty.
+
+      const groupElements = gridElement.find('.treepickergrid-component-group');
+      expect(groupElements).to.have.length(2);
+
+      _.forEach(props.nodes, (node, index) => {
+        const groupElement = groupElements.at(index);
+        const labelElement = groupElement.find('.treepickergrid-component-group-label');
+        expect(labelElement.children().children().text()).to.equal(node.id);
+
+        const nodeElement = groupElement.find(TreePickerNodeFast);
+        expect(nodeElement.prop('expandNode')).to.equal(props.expandNode);
+        expect(nodeElement.prop('includeNode')).to.equal(props.includeNode);
+        expect(nodeElement.prop('removeNode')).to.equal(props.removeNode);
+        expect(nodeElement.prop('node')).to.equal(node);
+      });
+
+      const emptyElement = gridElement.find(Empty);
+      expect(emptyElement).to.have.length(1);
+      expect(emptyElement.prop('collection')).to.equal(props.nodes);
+      expect(emptyElement.prop('svgSymbol')).to.equal(props.emptySvgSymbol);
+      expect(emptyElement.prop('text')).to.equal(props.emptyText);
+    });
+
+    it('should render with no group header when displayGroupHeader is false', () => {
+      props = _.assign({}, props, {
+        nodes: [qldNode],
+        displayGroupHeader: false,
+      });
+      const component = shallow(<TreePickerGrid {...props} />);
+      const gridElement = component.find(Grid);
+      expect(gridElement).to.have.length(1);
+      expect(gridElement.children()).to.have.length(2); // One group node and an Empty.
+      const groupElement = gridElement.find('.treepickergrid-component-group');
+      expect(groupElement).to.have.length(1);
+      expect(groupElement.children()).to.have.length(1);
+    });
   });
 
   it('should display empty when there is no valid group', () => {


### PR DESCRIPTION
Sometimes we don't want to display group header because there is none (e.g. list of Countries, which is obvious enough to not have a header). More examples in the bug card

Screenshots:
- Default (`displayGroupHeader = true`):

  - with only 1 group
![screen shot 2017-07-10 at 3 55 48 pm](https://user-images.githubusercontent.com/2588669/28004494-662d0126-6588-11e7-82cb-67d64cd2b11b.png)

   - with multiple groups
![screen shot 2017-07-10 at 3 57 18 pm](https://user-images.githubusercontent.com/2588669/28004510-7acf67ae-6588-11e7-8c2f-5324f1cac9a4.png)


- `displayGroupHeader = false`
![screen shot 2017-07-10 at 3 50 46 pm](https://user-images.githubusercontent.com/2588669/28004486-5a283c92-6588-11e7-8d16-52bb44632184.png)
