### PR TITLE
[Docs] Add a search bar component to the DOC

### DIFF
--- a/docs/components/Layout/index.jsx
+++ b/docs/components/Layout/index.jsx
@@ -1,8 +1,11 @@
+import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Header from '../Header';
 import Navigation from '../Navigation';
 import Contributors from '../Contributors';
+import SearchBar from '../SearchBar';
+import SearchResultCard from '../SearchResultCard';
 
 import ButtonExample from '../../examples/ButtonExample';
 import AlertInputExample from '../../examples/AlertInputExample';
@@ -131,16 +134,46 @@ const componentsBySection = {
   ],
 };
 
+const componentIndexForSearch = _.flatMap(componentsBySection);
+
 class PageLayout extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       page: 'buttons',
+      searchTerm: '',
+      searchResults: [],
     };
 
     this.navigateTo = (newPage) => {
       if (newPage !== this.state.page) { this.setState({ page: newPage }); }
       window.location.href = `${window.location.origin}${window.location.pathname}#${newPage}-example`;
+    };
+
+    this.filterComponents = (searchTerm) => {
+      const searchTermRegExp = new RegExp(searchTerm, 'i');
+      return _(componentIndexForSearch)
+        .filter((val) => searchTermRegExp.test(val))
+        .sort()
+        .value();
+    };
+
+    this.handleSearch = (searchTerm) => {
+      if (searchTerm.length === 0) {
+        this.clearSearch();
+      } else {
+        this.setState({
+          searchTerm,
+          searchResults: this.filterComponents(searchTerm),
+        });
+      }
+    };
+
+    this.clearSearch = () => {
+      this.setState({
+        searchTerm: '',
+        searchResults: [],
+      });
     };
   }
 
@@ -150,7 +183,16 @@ class PageLayout extends React.Component {
         <Header />
         <div className="adslot-ui-body">
           <SidebarArea>
-            <Navigation componentsBySection={componentsBySection} navigateTo={this.navigateTo} />
+            <SearchBar onSearch={this.handleSearch} />
+            {
+              (this.state.searchTerm.length > 0 || this.state.searchResults.length > 0)
+                ? (<SearchResultCard
+                  searchResults={this.state.searchResults}
+                  navigateTo={this.navigateTo}
+                  clearSearch={this.clearSearch}
+                />)
+                : <Navigation componentsBySection={componentsBySection} navigateTo={this.navigateTo} />
+            }
           </SidebarArea>
           <ContentArea>
             <PageTitle title="Form Elements" />

--- a/docs/components/SearchBar/index.jsx
+++ b/docs/components/SearchBar/index.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  SearchBar,
+} from '../../../src/dist-entry';
+import './styles.scss';
+
+class SearchBarComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      searchBarString: '',
+    };
+    this.handleStringChange = (searchBarString) => {
+      this.setState({ searchBarString: searchBarString.trim() });
+    };
+  }
+
+  render() {
+    return (
+      <SearchBar
+        additionalClassNames={['adslot-ui-searchbar']}
+        searchString={this.state.searchBarString}
+        searchPlaceholder="Search for component."
+        searchIconHref="./docs/assets/svg-symbols.svg#search"
+        onSearchStringChange={this.handleStringChange}
+        onSearch={() => this.props.onSearch(this.state.searchBarString)}
+      />
+    );
+  }
+}
+
+SearchBarComponent.propTypes = {
+  onSearch: PropTypes.func.isRequired,
+};
+
+export default SearchBarComponent;

--- a/docs/components/SearchBar/styles.scss
+++ b/docs/components/SearchBar/styles.scss
@@ -1,0 +1,5 @@
+@import '~styles/variable';
+
+.adslot-ui-searchbar {
+  margin-bottom: $spacing-etalon;
+}

--- a/docs/components/SearchResultCard/index.jsx
+++ b/docs/components/SearchResultCard/index.jsx
@@ -1,0 +1,53 @@
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card,
+  Button,
+  Empty,
+} from '../../../src/dist-entry';
+import './styles.scss';
+
+const SearchResultCard = ({
+  navigateTo,
+  clearSearch,
+  searchResults,
+}) => (
+  <Card.Container className="search-result-card">
+    <Card.Content key="search-result-card-title">
+      <strong className="title">Results</strong>
+      <Button
+        bsStyle="link"
+        onClick={clearSearch}
+        className="clear-button"
+      >
+        Clear
+      </Button>
+    </Card.Content>
+    {
+      _.map(searchResults, (componentName) => (
+        <Card.Content key={componentName}>
+          <Button
+            bsStyle="link"
+            onClick={() => navigateTo(componentName)}
+          >
+            {_.startCase(componentName)}
+          </Button>
+        </Card.Content>
+      ))
+    }
+    <Empty
+      collection={searchResults}
+      text="No results found."
+      svgSymbol={{ href: './docs/assets/svg-symbols.svg#search' }}
+    />
+  </Card.Container>
+);
+
+SearchResultCard.propTypes = {
+  navigateTo: PropTypes.func.isRequired,
+  clearSearch: PropTypes.func.isRequired,
+  searchResults: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default SearchResultCard;

--- a/docs/components/SearchResultCard/styles.scss
+++ b/docs/components/SearchResultCard/styles.scss
@@ -1,0 +1,31 @@
+@import '~styles/variable';
+
+.search-result-card {
+  width: 240px;
+
+  .card-component-content {
+    padding-top: 0;
+
+    &:first-child {
+      padding: $spacing-etalon;
+      border-bottom: $border-lighter;
+      display: flex;
+    }
+
+    &:nth-child(2) {
+      padding-top: $spacing-etalon;
+    }
+
+    &:nth-last-child(2):not(:first-child) {
+      padding-bottom: $spacing-etalon;
+    }
+
+    .title {
+      flex: 1;
+    }
+
+    .clear-button {
+      padding: 0;
+    }
+  }
+}


### PR DESCRIPTION
# A fixed PR of https://github.com/Adslot/adslot-ui/pull/661

- [x] Add a search bar to the top of the navigation sidebar that shows search results in a search results panel.
  * Add a component search bar for searching component based on component name
  * Add a Card component for holding all search results

### Screenshot:
![screen shot 2017-12-07 at 12 14 47 pm](https://user-images.githubusercontent.com/15777593/33693681-3d5671de-db48-11e7-974b-1c967cda0d1d.png)


### No result:
![screen shot 2017-12-07 at 12 13 09 pm](https://user-images.githubusercontent.com/15777593/33693643-0a497106-db48-11e7-978b-f682f4e6bd25.png)