### PR TITLE
Update ListPickerPureComponent itemHeaders.label to take in node type

### DIFF
--- a/src/components/adslotUi/ListPickerPureComponent.jsx
+++ b/src/components/adslotUi/ListPickerPureComponent.jsx
@@ -98,7 +98,7 @@ ListPickerPureComponent.propTypes = {
   labelFormatter: PropTypes.func.isRequired,
   addonFormatter: PropTypes.func,
   itemHeaders: PropTypes.shape({
-    label: PropTypes.string,
+    label: PropTypes.node,
     toggle: PropTypes.string,
   }),
   items: PropTypes.arrayOf(itemProps).isRequired,

--- a/test/components/adslotUi/ListPickerPureComponentTest.jsx
+++ b/test/components/adslotUi/ListPickerPureComponentTest.jsx
@@ -16,6 +16,7 @@ describe('ListPickerPureComponent', () => {
     labelFormatter,
     teamMember4,
     userHeaders,
+    nodeUserHeaders,
     users,
     usersWithUuid,
   } = ListPickerMocks;
@@ -127,6 +128,26 @@ describe('ListPickerPureComponent', () => {
       const gridRowCellAddonElement = gridRowCellRightElement.find(Empty);
       expect(gridRowCellAddonElement.length).to.equal(1);
     });
+  });
+
+  it('should allow user to render node type label', () => {
+    const props = {
+      itemType: 'group-user',
+      items: users,
+      itemHeaders: nodeUserHeaders,
+      labelFormatter,
+      selectedItems,
+    };
+    const component = shallow(<ListPickerPureComponent {...props} />);
+    expect(component.prop('className')).to.equal('listpickerpure-component');
+    expect(component.prop('data-test-selector')).to.equal('listpickerpure-component-group-user');
+
+    const headerGridElement = component.find(Grid).first();
+    const gridHeaderElement = headerGridElement.find(GridRow);
+    const gridHeaderCellElements = gridHeaderElement.find(GridCell);
+    expect(gridHeaderCellElements.first().find('.left-sub-label').text()).to.equal('Group');
+    expect(gridHeaderCellElements.first().find('.right-sub-label').text()).to.equal('Team');
+    expect(gridHeaderCellElements.last().children().text()).to.equal('Member');
   });
 
   it('should render radio buttons with `allowMultiSelection` as false', () => {

--- a/test/mocks/ListPickerMocks.jsx
+++ b/test/mocks/ListPickerMocks.jsx
@@ -1,4 +1,5 @@
 import immutable from 'seamless-immutable';
+import React from 'react';
 
 const labelFormatter = (item) => `${item.givenName} ${item.surname}`;
 
@@ -14,6 +15,15 @@ const teamMember5 = { givenName: 'Joe', id: 'bdf9e9a6-22df-11e6-b67b-9e71128cae8
 
 const userHeaders = { label: 'Team', toggle: 'Member' };
 
+const nodeUserHeaders = {
+  label:
+    (<div className="label-container">
+      <div className="left-sub-label">Group</div>
+      <div className="right-sub-label">Team</div>
+    </div>),
+  toggle: 'Member',
+};
+
 const users = [teamMember1, teamMember2, teamMember3];
 
 const usersWithUuid = [teamMember4, teamMember5];
@@ -27,6 +37,7 @@ const ListPickerMocks = immutable({
   teamMember2,
   teamMember4,
   userHeaders,
+  nodeUserHeaders,
   users,
   usersWithUuid,
 });


### PR DESCRIPTION
Update `ListPickerPureComponent` `itemHeaders.label` to take in any renderable element.