### PR TITLE
Docs: Add GitHub templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Types of issue
+<!--- What types of issue are we looking at? Put an `x` in all the boxes that apply: -->
+- [ ] Bug (High impact or critical to a production build)
+- [ ] Bug (Low impact or not working as expected)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Something else (idea, build tool, documentation improvement)
+
+## Description
+<!--- Describe your issue in detail -->
+
+## Expected Behaviour and Accepted Behaviour
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+<!--- Consider making a check-list -->
+- [ ] Should …
+- [ ] Should …
+- [ ] Should …
+
+## Current Behaviour
+<!--- If describing a bug, tell us what happens instead of the expected behaviour -->
+<!--- If suggesting a change/improvement, explain the difference from current behaviour -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change. Can you point to similar functionality with any existing libraries or components? -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+1.
+1.
+1.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world, why is it important to you -->
+
+## Screenshots
+<!--- A picture speaks a thousand words. Include one to help us see your problem or understand your request -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- A few sentences describing the overall goals of the pull request's commit. -->
+
+## Motivation and Background Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## Does this PR introduce a breaking change?
+<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->
+
+- [ ] Yes
+- [ ] No
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Check-list:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I have read the [Contributing](CONTRIBUTING.md) document.
+- [ ] I've thought about and labelled my PR/commit message appropriately.
+- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
+- [ ] CI is green (coverage, linting, tests).
+- [ ] I have updated the documentation accordingly.
+- [ ] I've two LGTMs/Approvals.
+- [ ] I've fixed or replied to all my code-review comments.
+- [ ] I've manually tested with a buddy.
+- [ ] I've squashed my commits into one.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add an issue and pull-request template.

A modification on [CYOA Templates](https://www.talater.com/open-source-templates/#/).

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issues and pull-requests require more background context. With multiple projects and developers consuming the library we need a more consistent way of reporting and triaging issues and being able to have context when reviewing pull-requests.

Resolves #663 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code reviews & this PR.

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [x] I've fixed or replied to all my code-review comments.
- [x] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
