### PR TITLE
Update: AlertInput: accept type, min, placeholder as props

### DIFF
--- a/src/components/adslotUi/AlertInput/index.jsx
+++ b/src/components/adslotUi/AlertInput/index.jsx
@@ -62,6 +62,9 @@ export default class AlertInput extends Component {
     const {
       defaultValue,
       value,
+      type,
+      min,
+      placeholder,
       prefixAddon,
       suffixAddon,
       alertStatus = '',
@@ -85,9 +88,11 @@ export default class AlertInput extends Component {
         {prefixAddon ? <span className={`${baseClass}-addon`}>{prefixAddon}</span> : null}
         <input
           className={`${baseClass}-input`}
-          type="text"
+          type={type}
           defaultValue={defaultValue}
           value={value}
+          min={min}
+          placeholder={placeholder}
           onChange={onValueChange}
           onFocus={this.handleInputFocus}
           onBlur={this.handleInputBlur}
@@ -110,6 +115,9 @@ export default class AlertInput extends Component {
 AlertInput.propTypes = {
   defaultValue: PropTypes.string,
   value: PropTypes.string,
+  type: PropTypes.oneOf(['text', 'number']),
+  min: PropTypes.number,
+  placeholder: PropTypes.string,
   prefixAddon: PropTypes.node,
   suffixAddon: PropTypes.node,
   alertStatus: PropTypes.oneOf(['success', 'info', 'warning', 'error']),
@@ -117,3 +125,8 @@ AlertInput.propTypes = {
   onValueChange: PropTypes.func,
   onBlur: PropTypes.func,
 };
+
+AlertInput.defaultProps = {
+  type: 'text',
+};
+

--- a/src/components/adslotUi/AlertInput/index.spec.jsx
+++ b/src/components/adslotUi/AlertInput/index.spec.jsx
@@ -98,7 +98,10 @@ describe('AlertInput', () => {
   describe('render()', () => {
     it('should render with input props', () => {
       const props = {
-        value: 'lorem',
+        value: 100,
+        type: 'number',
+        min: 0,
+        placeholder: 'Type a number',
         onValueChange: _.noop,
         onBlur: _.noop,
       };
@@ -110,8 +113,10 @@ describe('AlertInput', () => {
 
       const inputElement = component.childAt(0);
       expect(inputElement.prop('className')).to.equal('alert-input-component-input');
-      expect(inputElement.prop('type')).to.equal('text');
-      expect(inputElement.prop('value')).to.equal('lorem');
+      expect(inputElement.prop('type')).to.equal('number');
+      expect(inputElement.prop('min')).to.equal(0);
+      expect(inputElement.prop('placeholder')).to.equal('Type a number');
+      expect(inputElement.prop('value')).to.equal(100);
       expect(inputElement.prop('onChange')).to.be.a('function');
       expect(inputElement.prop('onFocus')).to.be.a('function');
       expect(inputElement.prop('onBlur')).to.be.a('function');
@@ -120,6 +125,10 @@ describe('AlertInput', () => {
       expect(overlayElement.prop('show')).to.equal(false);
       expect(overlayElement.prop('target')).to.be.a('function');
       expect(overlayElement.prop('placement')).to.equal('bottom');
+    });
+
+    it('should also render with default props', () => {
+      expect(shallow(<AlertInput />).find('input').prop('type')).to.equal('text');
     });
 
     it('should render with addons', () => {


### PR DESCRIPTION
- make `AlertInput` accpet `type` as a prop, and pass it on the the internal `input` html element.

### context
- need to use a `number` input in the create product form