### PR TITLE
New: AlertInput onFocus prop addition

### DIFF
--- a/docs/examples/AlertInputExample.jsx
+++ b/docs/examples/AlertInputExample.jsx
@@ -107,6 +107,9 @@ const exampleProps = {
       propType: 'onBlur',
       type: 'func',
     }, {
+      propType: 'onFocus',
+      type: 'func',
+    }, {
       propType: 'type',
       type: "oneOf: 'text', 'number'",
     }, {

--- a/src/components/adslot-ui/AlertInput/index.jsx
+++ b/src/components/adslot-ui/AlertInput/index.jsx
@@ -46,6 +46,10 @@ export default class AlertInput extends Component {
       isFocused: true,
       isPopoverVisible: Boolean(this.props.alertMessage),
     });
+
+    if (this.props.onFocus) {
+      this.props.onFocus(event);
+    }
   }
 
   handleInputBlur(event) {
@@ -127,6 +131,7 @@ AlertInput.propTypes = {
   alertMessage: PropTypes.string,
   onValueChange: PropTypes.func,
   onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
 };
 
 AlertInput.defaultProps = {

--- a/src/components/adslot-ui/AlertInput/index.spec.jsx
+++ b/src/components/adslot-ui/AlertInput/index.spec.jsx
@@ -70,6 +70,26 @@ describe('AlertInput', () => {
       });
       expect(focusEvent.target.select.callCount).to.equal(1);
     });
+
+    it('should call prop `onFocus` if exists', () => {
+      const onFocusSpy = sinon.spy();
+      const focusEvent = {
+        target: {
+          select: sinon.spy(),
+        },
+      };
+      const component = shallow(<AlertInput onFocus={onFocusSpy} />);
+      const inputElement = component.find('.alert-input-component-input');
+
+      inputElement.simulate('focus', focusEvent);
+
+      expect(component.state()).to.eql({
+        isFocused: true,
+        isPopoverVisible: false,
+      });
+      expect(focusEvent.target.select.callCount).to.equal(1);
+      expect(onFocusSpy.callCount).to.equal(1);
+    });
   });
 
   describe('handleInputBlur ()', () => {


### PR DESCRIPTION
Add `onFocus` propType function to `AlertInput`

Resolves: https://github.com/Adslot/adslot-ui/issues/637

![capture](https://user-images.githubusercontent.com/3688957/31697810-98ac748a-b405-11e7-8b75-9d89704544b2.JPG)
