### PR TITLE
Update: 3rd Party Button Component with AdslotUI Wrapper

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -9,6 +9,7 @@ module.exports = {
     modules: ['node_modules'],
     extensions: ['.js', '.jsx'],
     alias: {
+      'third-party': `${srcPath}/components/third-party`,
       'adslot-ui': `${srcPath}/components/adslot-ui`,
       alexandria: `${srcPath}/components/alexandria`,
       lib: `${srcPath}/lib/`,

--- a/docs/examples/ButtonExample.jsx
+++ b/docs/examples/ButtonExample.jsx
@@ -6,9 +6,34 @@ import {
 } from '../../src/dist-entry';
 
 class ButtonExample extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      canUndo: false,
+    };
+    this.onClick = () => this.setState({ canUndo: !this.state.canUndo });
+  }
+
   render() {
-    const onClick = _.noop;
-    return (<Button bsStyle="primary" onClick={onClick}>Apply</Button>);
+    return (
+      <div>
+        <Button
+          bsStyle="link"
+          disabled={!this.state.canUndo}
+          reason="There's nothing to undo."
+          onClick={this.onClick}
+        >
+          Undo
+        </Button>
+        <Button
+          bsStyle="primary"
+          disabled={this.state.canUndo}
+          onClick={this.onClick}
+        >
+          Apply
+        </Button>
+      </div>
+    );
   }
 }
 
@@ -19,16 +44,39 @@ export const exampleProps = {
   </a> or <a href="https://react-bootstrap.github.io/components.html#buttons" target="_blank" rel="noopener noreferrer">
     React Bootstrap documentation
   </a>.</p>),
-  exampleCodeSnippet: '<Button bsStyle="primary" onClick={onClick}>\n  Apply\n</Button>',
+  exampleCodeSnippet: `<div>
+  <Button
+    bsStyle="link"
+    disabled={!this.state.canUndo}
+    reason="There's nothing to undo."
+    onClick={this.onClick}
+  >
+    Undo
+  </Button>
+  <Button
+    bsStyle="primary"
+    disabled={this.state.canUndo}
+    onClick={this.onClick}
+  >
+    Apply
+  </Button>
+</div>`,
   propTypes: [{
     propType: 'bsStyle',
     type: 'string, oneOf primary, link, and default.',
     defaultValue: 'default',
     note: <span>
-      For an inverse button use <pre>className="btn-inverse"</pre>.
       <br />It's uncommon to use <pre>success</pre>, <pre>info</pre>, <pre>warning</pre>, or <pre>danger</pre>
       which are supported by Bootstrap but not us.
     </span>,
+  }, {
+    propType: 'inverse',
+    type: 'bool',
+    note: 'Renders an inverse button. Can be used with bsStyle to create primary inverse buttons.',
+  }, {
+    propType: 'reason',
+    type: 'string',
+    note: 'Used in tandem with the disabled prop to present a popover explaining why the button is disabled.',
   }, {
     propType: 'onClick',
     type: 'func',

--- a/src/components/third-party/bootstrap/Button/index.jsx
+++ b/src/components/third-party/bootstrap/Button/index.jsx
@@ -1,0 +1,62 @@
+/* eslint-disable react/prop-types */
+// disable proptypes check because it doens't take into consideration extended types
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import BootstrapButton from 'react-bootstrap/lib/Button';
+import BootstrapPopover from 'react-bootstrap/lib/Popover';
+import BootstrapOverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import { expandDts } from 'lib/utils';
+
+
+class Button extends React.PureComponent {
+  renderWithReason() {
+    const popover = (<BootstrapPopover
+      id="btn-reason"
+      className="btn-popover-reason"
+    >{this.props.reason}</BootstrapPopover>);
+    return (
+      <BootstrapOverlayTrigger trigger={['focus', 'hover']} placement="bottom" overlay={popover}>
+        {this.renderButton()}
+      </BootstrapOverlayTrigger>
+    );
+  }
+
+  renderButton() {
+    const {
+      inverse,
+      children,
+      dts,
+      className,
+    } = this.props;
+
+    return (
+      <BootstrapButton
+        {..._.pick(this.props, _.keys(BootstrapButton.propTypes))}
+        className={classNames(className, { 'btn-inverse': inverse && !/btn-inverse/.test(className) })}
+        {...expandDts(dts)}
+      >{children}</BootstrapButton>
+    );
+  }
+
+  render() {
+    const {
+      disabled,
+      reason,
+    } = this.props;
+    return (disabled && reason) ? this.renderWithReason() : this.renderButton();
+  }
+}
+
+Button.propTypes = _.assign({
+  inverse: PropTypes.bool,
+  reason: PropTypes.string,
+  dts: PropTypes.string,
+}, BootstrapButton.propTypes);
+
+Button.defaultProps = {
+  inverse: false,
+};
+
+export default Button;

--- a/src/components/third-party/bootstrap/Button/index.spec.jsx
+++ b/src/components/third-party/bootstrap/Button/index.spec.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Button } from 'third-party';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import BootstrapButton from 'react-bootstrap/lib/Button';
+
+describe('ButtonComponent', () => {
+  it('should render Bootstrap Button', () => {
+    const element = shallow(<Button>Test</Button>);
+    expect(element.type()).to.equal(BootstrapButton);
+  });
+
+  it('should support legacy classname btn-inverse for non-breaking change', () => {
+    const element = shallow(<Button className="btn-inverse">Test</Button>);
+    expect(element.prop('className')).to.equal('btn-inverse');
+  });
+
+  it('should support className prop', () => {
+    const element = shallow(<Button className="all the-classes">Test</Button>);
+    expect(element.prop('className')).to.equal('all the-classes');
+  });
+
+  it('should not duplicate btn-inverse class if both legacy and new are used', () => {
+    const element = shallow(<Button inverse className="btn-inverse">Test</Button>);
+    expect(element.prop('className')).to.equal('btn-inverse');
+  });
+
+  it('should render inverse button with btn-inverse class', () => {
+    const element = shallow(<Button inverse>Test</Button>);
+    expect(element.prop('className')).to.equal('btn-inverse');
+  });
+
+  it('should support data-test-selectors', () => {
+    const element = shallow(<Button dts="test-button">Test</Button>);
+    expect(element.prop('data-test-selector')).to.equal('test-button');
+  });
+
+  it('should render disabled button without a reason popover if no reason given', () => {
+    const element = shallow(<Button disabled>Test</Button>);
+    expect(element.find(OverlayTrigger)).to.have.length(0);
+  });
+
+  it('should render disabled button with a reason popover', () => {
+    const element = shallow(<Button disabled reason="Because">Test</Button>);
+    const overlay = element.find(OverlayTrigger);
+    expect(overlay).to.have.length(1);
+    expect(shallow(overlay.prop('overlay')).text()).to.eql('Because');
+  });
+});

--- a/src/components/third-party/index.js
+++ b/src/components/third-party/index.js
@@ -1,0 +1,7 @@
+import Button from './bootstrap/Button';
+
+export { Button };
+
+export default {
+  Button,
+};

--- a/src/dist-entry/core.js
+++ b/src/dist-entry/core.js
@@ -5,7 +5,8 @@ import RadioGroup from 'react-icheck/lib/RadioGroup';
 import Select from 'react-select';
 
 // React Bootstrap
-import Button from 'react-bootstrap/lib/Button';
+import { Button } from 'third-party';
+
 import Dropdown from 'react-bootstrap/lib/Dropdown';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 import Modal from 'react-bootstrap/lib/Modal';

--- a/src/styles/bootstrapOverrides/Button.scss
+++ b/src/styles/bootstrapOverrides/Button.scss
@@ -108,7 +108,14 @@
   }
 }
 
-.btn-link {
+.btn-popover-reason {
+  max-width: 140px;
+  color: $color-help;
+  font-size: $font-size-small;
+}
+
+// disable lint on next line as we need to force extra specificity to ensure disabled styles take precedence
+.btn.btn-link { // sass-lint:disable-line force-element-nesting
   cursor: pointer;
 
   &,
@@ -116,7 +123,15 @@
     @include reset-shadow-and-transform;
   }
 
-  &:disabled {
+
+  &:disabled,
+  &[disabled] {
+    background-color: transparent;
+    cursor: not-allowed;
+  }
+
+  &:hover,
+  &:active {
     background-color: transparent;
   }
 }


### PR DESCRIPTION
Starting with the `button` component this PR demonstrates the preferred and proposed way of wrapping and exporting supported third-party components.

It allows us to properly document, test and support features and opinions as part of adslot ui directly - such as data-test-selectors.

### Changes
Create a wrapper component for Bootstrap's Button Component
Allows DTS
Supports 'inverse' buttons
Support disabled buttons to have a 'reason'


### Screenos
Support for disabled reasons
<img width="184" alt="screen shot 2017-12-08 at 17 26 39" src="https://user-images.githubusercontent.com/908155/33753738-fe70a872-dc3c-11e7-9873-9ef113aa649c.png">
