### PR TITLE
Fix: firefox input overflow on flex

### DIFF
--- a/src/components/adslot-ui/AlertInput/index.jsx
+++ b/src/components/adslot-ui/AlertInput/index.jsx
@@ -87,17 +87,19 @@ export default class AlertInput extends Component {
         onMouseLeave={this.handleMouseLeave}
       >
         {prefixAddon ? <span className={`${baseClass}-addon`}>{prefixAddon}</span> : null}
-        <input
-          className={`${baseClass}-input`}
-          type={type}
-          defaultValue={defaultValue}
-          value={value}
-          min={min}
-          placeholder={placeholder}
-          onChange={onValueChange}
-          onFocus={this.handleInputFocus}
-          onBlur={this.handleInputBlur}
-        />
+        <span className={`${baseClass}-flex-wrapper`}>
+          <input
+            className={`${baseClass}-input`}
+            type={type}
+            defaultValue={defaultValue}
+            value={value}
+            min={min}
+            placeholder={placeholder}
+            onChange={onValueChange}
+            onFocus={this.handleInputFocus}
+            onBlur={this.handleInputBlur}
+          />
+        </span>
         {suffixAddon ? <span className={`${baseClass}-addon`}>{suffixAddon}</span> : null}
         <Overlay
           show={this.state.isPopoverVisible}

--- a/src/components/adslot-ui/AlertInput/index.spec.jsx
+++ b/src/components/adslot-ui/AlertInput/index.spec.jsx
@@ -111,7 +111,7 @@ describe('AlertInput', () => {
       expect(component.prop('onMouseLeave')).to.be.a('function');
       expect(component.children()).to.have.length(2);
 
-      const inputElement = component.childAt(0);
+      const inputElement = component.childAt(0).childAt(0);
       expect(inputElement.prop('className')).to.equal('alert-input-component-input');
       expect(inputElement.prop('type')).to.equal('number');
       expect(inputElement.prop('min')).to.equal(0);

--- a/src/components/adslot-ui/AlertInput/styles.scss
+++ b/src/components/adslot-ui/AlertInput/styles.scss
@@ -31,6 +31,10 @@
     border-color: $color-negative;
   }
 
+  &-flex-wrapper {
+    width: 100%;
+  }
+
   &-input {
     background-color: $color-well;
     border: 0;


### PR DESCRIPTION
Flex and Input does not play well with Firefox, see screenshots

Firefox: 
![screen shot 2017-09-27 at 4 39 07 pm](https://user-images.githubusercontent.com/2588669/30901515-808754a2-a3ab-11e7-8990-532e2f30ea39.png)

Chrome:
![screen shot 2017-09-27 at 4 39 11 pm](https://user-images.githubusercontent.com/2588669/30901519-833f466e-a3ab-11e7-9a0a-4e3adf15dd78.png)

Fix: wrap input inside a wrapper element