### PR TITLE
New: Introducing flat button

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -391,6 +391,9 @@ class AppComponent extends React.Component {
           <Button className="btn-borderless" disabled>
             Borderless Disabled
           </Button>
+          <Button className="btn-flat">
+            Flat Button
+          </Button>
         </div>
 
         <div className="btn-panel">

--- a/src/styles/bootstrapOverrides/Button.scss
+++ b/src/styles/bootstrapOverrides/Button.scss
@@ -135,6 +135,19 @@
   }
 }
 
+.btn-flat {
+  &:not(:disabled) {
+    @include button-variant($color-text-light, $color-inverse, $color-white);
+    border: 0;
+    box-shadow: none;
+
+    &:hover,
+    &:focus {
+      background-color: $color-white;
+    }
+  }
+}
+
 .btn-xs,
 .btn-group-xs > .btn {
   font-size: $font-size-tiny;


### PR DESCRIPTION
Introducing a new flat button without any borders, even when hover over the button. This is useful for close buttons. 

 
![screen shot 2017-08-07 at 11 30 42 am](https://user-images.githubusercontent.com/7802760/29009143-f3d3ef58-7b63-11e7-8ada-00cb3b400b45.png)

can use for buttons like - close button
![screen shot 2017-08-07 at 11 31 42 am](https://user-images.githubusercontent.com/7802760/29009154-07cf7b62-7b64-11e7-91aa-0cad8cb67857.png)


can't use borderless - focus or hover will add a border for the borderless button
![screen shot 2017-08-07 at 11 33 52 am](https://user-images.githubusercontent.com/7802760/29009187-5b822c1e-7b64-11e7-921c-592718bc3d97.png)
