### PR TITLE
Upgrade: update sinon to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "seamless-immutable": "^7.1.2",
     "semver": "^5.4.1",
     "shelljs": "^0.7.8",
-    "sinon": "^3.2.0",
+    "sinon": "^4.0.0",
     "url-loader": "^0.5.9",
     "webpack": "^3.5.6",
     "webpack-dev-server": "^2.8.1",


### PR DESCRIPTION
This is a fix for https://github.com/Adslot/adslot-ui/issues/608

`wrench.js` is a dependency of `sinon`, which is removed in `sinon v4.0.0`