### PR TITLE
Update: option to run single test & disable coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ npm run lint
 
 # Run tests and posttest linting
 
-npm run test
+npm run test [-- --no-coverage]
 
 # Run tests and rebuild on file changes.
 
-npm run test:watch
+npm run test:watch [--file=<path>] [--coverage]
 ```
 
 Generating New Components

--- a/config/loadtests.js
+++ b/config/loadtests.js
@@ -1,2 +1,6 @@
-const modularTestsContext = require.context('../src/components', true, /(\.spec)\.(jsx?)$/);
-modularTestsContext.keys().forEach(modularTestsContext);
+if (ADSLOT_TEST_FILE) {
+  require(ADSLOT_TEST_FILE);
+} else {
+  const modularTestsContext = require.context('../src/components', true, /(\.spec)\.(jsx?)$/);
+  modularTestsContext.keys().forEach(modularTestsContext);
+}

--- a/config/test.js
+++ b/config/test.js
@@ -7,7 +7,7 @@ const commonConfig = require('./common');
 const srcPath = path.resolve(__dirname, '../src');
 const jsRegEx = /\.(js|jsx)$/;
 
-module.exports = merge(commonConfig, {
+const testConfig = merge(commonConfig, {
   output: {
     path: path.join(__dirname, '/../dist/assets'),
     filename: 'app.js',
@@ -30,16 +30,6 @@ module.exports = merge(commonConfig, {
         test: /\.(png|jpg|gif|woff|woff2|css|sass|scss|less|styl)$/,
         loader: 'null-loader', // tests don't care about images and style
       },
-
-      {
-        test: jsRegEx,
-        include: srcPath,
-        exclude: /src\/lib/,
-        use: {
-          loader: 'istanbul-instrumenter-loader',
-          options: { esModules: true },
-        },
-      },
     ],
   },
   externals: {
@@ -49,11 +39,28 @@ module.exports = merge(commonConfig, {
     'react/lib/ReactContext': 'react',
     'react-addons-test-utils': 'react-dom',
   },
-  devtool: 'inline-source-map',
-  plugins: [
-    new webpack.SourceMapDevToolPlugin({
-      filename: null, // if no value is provided the sourcemap is inlined
-      test: jsRegEx,
-    }),
-  ],
 });
+
+module.exports = process.env.npm_config_coverage
+  ? merge(testConfig, {
+    module: {
+      rules: [
+        {
+          test: jsRegEx,
+          include: srcPath,
+          exclude: /src\/lib/,
+          use: {
+            loader: 'istanbul-instrumenter-loader',
+            options: { esModules: true },
+          },
+        },
+      ],
+    },
+    devtool: 'inline-source-map',
+    plugins: [
+      new webpack.SourceMapDevToolPlugin({
+        filename: null, // if no value is provided the sourcemap is inlined
+        test: jsRegEx,
+      }),
+    ],
+  }) : testConfig;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,17 @@
 const webpackConfig = require('./webpack.config');
+const webpack = require('webpack');
+const _ = require('lodash');
+
+const env = { ADSLOT_TEST_FILE: '' };
+
+webpackConfig.plugins.push(
+  new webpack.DefinePlugin(
+    _(env)
+      .assign(_.pick(process.env, _.keys(env)))
+      .mapValues(JSON.stringify)
+      .value()
+  )
+);
 
 module.exports = function configureKarma(config) {
   config.set({

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,7 +33,10 @@ module.exports = function configureKarma(config) {
       mocha: {},
     },
     singleRun: true,
-    reporters: ['coverage', 'mocha'],
+    reporters: _.compact([
+      process.env.npm_config_coverage ? 'coverage' : null,
+      'mocha'
+    ]),
     preprocessors: {
       'config/loadtests.js': ['webpack'],
     },

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "start": "npm run start:dev",
     "start:dev": "webpack-dev-server --config=./config/dev.js",
     "start:cold": "node server.js --env=dev-cold",
-    "test": "scripts/test",
-    "test:watch": "scripts/test watch",
+    "test": "scripts/test --coverage",
+    "test:watch": "scripts/test --watch",
     "version": "echo '…generating dist…' && npm run -s dist && git add dist/*",
     "scaffold": "./scripts/scaffold"
   },

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "start": "npm run start:dev",
     "start:dev": "webpack-dev-server --config=./config/dev.js",
     "start:cold": "node server.js --env=dev-cold",
-    "test": "karma start",
-    "test:watch": "karma start --autoWatch=true --singleRun=false",
+    "test": "scripts/test",
+    "test:watch": "scripts/test watch",
     "version": "echo '…generating dist…' && npm run -s dist && git add dist/*",
     "scaffold": "./scripts/scaffold"
   },

--- a/scripts/test
+++ b/scripts/test
@@ -2,38 +2,30 @@
 
 const path = require('path');
 const { execSync } = require('child_process');
+let {
+  coverage, file = process.env.npm_config_file, watch
+} = require('minimist')(process.argv.slice(2));
+if (coverage) process.env.npm_config_coverage = coverage;
 
-const TASK = 2;
-const argv = require('minimist')(process.argv.slice(TASK + 1));
-let { file = argv._.pop() } = argv;
 if (file) {
-  if (!path.isAbsolute(file)) {
-    file = execSync('npm root').toString().replace('node_modules', file).trim()
-  }
+  const projectRoot = execSync('npm root').toString().replace('node_modules', '').trim()
+
   const FORMAT = {
-    UNDERLINE: '\x1b[4m',
+    BOLD: '\x1b[1m',
     RESET: '\x1b[0m',
-    BOLD: '\x1b[1m'
+    UNDERLINE: '\x1b[4m',
   }
-  
+  file = path.resolve(projectRoot, file);
   console.info(`${FORMAT.UNDERLINE}Running test${FORMAT.RESET}:${FORMAT.BOLD} ${file}${FORMAT.RESET}`); 
   process.env.ADSLOT_TEST_FILE = file;
   // has to be done this way as karma removed the cli option to override config
 }
 
-// npm run test[:watch] -- [--file=]path
-switch (process.argv[TASK]) {
-  case 'watch':
-    exec('karma start --autoWatch=true --singleRun=false');
-    break;
-  default:
-    exec('karma start');
-}
-
-function exec(cmd) {
-  try {
-    execSync(cmd, { stdio: [0, 1, 2] });
-  } catch (err) {
-    process.exit(err.status);
-  }
+// npm run test[:watch] --file=path [--coverage]
+let cmd = 'karma start';
+if (watch) cmd += ' --autoWatch=true --singleRun=false';
+try {
+  execSync(cmd, { stdio: [0, 1, 2] });
+} catch (err) {
+  process.exit(err.status);
 }

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { execSync } = require('child_process');
+
+const TASK = 2;
+const argv = require('minimist')(process.argv.slice(TASK + 1));
+let { file = argv._.pop() } = argv;
+if (file) {
+  if (!path.isAbsolute(file)) {
+    file = execSync('npm root').toString().replace('node_modules', file).trim()
+  }
+  const FORMAT = {
+    UNDERLINE: '\x1b[4m',
+    RESET: '\x1b[0m',
+    BOLD: '\x1b[1m'
+  }
+  
+  console.info(`${FORMAT.UNDERLINE}Running test${FORMAT.RESET}:${FORMAT.BOLD} ${file}${FORMAT.RESET}`); 
+  process.env.ADSLOT_TEST_FILE = file;
+  // has to be done this way as karma removed the cli option to override config
+}
+
+// npm run test[:watch] -- [--file=]path
+switch (process.argv[TASK]) {
+  case 'watch':
+    exec('karma start --autoWatch=true --singleRun=false');
+    break;
+  default:
+    exec('karma start');
+}
+
+function exec(cmd) {
+  try {
+    execSync(cmd, { stdio: [0, 1, 2] });
+  } catch (err) {
+    process.exit(err.status);
+  }
+}


### PR DESCRIPTION
To run a specific test file:
`$ npm run test[:watch] --file=<absolute path or path relative to project root>`
watch mode has coverage off by default, to turn it on:
`$ npm run test:watch --coverage`
