### PR TITLE
Fix: svg href issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11552,11 +11552,6 @@
         "has-flag": "2.0.0"
       }
     },
-    "svg4everybody": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/svg4everybody/-/svg4everybody-2.1.9.tgz",
-      "integrity": "sha1-W9n23vwTOFmgRGRtR0P6vCjbfi0="
-    },
     "svgo": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -108,8 +108,7 @@
     "diff-match-patch": "^1.0.0",
     "lodash": "^4.17.4",
     "react": "^15.6.1",
-    "react-dom": "^15.6.1",
-    "svg4everybody": "^2.1.9"
+    "react-dom": "^15.6.1"
   },
   "engines": {
     "node": ">=6 <9"

--- a/src/components/adslot-ui/index.js
+++ b/src/components/adslot-ui/index.js
@@ -23,9 +23,6 @@ import UserListPicker from 'adslot-ui/UserListPicker';
 import HoverDropdownMenu from 'adslot-ui/HoverDropdownMenu';
 import fastStatelessWrapper from 'adslot-ui/fastStatelessWrapper';
 import InformationBox from 'adslot-ui/InformationBox';
-import svg4everybody from 'svg4everybody';
-
-svg4everybody({ polyfill: true });
 
 export {
   Accordion,

--- a/src/components/alexandria/SvgSymbol/index.jsx
+++ b/src/components/alexandria/SvgSymbol/index.jsx
@@ -11,7 +11,7 @@ const SvgSymbol = (props) => {
 
   return (
     <svg className={`${componentClass}${classesList}`} onClick={onClick}>
-      <use href={href} />
+      <use href={href} xlinkHref={href} />
     </svg>
   );
 };


### PR DESCRIPTION
Context:
- There was a PR changing `xlink:href` to `href` because the former is deprecated
- Then safari stopped working so there was another PR that added `svg4everybody` polyfill
- Then it turns out that updating `href` does not work in the polyfill