### PR TITLE
Update: update search component to allow value to be controlled by props

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -33,7 +33,6 @@ import {
   Radio,
   RadioGroup,
   SearchBar,
-  SearchField,
   Slicey,
   Spinner,
   SpinnerButton,
@@ -65,6 +64,7 @@ import {
 
 import AlertInputExample from './adslotUi/AlertInput/example';
 import TextareaExample from './adslotUi/Textarea/example';
+import SearchExample from './adslotUi/Search/example';
 
 require('styles/App.scss');
 
@@ -962,13 +962,7 @@ class AppComponent extends React.Component {
         <h2>Pretty Diff</h2>
         <PrettyDiff newText={diffStrings[1]} oldText={diffStrings[0]} />
 
-        <h2>Search</h2>
-        <SearchField
-          onChange={this.searchOnChange}
-          onClear={this.searchOnClear}
-          placeholder="Cities"
-          value={this.state.searchValue}
-        />
+        <SearchExample />
 
         <h2>Slicey</h2>
         <Slicey dataset={sliceyDataset} diameter={150} marker={0.2} donut />

--- a/src/components/adslotUi/Search/example.jsx
+++ b/src/components/adslotUi/Search/example.jsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import Search from './';
+
+export default class SearchExample extends Component {
+  constructor() {
+    super();
+    this.state = {
+      value: '',
+    };
+
+    this.onChange = this.onChange.bind(this);
+    this.onClear = this.onClear.bind(this);
+  }
+
+  onChange(value) {
+    this.setState({ value });
+  }
+
+  onClear() {
+    this.setState({ value: '' });
+  }
+
+  render() {
+    const props = {
+      placeholder: 'Cities',
+      onChange: this.onChange,
+      onClear: this.onClear,
+      value: this.state.value,
+    };
+
+    return (
+      <div>
+        <h2>Search</h2>
+        <div className="row">
+          <div className="col-xs-12">
+            <Search {...props} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/adslotUi/Search/index.jsx
+++ b/src/components/adslotUi/Search/index.jsx
@@ -8,8 +8,9 @@ import './styles.scss';
 export default class Search extends Component {
   constructor(props) {
     super(props);
-    this.state = { value: props.value };
     this.debounceOnSearch = _.debounce(props.onSearch, props.debounceInterval);
+    this.defaultValue = props.value;
+
     this.onChange = this.onChange.bind(this);
     this.onClear = this.onClear.bind(this);
     this.onKeyPress = this.onKeyPress.bind(this);
@@ -20,10 +21,7 @@ export default class Search extends Component {
     if (disabled) return;
 
     const value = _.get(event, 'target.value');
-
-    this.setState({ value });
     onChange(value);
-
     if (searchOnChange) this.debounceOnSearch(value);
   }
 
@@ -32,7 +30,8 @@ export default class Search extends Component {
     if (disabled) return;
 
     if (searchOnEnterKey && event.which === 13) {
-      onSearch(this.state.value);
+      const value = _.get(event, 'target.value');
+      onSearch(value);
     }
   }
 
@@ -42,7 +41,6 @@ export default class Search extends Component {
 
     const value = '';
 
-    this.setState({ value });
     onChange(value);
     if (searchOnChange) {
       onSearch(value);
@@ -51,7 +49,7 @@ export default class Search extends Component {
   }
 
   render() {
-    const { disabled, isLoading, placeholder, svgSymbolCancel, svgSymbolSearch } = this.props;
+    const { disabled, isLoading, placeholder, svgSymbolCancel, svgSymbolSearch, value } = this.props;
     const searchClassSuffixes = disabled ? ['color-disabled'] : svgSymbolSearch.classSuffixes;
     const cancelClassSuffixes = disabled ? ['color-disabled'] : svgSymbolCancel.classSuffixes;
 
@@ -66,10 +64,11 @@ export default class Search extends Component {
           onKeyPress={this.onKeyPress}
           placeholder={`Search ${placeholder}`}
           type="search"
-          value={this.state.value}
+          value={value}
+          defaultValue={this.defaultValue}
         />
         {isLoading ? <Spinner size="small" /> : null}
-        {_.isEmpty(this.state.value)
+        {_.isEmpty(value)
           ? <SvgSymbol href={svgSymbolSearch.href} classSuffixes={searchClassSuffixes} />
           : <SvgSymbol href={svgSymbolCancel.href} classSuffixes={cancelClassSuffixes} onClick={this.onClear} />
         }

--- a/src/examples/components/TreePickerSimplePureDemo.jsx
+++ b/src/examples/components/TreePickerSimplePureDemo.jsx
@@ -162,6 +162,7 @@ class TreePickerSimplePureDemo extends Component {
     this.setState({
       breadcrumbNodes: _.slice(breadcrumbNodes, 0, newBreadcrumbHeadIndex + 1),
       subtree: this.getSubtree(nodeId === 'all' ? 'all' : newHeadNode),
+      searchValue: '',
     });
   }
 


### PR DESCRIPTION
## Current behaviour
`searchValue` is completely controlled internally via state, and therefore we cannot clear value on demand. The only way to clear value is triggering `onClear` function.
This causes problems when applying `Search` into `Treepicker`, since we would like to remove searchString when expanding nodes, breadcrumb clicks, etc.

## Changes
- remove internal state of `Search` component
- add `defaultValue` into `input`
- add Search demo component

## Screenshot
