### PR TITLE
Update: deprecate OpenBrowserPlugin

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -2,7 +2,6 @@
 const merge = require('webpack-merge');
 const webpack = require('webpack');
 const { resolve } = require('path');
-const OpenBrowserPlugin = require('open-browser-webpack-plugin');
 
 const commonConfig = require('./common');
 
@@ -68,11 +67,11 @@ module.exports = merge(commonConfig, {
       timings: false,
       warnings: true,
     },
+    open: `http://${HOST}:${PORT}/webpack-dev-server/`,
   },
   devtool: 'cheap-module-eval-source-map',
   plugins: [
     new webpack.HotModuleReplacementPlugin(), // enable HMR globally
     new webpack.NamedModulesPlugin(), // prints more readable module names in the browser console on HMR updates
-    new OpenBrowserPlugin({ url: `http://${HOST}:${PORT}/webpack-dev-server/` }),
   ],
 });

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "nuka-carousel": "^2.0.4",
     "null-loader": "^0.1.1",
     "object-assign": "^4.1.1",
-    "open-browser-webpack-plugin": "0.0.5",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
     "react-bootstrap": "^0.31.1",


### PR DESCRIPTION
Fix https://github.com/Adslot/adslot-ui/issues/613 and https://github.com/Adslot/adslot-ui/issues/614

As per https://webpack.github.io/docs/webpack-dev-server.html
> --open: opens the url in default browser (for webpack-dev-server versions > 2.0).

We don't need this plugin anymore.