### PR TITLE
Build: add development build into dist directory

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -12,13 +12,13 @@ const publicPath = '/assets/';
 
 module.exports = merge(commonConfig, {
   entry: [
-     // activate HMR for React (needs to be before everything except polyfills)
+    // activate HMR for React (needs to be before everything except polyfills)
     'react-hot-loader/patch',
     // bundle the client for webpack-dev-server and connect to the provided endpoint
     `webpack-dev-server/client?http://${HOST}:${PORT}`,
     // bundle the client for hot reloading, only- means to only hot reload for successful updates
     'webpack/hot/only-dev-server',
-     // the entry point of our app
+    // the entry point of our app
     '../docs/run',
   ],
   output: {

--- a/config/dist.js
+++ b/config/dist.js
@@ -1,75 +1,91 @@
-// development config
+const _ = require('lodash');
 const merge = require('webpack-merge');
 const webpack = require('webpack');
 const { resolve } = require('path');
 const commonConfig = require('./common');
 
-module.exports = merge(commonConfig, {
-  entry: {
+module.exports = () => {
+  const buildType = process.env.TYPE || 'development';
+
+  let entries = {
     main: resolve(__dirname, '../src/dist-entry'),
     core: resolve(__dirname, '../src/dist-entry/core'),
     extra: resolve(__dirname, '../src/dist-entry/extra'),
-  },
-  externals: {
-    lodash: {
-      root: '_',
-      commonjs2: 'lodash',
-      commonjs: 'lodash',
-      amd: 'lodash',
-    },
-    react: {
-      root: 'React',
-      commonjs2: 'react',
-      commonjs: 'react',
-      amd: 'react',
-    },
-    'react-dom': {
-      root: 'ReactDOM',
-      commonjs2: 'react-dom',
-      commonjs: 'react-dom',
-      amd: 'react-dom',
-    },
-    'react-redux': {
-      root: 'reactRedux',
-      commonjs2: 'react-redux',
-      commonjs: 'react-redux',
-      amd: 'react-redux',
-    },
-    'redux': {
-      root: 'Redux',
-      commonjs2: 'redux',
-      commonjs: 'redux',
-      amd: 'redux',
-    },
-  },
-  output: {
-    path: resolve(__dirname, '../dist'),
-    filename: 'adslot-ui-[name].js',
-    libraryTarget: 'umd',
-    library: 'AdslotUI',
-  },
-  devtool: 'inline',
-  cache: false,
-  plugins: [
-    new webpack.DefinePlugin({ // ensures webpack will always optimise for production
-      'process.env.NODE_ENV': '"production"',
-    }),
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false,
-      },
-      output: {
-        comments: false,
-      },
-      sourceMap: false,
-      include: /\.js$/,
-      parallel: {
-        cache: true,
-        workers: 2, // run on two cores #GSD
-      },
-    }),
+  };
+  const plugins = [
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.ModuleConcatenationPlugin(),
-  ],
-});
+  ];
+
+  if (buildType === 'development') {
+    entries = _.mapKeys(entries, (value, key) => `${key}.dev`);
+  }
+
+  if (buildType === 'production') {
+    plugins.push(
+      new webpack.DefinePlugin({ // ensures webpack will always optimise for production
+        'process.env.NODE_ENV': '"production"',
+      }),
+      new webpack.optimize.UglifyJsPlugin({
+        compress: {
+          warnings: false,
+        },
+        output: {
+          comments: false,
+        },
+        sourceMap: false,
+        include: /\.js$/,
+        parallel: {
+          cache: true,
+          workers: 2, // run on two cores #GSD
+        },
+      })
+    );
+  }
+
+  return merge(commonConfig, {
+    entry: entries,
+    externals: {
+      lodash: {
+        root: '_',
+        commonjs2: 'lodash',
+        commonjs: 'lodash',
+        amd: 'lodash',
+      },
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react',
+      },
+      'react-dom': {
+        root: 'ReactDOM',
+        commonjs2: 'react-dom',
+        commonjs: 'react-dom',
+        amd: 'react-dom',
+      },
+      'react-redux': {
+        root: 'reactRedux',
+        commonjs2: 'react-redux',
+        commonjs: 'react-redux',
+        amd: 'react-redux',
+      },
+      'redux': {
+        root: 'Redux',
+        commonjs2: 'redux',
+        commonjs: 'redux',
+        amd: 'redux',
+      },
+    },
+    output: {
+      path: resolve(__dirname, '../dist'),
+      filename: 'adslot-ui-[name].js',
+      libraryTarget: 'umd',
+      library: 'AdslotUI',
+    },
+    devtool: 'inline',
+    cache: false,
+    plugins,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check-commit": "node scripts/commit-msg",
     "clean": "rimraf dist/*",
     "codecov": "cat coverage/coverage-final.json | codecov",
-    "dist": "webpack --bail --env=dist --progress -p --hide-modules",
+    "dist": "./scripts/dist",
     "eslint": "eslint --ext .jsx,.js --rulesdir ./src ./src",
     "lint": "npm run eslint && npm run sass-lint && npm run check-commit",
     "posttest": "npm run lint",

--- a/scripts/dist
+++ b/scripts/dist
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo 'Deleting distribution files...';
+npm run clean;
+
+echo 'Generating development build...';
+TYPE=development webpack --bail --env=dist --progress --hide-modules;
+
+echo 'Generating production build...';
+TYPE=production webpack --bail --env=dist --progress -p --hide-modules;
+exit 0;


### PR DESCRIPTION
Resolves https://github.com/Adslot/adslot-ui/issues/646
new dist directory structure
```bash
dist/
-- adslot-ui-core.css
-- adslot-ui-core.dev.css
-- adslot-ui-core.dev.js
-- adslot-ui-core.js
-- adslot-ui-extra.css
-- adslot-ui-extra.dev.css
-- adslot-ui-extra.dev.js
-- adslot-ui-extra.js
-- adslot-ui-main.css
-- adslot-ui-main.dev.css
-- adslot-ui-main.dev.js
-- adslot-ui-main.js
```