### PR TITLE
[ADS-355] information box component added

### DIFF
--- a/docs/components/Layout/index.jsx
+++ b/docs/components/Layout/index.jsx
@@ -43,6 +43,7 @@ import SearchExample from '../../examples/SearchExample';
 import SearchBarExample from '../../examples/SearchBarExample';
 import TreePickerExample from '../../examples/TreePickerExample';
 import UserListPickerExample from '../../examples/UserListPickerExample';
+import InformationBoxExample from '../../examples/InformationBoxExample';
 import SplitPaneExample from '../../examples/SplitPaneExample';
 
 import { PageTitle } from '../../../src/dist-entry';
@@ -116,6 +117,7 @@ const componentsBySection = {
     'tile-grid',
     'flexible-spacer',
     'split-pane',
+    'information-box',
   ],
   'tree-picker': [
     'tree-picker',
@@ -203,6 +205,7 @@ class PageLayout extends React.Component {
             <TileGridExample />
             <FlexibleSpacerExample />
             <SplitPaneExample />
+            <InformationBoxExample />
 
             <PageTitle title="Tree Picker" />
             <TreePickerExample />

--- a/docs/examples/InformationBoxExample.jsx
+++ b/docs/examples/InformationBoxExample.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Example from '../components/Example';
+import {
+  InformationBox,
+} from '../../src/dist-entry';
+
+class InformationBoxExample extends React.PureComponent {
+
+   render() {
+    return (<InformationBox
+      title="This is an information"
+      icon="/assets/svg-symbols.svg#cancel">
+        Content body.
+    </InformationBox>);
+  }
+}
+
+const exampleProps = {
+  componentName: 'Information Box',
+  exampleCodeSnippet: `
+    <InformationBox
+      title="This is an information"
+      icon="/assets/svg-symbols.svg#cancel">
+        Content body.
+    </InformationBox>`,
+  propTypes: [{
+    propType: 'children',
+    type: 'node',
+  },
+  {
+    propType: 'icon',
+    type: 'string',
+    note: <span>href for <a href="#svg-symbol-example">SVG Symbol</a> component.</span>,
+  },
+  {
+    propType: 'title',
+    type: 'string',
+  }],
+};
+
+export default () => <Example {...exampleProps}><InformationBoxExample /></Example>;

--- a/src/components/adslot-ui/InformationBox/index.jsx
+++ b/src/components/adslot-ui/InformationBox/index.jsx
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import SvgSymbol from 'alexandria/SvgSymbol';
+
+require('./styles.scss');
+
+const InformationBox = ({ children, icon, title }) =>
+  <div className="information-box">
+    <div className="information-box-icon">
+      {icon ? <SvgSymbol classSuffixes={['70']} href={icon} /> : null}
+    </div>
+    <div className="information-box-text">
+      {title ? <label className="information-box-title">{title}</label> : null}
+      <div className="information-box-node">{children}</div>
+    </div>
+  </div>;
+
+InformationBox.propTypes = {
+  children: PropTypes.node,
+  title: PropTypes.string,
+  icon: PropTypes.string,
+};
+
+export default InformationBox;

--- a/src/components/adslot-ui/InformationBox/index.spec.jsx
+++ b/src/components/adslot-ui/InformationBox/index.spec.jsx
@@ -1,0 +1,55 @@
+import InformationBox from 'adslot-ui/InformationBox';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+describe('InformationBoxComponent', () => {
+  it('should render with props', () => {
+    const component = shallow(<InformationBox
+      title="render title here"
+      icon="assets/img#done"
+      children="<div>I am child</div>"
+    />);
+
+    const titleElement = component.find('.information-box-title');
+    expect(titleElement).to.have.length(1);
+    expect(titleElement.text()).to.equal('render title here');
+    expect(component.find('.information-box-node')).to.have.length(1);
+    expect(component.find('.information-box-icon')).to.have.length(1);
+  });
+
+  it('should render without a title when title props is not provided', () => {
+    const component = shallow(<InformationBox
+      icon="assets/img#done"
+      children="<div>I am child</div>"
+    />);
+
+    const titleElement = component.find('.information-box-title');
+    expect(titleElement).to.have.length(0);
+    expect(component.find('.information-box-node')).to.have.length(1);
+    expect(component.find('.information-box-icon')).to.have.length(1);
+    expect(component.find('SvgSymbol')).to.have.length(1);
+  });
+
+  it('should render with empty icon when icon props is not provided', () => {
+    const component = shallow(<InformationBox
+      title="render title here"
+      children="<div>I am child</div>"
+    />);
+
+    expect(component.find('.information-box-title')).to.have.length(1);
+    expect(component.find('.information-box-node').children()).to.have.length(1);
+    expect(component.find('.information-box-icon')).to.have.length(1);
+    expect(component.find('SvgSymbol')).to.have.length(0);
+  });
+
+  it('should render without children nodes when children props is not provided', () => {
+    const component = shallow(<InformationBox
+      title="render title here"
+      icon="assets/img#done"
+    />);
+
+    expect(component.find('.information-box-title')).to.have.length(1);
+    expect(component.find('.information-box-icon')).to.have.length(1);
+    expect(component.find('.information-box-node').children()).to.have.length(0);
+  });
+});

--- a/src/components/adslot-ui/InformationBox/styles.scss
+++ b/src/components/adslot-ui/InformationBox/styles.scss
@@ -1,0 +1,33 @@
+@import '~styles/color';
+@import '~styles/variable';
+
+.information-box {
+  background-color: $color-background-highlighted;
+  padding: $spacing-etalon;
+  color: $color-text-label;
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+
+  &-text {
+    padding-left: 20px;
+    flex-grow: 1;
+  }
+
+  &-title {
+    font-size: $font-size-subheader;
+    font-weight: $font-weight-bold;
+    color: $color-gray-darker;
+  }
+
+  &-icon {
+    $information-box-icon-size: 70px;
+
+    background-color: $color-background;
+    width: $information-box-icon-size;
+    height: $information-box-icon-size;
+    border-radius: $border-radius-circle;
+    text-align: center;
+    overflow: hidden;
+  }
+}

--- a/src/components/adslot-ui/index.js
+++ b/src/components/adslot-ui/index.js
@@ -21,6 +21,7 @@ import TreePickerNode from 'adslot-ui/TreePicker/Node';
 import TreePickerSimplePure from 'adslot-ui/TreePicker';
 import UserListPicker from 'adslot-ui/UserListPicker';
 import fastStatelessWrapper from 'adslot-ui/fastStatelessWrapper';
+import InformationBox from 'adslot-ui/InformationBox';
 
 export {
   Accordion,
@@ -46,4 +47,5 @@ export {
   TreePickerNode,
   TreePickerSimplePure,
   UserListPicker,
+  InformationBox,
 };

--- a/src/dist-entry/core.js
+++ b/src/dist-entry/core.js
@@ -67,6 +67,7 @@ import {
   TreePickerNode,
   TreePickerSimplePure,
   UserListPicker,
+  InformationBox,
 } from 'adslot-ui';
 
 export {
@@ -127,4 +128,5 @@ export {
   TreePickerNode,
   TreePickerSimplePure,
   UserListPicker,
+  InformationBox,
 };


### PR DESCRIPTION
can be used for showing an information box.
it can accept a title, icon and children.

for issue-- Resolves https://github.com/Adslot/adslot-ui/issues/633

![screen shot 2017-10-23 at 11 30 41 am](https://user-images.githubusercontent.com/10596596/31869864-833c0d64-b7f6-11e7-9619-6fa54a4f8d01.png)
