### PR TITLE
[ADS-645] Remove extra chunk and make moment external

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,7 +4,7 @@ if (process.env.TYPE === 'development') {
   plugins = [...plugins, 'react-hot-loader/babel'];
 }
 
-const presets = ['env', 'react'];
+const presets = process.env.TYPE === 'development' ? [['env', { modules: false }], 'react'] : ['env', 'react'];
 
 module.exports = {
   presets,

--- a/config/dist.js
+++ b/config/dist.js
@@ -8,9 +8,7 @@ module.exports = () => {
   const buildType = process.env.TYPE || 'development';
 
   let entries = {
-    main: resolve(__dirname, '../src/dist-entry'),
-    core: resolve(__dirname, '../src/dist-entry/core'),
-    extra: resolve(__dirname, '../src/dist-entry/extra'),
+    main: resolve(__dirname, '../src'),
     docs: resolve(__dirname, '../docs/run'),
   };
   const plugins = [
@@ -78,6 +76,12 @@ module.exports = () => {
         commonjs2: 'redux',
         commonjs: 'redux',
         amd: 'redux',
+      },
+      moment: {
+        root: 'moment',
+        commonjs2: 'moment',
+        commonjs: 'moment',
+        amd: 'moment',
       },
     },
     output: {

--- a/docs/components/Contributors/index.jsx
+++ b/docs/components/Contributors/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import { Avatar, Spinner, PageTitle } from '../../../src/dist-entry';
+import { Avatar, Spinner, PageTitle } from '../../../src';
 
 import './styles.scss';
 

--- a/docs/components/Example/index.jsx
+++ b/docs/components/Example/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { github } from 'react-syntax-highlighter/dist/styles';
 import NotePanel from '../NotePanel';
-import { Button, Empty } from '../../../src/dist-entry';
+import { Button, Empty } from '../../../src';
 
 import './styles.scss';
 

--- a/docs/components/Header/index.jsx
+++ b/docs/components/Header/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, PageTitle, SvgSymbol } from '../../../src/dist-entry';
+import { Button, PageTitle, SvgSymbol } from '../../../src';
 import './styles.scss';
 
 const HeaderGraphics = () => (

--- a/docs/components/Layout/index.jsx
+++ b/docs/components/Layout/index.jsx
@@ -51,7 +51,7 @@ import SplitPaneExample from '../../examples/SplitPaneExample';
 import HoverDropdownMenuExample from '../../examples/HoverDropdownMenuExample';
 import NavigationExample from '../../examples/NavigationExample';
 
-import { PageTitle } from '../../../src/dist-entry';
+import { PageTitle } from '../../../src';
 
 import './styles.scss';
 import '../../examples/styles.scss';

--- a/docs/components/Navigation/index.jsx
+++ b/docs/components/Navigation/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { Accordion, Button } from '../../../src/dist-entry';
+import { Accordion, Button } from '../../../src';
 import './styles.scss';
 
 const initialOpenPanel = 'form-elements';

--- a/docs/components/NotePanel/index.jsx
+++ b/docs/components/NotePanel/index.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Panel } from '../../../src/dist-entry';
+import { Panel } from '../../../src';
 
 import './styles.scss';
 

--- a/docs/components/SearchBar/index.jsx
+++ b/docs/components/SearchBar/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { SearchBar } from '../../../src/dist-entry';
+import { SearchBar } from '../../../src';
 import './styles.scss';
 
 class SearchBarComponent extends React.Component {

--- a/docs/components/SearchResultCard/index.jsx
+++ b/docs/components/SearchResultCard/index.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, Button, Empty } from '../../../src/dist-entry';
+import { Card, Button, Empty } from '../../../src';
 import './styles.scss';
 
 const SearchResultCard = ({ navigateTo, clearSearch, searchResults }) => (

--- a/docs/examples/AccordionExample.jsx
+++ b/docs/examples/AccordionExample.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import Immutable from 'seamless-immutable';
 import Example from '../components/Example';
-import { Accordion, Checkbox } from '../../src/dist-entry';
+import { Accordion, Checkbox } from '../../src';
 
 const initialState = {
   accordionPanels: [

--- a/docs/examples/AlertExample.jsx
+++ b/docs/examples/AlertExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Alert } from '../../src/dist-entry';
+import { Alert } from '../../src';
 
 class AlertExample extends React.PureComponent {
   render() {

--- a/docs/examples/AlertInputExample.jsx
+++ b/docs/examples/AlertInputExample.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import Example from '../components/Example';
-import { AlertInput } from '../../src/dist-entry';
+import { AlertInput } from '../../src';
 
 const initialState = {
   impressions: null,

--- a/docs/examples/AvatarExample.jsx
+++ b/docs/examples/AvatarExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Avatar } from '../../src/dist-entry';
+import { Avatar } from '../../src';
 
 class AvatarExample extends React.PureComponent {
   render() {

--- a/docs/examples/BorderedWellExample.jsx
+++ b/docs/examples/BorderedWellExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { BorderedWell } from '../../src/dist-entry';
+import { BorderedWell } from '../../src';
 
 class BorderedWellExample extends React.PureComponent {
   render() {

--- a/docs/examples/BreadcrumbExample.jsx
+++ b/docs/examples/BreadcrumbExample.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import Example from '../components/Example';
-import { Button, Breadcrumb } from '../../src/dist-entry';
+import { Button, Breadcrumb } from '../../src';
 
 const initialState = {
   breadcrumbNodes: [

--- a/docs/examples/ButtonExample.jsx
+++ b/docs/examples/ButtonExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Button } from '../../src/dist-entry';
+import { Button } from '../../src';
 
 class ButtonExample extends React.PureComponent {
   constructor(props) {

--- a/docs/examples/CardExample.jsx
+++ b/docs/examples/CardExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Card } from '../../src/dist-entry';
+import { Card } from '../../src';
 
 class CardExample extends React.PureComponent {
   render() {

--- a/docs/examples/CarouselExample.jsx
+++ b/docs/examples/CarouselExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Carousel } from '../../src/dist-entry';
+import { Carousel } from '../../src';
 
 class CarouselExample extends React.PureComponent {
   render() {

--- a/docs/examples/CheckboxExample.jsx
+++ b/docs/examples/CheckboxExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Checkbox } from '../../src/dist-entry';
+import { Checkbox } from '../../src';
 
 class CheckboxExample extends React.PureComponent {
   render() {

--- a/docs/examples/ConfirmModalExample.jsx
+++ b/docs/examples/ConfirmModalExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Button, ConfirmModal } from '../../src/dist-entry';
+import { Button, ConfirmModal } from '../../src';
 
 class ConfirmModalExample extends React.PureComponent {
   constructor() {

--- a/docs/examples/DatePickerExample.jsx
+++ b/docs/examples/DatePickerExample.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import Example from '../components/Example';
-import { DatePicker } from '../../src/dist-entry';
+import { DatePicker } from '../../src';
 
 class DatePickerExample extends React.Component {
   constructor() {

--- a/docs/examples/EmptyExample.jsx
+++ b/docs/examples/EmptyExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Empty } from '../../src/dist-entry';
+import { Empty } from '../../src';
 
 class EmptyExample extends React.PureComponent {
   render() {

--- a/docs/examples/FilePickerExample.jsx
+++ b/docs/examples/FilePickerExample.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import Example from '../components/Example';
-import { FilePicker } from '../../src/dist-entry';
+import { FilePicker } from '../../src';
 
 class FilePickerExample extends React.PureComponent {
   render() {

--- a/docs/examples/FlexibleSpacerExample.jsx
+++ b/docs/examples/FlexibleSpacerExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { FlexibleSpacer } from '../../src/dist-entry';
+import { FlexibleSpacer } from '../../src';
 
 class FlexibleSpacerExample extends React.PureComponent {
   render() {

--- a/docs/examples/GridExample.jsx
+++ b/docs/examples/GridExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Grid, GridCell, GridRow } from '../../src/dist-entry';
+import { Grid, GridCell, GridRow } from '../../src';
 
 const cellClicked = () => console.log('Cell clicked');
 

--- a/docs/examples/HelpIconPopoverExample.jsx
+++ b/docs/examples/HelpIconPopoverExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { HelpIconPopover } from '../../src/dist-entry';
+import { HelpIconPopover } from '../../src';
 
 class HelpIconPopoverExample extends React.PureComponent {
   render() {

--- a/docs/examples/HoverDropdownMenuExample.jsx
+++ b/docs/examples/HoverDropdownMenuExample.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import Example from '../components/Example';
-import { Avatar, HoverDropdownMenu } from '../../src/dist-entry';
+import { Avatar, HoverDropdownMenu } from '../../src';
 
 class HoverDropdownMenuExample extends React.PureComponent {
   render() {

--- a/docs/examples/InformationBoxExample.jsx
+++ b/docs/examples/InformationBoxExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { InformationBox } from '../../src/dist-entry';
+import { InformationBox } from '../../src';
 
 class InformationBoxExample extends React.PureComponent {
   render() {

--- a/docs/examples/ListPickerExample.jsx
+++ b/docs/examples/ListPickerExample.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Checkbox from 'react-icheck/lib/Checkbox';
 import Example from '../components/Example';
-import { ListPicker, Button } from '../../src/dist-entry';
+import { ListPicker, Button } from '../../src';
 
 const teamMember1 = {
   avatar: '//lorempixel.com/35/35/people/7',

--- a/docs/examples/NavigationExample.jsx
+++ b/docs/examples/NavigationExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Nav, NavItem } from '../../src/dist-entry';
+import { Nav, NavItem } from '../../src';
 
 class NavigationExample extends React.PureComponent {
   constructor(props) {

--- a/docs/examples/PageTitleExample.jsx
+++ b/docs/examples/PageTitleExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { PageTitle } from '../../src/dist-entry';
+import { PageTitle } from '../../src';
 
 class PageTitleExample extends React.PureComponent {
   render() {

--- a/docs/examples/PagedGridExample.jsx
+++ b/docs/examples/PagedGridExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { PagedGrid } from '../../src/dist-entry';
+import { PagedGrid } from '../../src';
 
 class PagedGridExample extends React.PureComponent {
   render() {

--- a/docs/examples/PanelExample.jsx
+++ b/docs/examples/PanelExample.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import Example from '../components/Example';
-import { Panel } from '../../src/dist-entry';
+import { Panel } from '../../src';
 
 class PanelExample extends React.Component {
   constructor() {

--- a/docs/examples/PrettyDiffExample.jsx
+++ b/docs/examples/PrettyDiffExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { PrettyDiff } from '../../src/dist-entry';
+import { PrettyDiff } from '../../src';
 
 class PrettyDiffExample extends React.PureComponent {
   render() {

--- a/docs/examples/RadioExample.jsx
+++ b/docs/examples/RadioExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Radio, RadioGroup } from '../../src/dist-entry';
+import { Radio, RadioGroup } from '../../src';
 
 class RadioExample extends React.PureComponent {
   render() {

--- a/docs/examples/SearchBarExample.jsx
+++ b/docs/examples/SearchBarExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { SearchBar } from '../../src/dist-entry';
+import { SearchBar } from '../../src';
 
 class SearchBarExample extends React.Component {
   constructor() {

--- a/docs/examples/SearchExample.jsx
+++ b/docs/examples/SearchExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Search } from '../../src/dist-entry';
+import { Search } from '../../src';
 
 class SearchExample extends React.Component {
   constructor() {

--- a/docs/examples/SelectExample.jsx
+++ b/docs/examples/SelectExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Select } from '../../src/dist-entry';
+import { Select } from '../../src';
 
 class SelectExample extends React.Component {
   constructor() {

--- a/docs/examples/SliceyExample.jsx
+++ b/docs/examples/SliceyExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Slicey } from '../../src/dist-entry';
+import { Slicey } from '../../src';
 
 class SliceyExample extends React.PureComponent {
   render() {

--- a/docs/examples/SpinnerExample.jsx
+++ b/docs/examples/SpinnerExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Spinner } from '../../src/dist-entry';
+import { Spinner } from '../../src';
 
 class SpinnerExample extends React.PureComponent {
   render() {

--- a/docs/examples/SplitPaneExample.jsx
+++ b/docs/examples/SplitPaneExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { SplitPane } from '../../src/dist-entry';
+import { SplitPane } from '../../src';
 
 class SplitPaneExample extends React.PureComponent {
   render() {

--- a/docs/examples/StatisticExample.jsx
+++ b/docs/examples/StatisticExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Statistic } from '../../src/dist-entry';
+import { Statistic } from '../../src';
 
 class StatisticExample extends React.PureComponent {
   render() {

--- a/docs/examples/SvgSymbolCircleExample.jsx
+++ b/docs/examples/SvgSymbolCircleExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { SvgSymbolCircle } from '../../src/dist-entry';
+import { SvgSymbolCircle } from '../../src';
 
 class SvgSymbolCircleExample extends React.PureComponent {
   render() {

--- a/docs/examples/SvgSymbolExample.jsx
+++ b/docs/examples/SvgSymbolExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { SvgSymbol } from '../../src/dist-entry';
+import { SvgSymbol } from '../../src';
 
 class SvgSymbolExample extends React.PureComponent {
   render() {

--- a/docs/examples/TabExample.jsx
+++ b/docs/examples/TabExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Empty, SvgSymbol, FlexibleSpacer, Tabs, Tab } from '../../src/dist-entry';
+import { Empty, SvgSymbol, FlexibleSpacer, Tabs, Tab } from '../../src';
 
 class TabExample extends React.PureComponent {
   render() {

--- a/docs/examples/TagExample.jsx
+++ b/docs/examples/TagExample.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import Example from '../components/Example';
-import { Button, Tag } from '../../src/dist-entry';
+import { Button, Tag } from '../../src';
 
 const initialState = {
   tags: [

--- a/docs/examples/TextEllipsisExample.jsx
+++ b/docs/examples/TextEllipsisExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { TextEllipsis } from '../../src/dist-entry';
+import { TextEllipsis } from '../../src';
 
 const loremIpsum = `
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore

--- a/docs/examples/TextareaExample.jsx
+++ b/docs/examples/TextareaExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Textarea } from '../../src/dist-entry';
+import { Textarea } from '../../src';
 
 class TextareaExample extends React.PureComponent {
   render() {

--- a/docs/examples/TileGridExample.jsx
+++ b/docs/examples/TileGridExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { TileGrid } from '../../src/dist-entry';
+import { TileGrid } from '../../src';
 
 class TileGridExample extends React.PureComponent {
   constructor() {

--- a/docs/examples/TotalsExample.jsx
+++ b/docs/examples/TotalsExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Totals } from '../../src/dist-entry';
+import { Totals } from '../../src';
 
 class TotalsExample extends React.PureComponent {
   render() {

--- a/docs/examples/TreePickerExample.jsx
+++ b/docs/examples/TreePickerExample.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Example from '../components/Example';
 import _ from 'lodash';
-import { TreePickerSimplePure } from '../../src/dist-entry';
+import { TreePickerSimplePure } from '../../src';
 
 class TreePickerExample extends React.Component {
   constructor() {

--- a/docs/examples/UserListPickerExample.jsx
+++ b/docs/examples/UserListPickerExample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { Button, UserListPicker } from '../../src/dist-entry';
+import { Button, UserListPicker } from '../../src';
 
 const avatarColor = () => 'cyan';
 const emptySvgSymbol = {

--- a/docs/examples/template.jsx
+++ b/docs/examples/template.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
-import { xxx } from '../../src/dist-entry';
+import { xxx } from '../../src';
 
 class xxxExample extends React.PureComponent {
   render() {

--- a/docs/run.jsx
+++ b/docs/run.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
-import Layout from './components/Layout';
+import App from './components/Layout';
 
-const renderApp = App => {
+const renderApp = () => {
   ReactDOM.render(
     <AppContainer>
       <App />
@@ -12,11 +12,8 @@ const renderApp = App => {
   );
 };
 
-renderApp(Layout);
+renderApp();
 
 if (module.hot) {
-  module.hot.accept('./components/Layout', () => {
-    const NextLayout = require('./components/Layout').default; // eslint-disable-line
-    renderApp(NextLayout);
-  });
+  module.hot.accept('./components/Layout', renderApp);
 }

--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@
     integrity="sha256-8E6QUcFg1KTnpEU8TFGhpTGHw5fJqB9vCms3OhAYLqw="
     crossorigin="anonymous"
   ></script>
+  <script
+    src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment.min.js"
+    integrity="sha256-ABVkpwb9K9PxubvRrHMkk6wmWcIHUE9eBxNZLXYQ84k="
+    crossorigin="anonymous"
+  ></script>
   <script src="./dist/adslot-ui-main.js"></script>
   <script src="./dist/adslot-ui-docs.js"></script>
 </body>

--- a/scripts/scaffold
+++ b/scripts/scaffold
@@ -15,4 +15,4 @@ cp ./docs/examples/template.jsx ./docs/examples/"${1}Example.jsx"
 sed -i '.bak' "s/xxx/$1/g" docs/examples/"$1"Example.jsx && rm -f docs/examples/"$1"Example.jsx.bak;
 sed -i '.bak' "s/xxx/$1/g" src/components/adslot-ui/"$1"/* && rm -f src/components/adslot-ui/"$1"/*.bak;
 sed -i '.bak' "s/x-x-x/$(sed -e 's/\([A-Z]\)/-\1/g' -e 's/^-//' <<< $1  | tr '[:upper:]' '[:lower:]')/g" src/components/adslot-ui/"$1"/* && rm -f src/components/adslot-ui/"$1"/*.bak;
-echo "✓ Generated '${1}'. Don't forget to add your new component to src/dist-entry/core.js" && exit 0;
+echo "✓ Generated '${1}'. Don't forget to add your new component to src/index.js" && exit 0;

--- a/src/dist-entry/extra.js
+++ b/src/dist-entry/extra.js
@@ -1,4 +1,0 @@
-import 'styles/_react-datepicker-custom.scss';
-import DatePicker from 'react-datepicker/dist/react-datepicker';
-
-export { DatePicker }; // eslint-disable-line import/prefer-default-export

--- a/src/dist-entry/index.js
+++ b/src/dist-entry/index.js
@@ -1,5 +1,0 @@
-// Webpack chunk entry file for distribution
-import _ from 'lodash';
-
-// es6 "import * from" is not used for upsetting coverage because of unknown reason
-module.exports = _.assign(require('./core'), require('./extra'));

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import Radio from 'react-icheck/lib/Radio';
 import RadioGroup from 'react-icheck/lib/RadioGroup';
 import Select from 'react-select';
 
+import DatePicker from 'react-datepicker';
+
 // React Bootstrap
 import { Button } from 'third-party';
 
@@ -20,6 +22,7 @@ import NavItem from 'react-bootstrap/lib/NavItem';
 
 import 'styles/_bootstrap-custom.scss';
 import 'styles/_icheck-custom.scss';
+import 'styles/_react-datepicker-custom.scss';
 import 'styles/_react-select-custom.scss';
 
 import {
@@ -86,6 +89,7 @@ export {
   Checkbox,
   ConfirmModal,
   Dropdown,
+  DatePicker,
   Empty,
   fastStatelessWrapper,
   FilePicker,


### PR DESCRIPTION
## Description
- Remove the extra bundle
- Externalizing `moment`js

## Motivation and Background Context
- Currently, the build generates 3 bundles: "core", "extra" (that contains `react-datepicker`) and "main" that has everything. The splitting was done mainly because `react-datepicker` has `moment`js bundled which we don't use but Symphony does, and `moment`'s size is considerable.
- `direct-web` however has not switched to only import `core`, so `moment` code is duplicated anyway.
## Does this PR introduce a breaking change?
for SYMPHONY in case they don't already have `moment` as a dependency, If they do this saves them 240K as well

- [x] Yes
- [ ] No

## How Has This Been Tested?
<!--- Not regression tested with direct-web -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
