### PR TITLE
[Docs] Add max width AND add state for navigation bar

### DIFF
--- a/docs/components/Example/index.jsx
+++ b/docs/components/Example/index.jsx
@@ -44,35 +44,38 @@ class Example extends React.PureComponent {
           {children}
         </div>
 
-        <SyntaxHighlighter language="html" style={github}>{exampleCodeSnippet}</SyntaxHighlighter>
-
+        <div className="adslot-ui-code-snippet">
+          <SyntaxHighlighter language="html" style={github}>{exampleCodeSnippet}</SyntaxHighlighter>
+        </div>
 
         <h3>PropTypes</h3>
-        <table className="table table-striped table-bordered">
-          <thead>
-            <tr>
-              <th>PropType</th>
-              <th>Type</th>
-              <th>Default Value</th>
-              <th>Notes</th>
-            </tr>
-          </thead>
-          <tbody>
-            {_.map(propTypes, ({ propType, type, defaultValue, note }) => (
-              <tr key={propType}>
-                <td><pre>{propType}</pre></td>
-                <td><pre>{type}</pre></td>
-                <td>{defaultValue}</td>
-                <td>{note}</td>
+        <div className="adslot-ui-proptype-table">
+          <table className="table table-striped table-bordered">
+            <thead>
+              <tr>
+                <th>PropType</th>
+                <th>Type</th>
+                <th>Default Value</th>
+                <th>Notes</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-        <Empty
-          collection={propTypes}
-          hideIcon
-          text="No PropType definitions for this component, please check the source-code."
-        />
+            </thead>
+            <tbody>
+              {_.map(propTypes, ({ propType, type, defaultValue, note }) => (
+                <tr key={propType}>
+                  <td><pre>{propType}</pre></td>
+                  <td><pre>{type}</pre></td>
+                  <td>{defaultValue}</td>
+                  <td>{note}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <Empty
+            collection={propTypes}
+            hideIcon
+            text="No PropType definitions for this component, please check the source-code."
+          />
+        </div>
         <Button bsStyle="link" href="#top">↑ Back to top.</Button>
       </div>
     );

--- a/docs/components/Example/styles.scss
+++ b/docs/components/Example/styles.scss
@@ -8,6 +8,14 @@
     max-width: 940px;
   }
 
+  .adslot-ui-code-snippet {
+    max-width: 940px;
+  }
+
+  .adslot-ui-proptype-table {
+    max-width: 1100px;
+  }
+
   h2 {
     margin-bottom: $spacing-etalon;
     font-size: $font-size-header;
@@ -19,12 +27,40 @@
   }
 
   table {
-    td:empty:before {
-      content: '—';
-    }
 
     + .empty-component {
       padding: 0;
     }
+
+    tr {
+      td {
+
+        &:empty:before {
+          content: '—';
+        }
+
+        &:nth-child(1) {
+          width: 10%;
+        }
+
+        &:nth-child(2) {
+          width: 15%;
+        }
+
+        &:nth-child(3) {
+          width: 25%;
+        }
+
+        &:nth-child(4) {
+          width: 50%;
+        }
+
+        pre {
+          white-space: pre-wrap;
+        }
+
+      }
+    }
+
   }
 }

--- a/docs/components/Navigation/index.jsx
+++ b/docs/components/Navigation/index.jsx
@@ -7,37 +7,37 @@ import {
 } from '../../../src/dist-entry';
 import './styles.scss';
 
+const initialOpenPanel = 'form-elements';
+
 const contentFactory = (navigateTo) => (componentName) => <li key={componentName}>
   <Button bsStyle="link" onClick={() => navigateTo(componentName)}>{_.startCase(componentName)}</Button>
 </li>;
 
-const panelFactory = (navigateTo) => (section, sectionName) => ({
+const panelFactory = (navigateTo, currentOpenPanel) => (section, sectionName) => ({
   id: sectionName,
   title: _.startCase(sectionName),
   content: <ul className="list-unstyled">{_.map(section, contentFactory(navigateTo))}</ul>,
-  isCollapsed: sectionName !== 'form-elements',
+  isCollapsed: sectionName !== currentOpenPanel,
 });
-
 
 class Navigation extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      panels: _.map(props.componentsBySection, panelFactory(props.navigateTo)),
+      currentOpenPanel: initialOpenPanel,
     };
     this.togglePanel = this.togglePanel.bind(this);
   }
 
   togglePanel(panelId) {
-    const nextPanels = _.assign({}, this.state.panels);
-    const panel = _.find(nextPanels, { id: panelId });
-    panel.isCollapsed = !panel.isCollapsed;
-    this.setState({ panels: nextPanels });
+    const nextPanel = panelId === this.state.currentOpenPanel ? '' : panelId
+    this.setState({ currentOpenPanel: nextPanel })
   }
 
   render() {
+    const panels = _.map(this.props.componentsBySection, panelFactory(this.props.navigateTo, this.state.currentOpenPanel));
     return (<div className="adslot-ui-navigation">
-      <Accordion onPanelClick={this.togglePanel} panels={this.state.panels} />
+      <Accordion onPanelClick={this.togglePanel} panels={panels} />
     </div>);
   }
 }


### PR DESCRIPTION
- [x] Set max width on page so prop types grid and code example don't go beyond 940px
  * Set code block a max width of 940px
  * Set prop-types table a max width of 1100px
  * Set width for each column in prop-types table

- [x] Set sidebar accordion state to only have one open at a time (close all others when you select a new heading)
  * The Navigation component's state only have the name the current open panel instead of the whole panels list

![screen shot 2017-12-05 at 5 30 31 pm](https://user-images.githubusercontent.com/15777593/33593171-3c3ec86c-d9e2-11e7-90c3-f16c81e20cb5.png)
