### PR TITLE
Build: Add sudo required and before_script to stabilise chrome headless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
+sudo: required
 language: node_js
 node_js:
 - '6'
 - '8'
 addons:
   chrome: stable
+before_script:
+- sudo chown root /opt/google/chrome/chrome-sandbox
+- sudo chmod 4755 /opt/google/chrome/chrome-sandbox
 after_success:
 - npm run codecov
 notifications:


### PR DESCRIPTION
Add extra parameters to `travis.yml` to resolve flaky chrome headless starts

## Description
Travis started to randomly fail, after some investigation it seems to be related to changes done on the TravisCI side of things in moving builds to a different infrastructure which is causing the builds to fail. https://github.com/travis-ci/travis-ci/issues/9024 https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524

## Motivation and Background Context
Attempt to resolve the issue for now based on comments in the TravisCI issues given above. These workarounds can be relooked at again later to be removed once it has stabilised as it potentially causes a slowdown in build times.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## How Has This Been Tested?
TravisCI builds passes

## Screenshots (if appropriate):

## Check-list:
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
