### PR TITLE
Fix: Alert Input User-Agent padding

### DIFF
--- a/src/components/adslotUi/AlertInput/styles.scss
+++ b/src/components/adslotUi/AlertInput/styles.scss
@@ -8,7 +8,7 @@
   border: $border-lighter;
   border-radius: $border-radius;
   display: flex;
-  padding: 4px;
+  padding: 4px 5px;
   position: relative;
 
   &.is-focused {
@@ -36,6 +36,7 @@
     border: 0;
     flex: 1;
     width: 100%;
+    padding: 0;
 
     &:focus {
       outline: none;


### PR DESCRIPTION
Fixes Adslot Product input field growth in line items.

 - Remove user-agent styling of 1px from alert input field to prevent un-expected container heights.
 - Add 1px more left/right padding for breathability of inputs.

![screen shot 2017-08-21 at 11 01 52](https://user-images.githubusercontent.com/908155/29501678-be73f2c6-866d-11e7-9bc1-e6c6cd664acc.png)
