### PR TITLE
Fix: dist error

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,7 +4,7 @@ if (process.env.TYPE === 'development') {
   plugins = [...plugins, 'react-hot-loader/babel'];
 }
 
-const presets = process.env.TYPE === 'development' ? [['env', { modules: false }], 'react'] : ['env', 'react'];
+const presets = ['env', 'react'];
 
 module.exports = {
   presets,

--- a/docs/run.jsx
+++ b/docs/run.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
-import App from './components/Layout';
+import Layout from './components/Layout';
 
-const renderApp = () => {
+const renderApp = (App) => {
   ReactDOM.render(
     <AppContainer>
       <App />
@@ -12,8 +12,11 @@ const renderApp = () => {
   );
 };
 
-renderApp();
+renderApp(Layout);
 
 if (module.hot) {
-  module.hot.accept('./components/Layout', renderApp);
+  module.hot.accept('./components/Layout', () => {
+    const NextLayout = require('./components/Layout').default; // eslint-disable-line
+    renderApp(NextLayout);
+  });
 }


### PR DESCRIPTION
change the `env` preset so that it does transpile to commonjs modules. Because `src/dist-entry/index.js` uses `module.exorts` instead of es6 modules.

Ideally, we can utilise babel export extension plugin to fix `src/dist-entry/index.js`, but for now this fix should work

And subsequently need to modify hot-reloader setup.