### PR TITLE
Doc: Adding descriptions and missing props to treepicker example

### DIFF
--- a/docs/examples/TreePickerExample.jsx
+++ b/docs/examples/TreePickerExample.jsx
@@ -95,14 +95,20 @@ const exampleProps = {
 />`,
   propTypes: [
     {
+      propType: 'additionalClassNames',
+      type: 'arrayOf(string)',
+      note: 'Class Names for SplitPane component',
+    },
+    {
       propType: 'breadcrumbNodes',
       type: 'arrayOf { id: string/number, label: string }',
-      note: 'returns node id',
+      note: `returns node id. This prop is not required,
+        but an empty array is not allowed. At least one element is required in the array.`,
     },
     {
       propType: 'breadcrumbOnClick',
       type: 'func',
-      note: 'required. This propType creates a list of breadcrumb node',
+      note: 'This propType creates a list of breadcrumb node',
     },
     {
       propType: 'debounceInterval',
@@ -114,7 +120,7 @@ const exampleProps = {
       propType: 'disabled',
       type: 'bool',
       defaultValue: <pre>false</pre>,
-      note: 'disables treepicker including serach bar',
+      note: 'disables treepicker including search bar',
     },
     {
       propType: 'disableInclude',
@@ -141,13 +147,13 @@ const exampleProps = {
     },
     {
       propType: 'emptyText',
-      type: 'string',
-      note: `displays this text when there will be no item on left Grid`,
+      type: 'node',
+      note: `displays this text when there will be no item on left Grid. Prefer type 'string', but rich text can be used here.`,
     },
     {
       propType: 'emptySelectedListText',
-      type: 'string',
-      note: `displays this text when there will be no item on right Grid(Selected list)`,
+      type: 'node',
+      note: `displays this text when there will be no item on right Grid(Selected list). Prefer type 'string', but rich text can be used here.`,
     },
     {
       propType: 'expandNode',
@@ -186,7 +192,7 @@ const exampleProps = {
     {
       propType: 'itemType',
       type: 'string',
-      defaultValue: <pre>node</pre>,
+      defaultValue: <pre>'node'</pre>,
       note: 'uses for specific className',
     },
     {
@@ -206,7 +212,12 @@ const exampleProps = {
     {
       propType: 'onChange',
       type: 'func',
-      note: 'triggers search input onchange',
+      note: 'onChange function triggers, when search input changes',
+    },
+    {
+      propType: 'onClear',
+      type: 'func',
+      note: 'onClear function triggers, when the user clicks the clear button on search input',
     },
     {
       propType: 'onSearch',
@@ -217,13 +228,13 @@ const exampleProps = {
       propType: 'searchOnChange',
       type: 'bool',
       defaultValue: <pre>true</pre>,
-      note: 'Serach for item on onChange trigger when the value is true',
+      note: 'When true, search is triggered as soon as the user types in the search field',
     },
     {
       propType: 'searchOnEnterKey',
       type: 'bool',
       defaultValue: <pre>false</pre>,
-      note: 'Serach for item on Enter key trigger when the value is true',
+      note: 'When true, triggers search when the user presses the Enter key',
     },
     {
       propType: 'searchPlaceholder',
@@ -241,7 +252,8 @@ const exampleProps = {
     {
       propType: 'subtree',
       type: 'arrayOf Treepicker Nodes',
-      note: 'required. A list of available unselected nodes',
+      note: `A list of available unselected nodes. This prop is not required,
+        but an empty array is not allowed. At least one element is required in the array.`,
     },
     {
       propType: 'svgSymbolCancel',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding missing props to treepicker example

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Adding missing props to treepicker example
And adding descriptions to those props
The mismatch proptypes are related to this issue https://github.com/Adslot/adslot-ui/issues/689

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![screen shot 2018-02-09 at 2 35 15 pm](https://user-images.githubusercontent.com/15777593/36010630-8d10ec1e-0da6-11e8-803c-6c115944c3e8.png)

![screen shot 2018-02-09 at 2 35 28 pm](https://user-images.githubusercontent.com/15777593/36010633-928e85de-0da6-11e8-9d29-4bde9462eb9d.png)

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [x] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
