### PR TITLE
Fix: Add missing babel plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel": "^6.23.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-plugin-transform-strict-mode": "^6.24.1",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.0",


### PR DESCRIPTION
This plugin is missing locally and causes errors which means project doesn't build.

Not sure how some people are actually running this without the dep, maybe its installed globally for people?

Heres a little snippettz
![image](https://user-images.githubusercontent.com/6103860/31105513-7de7060a-a830-11e7-9812-ee8d938dd1d0.png)
