### PR TITLE
Fix: Remove deprecated svg xlinkhref

### DIFF
--- a/src/components/alexandria/SvgSymbol/index.jsx
+++ b/src/components/alexandria/SvgSymbol/index.jsx
@@ -11,7 +11,7 @@ const SvgSymbol = (props) => {
 
   return (
     <svg className={`${componentClass}${classesList}`} onClick={onClick}>
-      <use xlinkHref={href} />
+      <use href={href} />
     </svg>
   );
 };

--- a/src/components/alexandria/SvgSymbol/index.spec.jsx
+++ b/src/components/alexandria/SvgSymbol/index.spec.jsx
@@ -10,7 +10,7 @@ describe('SvgSymbol', () => {
     expect(component.type()).to.equal('svg');
 
     const useElement = component.find('use');
-    expect(useElement.prop('xlinkHref')).to.equal(undefined);
+    expect(useElement.prop('href')).to.equal(undefined);
   });
 
   it('should render with props', () => {
@@ -23,6 +23,6 @@ describe('SvgSymbol', () => {
       .equal('svg-symbol-component svg-symbol-component-16 svg-symbol-component-red');
 
     const useElement = component.find('use');
-    expect(useElement.prop('xlinkHref')).to.equal('/assets/other-svg-symbols.svg#checklist-incomplete');
+    expect(useElement.prop('href')).to.equal('/assets/other-svg-symbols.svg#checklist-incomplete');
   });
 });


### PR DESCRIPTION
Apparently the attr is deprecated. I noticed some issues with svg partial rendering and changing to `href` seemed to fix those issues so figured perhaps we should just upgrade this.

[Here is a link to the MDN page with the big red thingo saying its deprecated](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use)

![image](https://user-images.githubusercontent.com/6103860/31105354-53ccc22a-a82f-11e7-9158-49552e76b358.png)
![image](https://user-images.githubusercontent.com/6103860/31105351-40bef77a-a82f-11e7-9525-02c8c98df823.png)
