### PR TITLE
Fix: Safari SVG issues

### DIFF
--- a/src/components/adslot-ui/index.js
+++ b/src/components/adslot-ui/index.js
@@ -22,6 +22,9 @@ import TreePickerSimplePure from 'adslot-ui/TreePicker';
 import UserListPicker from 'adslot-ui/UserListPicker';
 import fastStatelessWrapper from 'adslot-ui/fastStatelessWrapper';
 import InformationBox from 'adslot-ui/InformationBox';
+import svg4everybody from 'svg4everybody';
+
+svg4everybody({ polyfill: true });
 
 export {
   Accordion,


### PR DESCRIPTION
`svg4everyone` was removed when we merged `adslot` and `alexandria`. This caused problems displaying `svg`s in Safari because `SvgSymbol` uses `href` instead of `xlink:href`. There may be other issues or other browsers affected that could be fixed by this.
https://adslot.atlassian.net/browse/ADS-364