### PR TITLE
Update: Allow treepicker to accept both path or ancestor as props

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -29,18 +29,6 @@ module.exports = merge(commonConfig, {
   module: {
     rules: [
       {
-        test: /\.(js|jsx)$/,
-        loader: 'babel-loader',
-        include: resolve(__dirname, '../docs'),
-        exclude: /node_modules/,
-        options: {
-          // This is a feature of `babel-loader` for webpack (not Babel itself). It enables caching results
-          // in ./node_modules/.cache/babel-loader/ directory for faster rebuilds.
-          cacheDirectory: true,
-        },
-      },
-
-      {
         test: /\.(jpe?g|png|gif|svg)$/i,
         loaders: [
           'file-loader?hash=sha512&digest=hex&name=[hash].[ext]',

--- a/src/components/adslot-ui/TreePicker/Node/index.jsx
+++ b/src/components/adslot-ui/TreePicker/Node/index.jsx
@@ -28,6 +28,10 @@ const pathPrefix = ({ type }) => (_.isEmpty(type) ? '' : `${type} in `);
 
 class TreePickerNodeComponent extends React.Component {
   constructor(props) {
+    if (_.isUndefined(props.node.path) && _.isUndefined(props.node.ancestors)) {
+      throw new Error(`AdslotUi TreePickerNode needs property 'path' or property 'ancestors' for ${props.node}`);
+    }
+
     super(props);
 
     this.state = {

--- a/src/components/adslot-ui/TreePicker/Node/index.spec.jsx
+++ b/src/components/adslot-ui/TreePicker/Node/index.spec.jsx
@@ -372,4 +372,11 @@ describe('TreePickerNodeComponent', () => {
     expect(stringIdNode.find(GridRow).prop('dts')).to.equal('example-item-type-au-act-cbr');
     expect(numberIdNode.find(GridRow).prop('dts')).to.equal('example-item-type-4');
   });
+
+  it('should throw error message when props does not contain `path` or `ancestors`', () => {
+    const nodeWithoutPathAndAncestors = _.omit(cbrNode, ['path', 'ancestors']);
+    expect(() => {
+      shallow(<TreePickerNode itemType={itemType} node={nodeWithoutPathAndAncestors} />);
+    }).to.throw(`AdslotUi TreePickerNode needs property 'path' or property 'ancestors'`);
+  });
 });

--- a/src/components/prop-types/TreePickerPropTypes.js
+++ b/src/components/prop-types/TreePickerPropTypes.js
@@ -2,30 +2,30 @@ import PropTypes from 'prop-types';
 import SvgSymbol from 'alexandria/SvgSymbol';
 import idPropType from './idPropType';
 
+const baseNodeProps = {
+  id: idPropType.isRequired,
+  label: PropTypes.string.isRequired,
+};
+
+const mergeNodeProps = addedProps => Object.assign({}, baseNodeProps, addedProps);
+
 export default {
-  node: PropTypes.shape({
-    id: idPropType.isRequired,
-    isExpandable: PropTypes.bool,
-    label: PropTypes.string.isRequired,
-    path: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: idPropType.isRequired,
-        label: PropTypes.string.isRequired,
-      }).isRequired
-    ).isRequired,
-    type: PropTypes.string.isRequired,
-    value: PropTypes.number,
-  }),
-  breadCrumbNode: PropTypes.shape({
-    id: idPropType.isRequired,
-    label: PropTypes.string.isRequired,
-  }),
-  rootType: PropTypes.shape({
-    emptySvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
-    svgSymbol: PropTypes.shape(SvgSymbol.propTypes),
-    hidden: PropTypes.bool,
-    id: idPropType.isRequired,
-    isRequired: PropTypes.bool.isRequired,
-    label: PropTypes.string.isRequired,
-  }),
+  node: PropTypes.shape(
+    mergeNodeProps({
+      isExpandable: PropTypes.bool,
+      path: PropTypes.arrayOf(PropTypes.shape(baseNodeProps).isRequired),
+      ancestors: PropTypes.arrayOf(PropTypes.shape(baseNodeProps).isRequired),
+      type: PropTypes.string.isRequired,
+      value: PropTypes.number,
+    })
+  ),
+  breadCrumbNode: PropTypes.shape(baseNodeProps),
+  rootType: PropTypes.shape(
+    mergeNodeProps({
+      emptySvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+      svgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+      hidden: PropTypes.bool,
+      isRequired: PropTypes.bool.isRequired,
+    })
+  ),
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow treePickerNode component using either `path` or `ancestors` to identify its path.

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
1. Add new prop type `ancestors` to treePickerNode component
2. Set both `path` and `ancestors` to be not required
3. Add error message to treePickerNode component, if neither `path` nor `ancestors` are provided.

No need to update the docs at this moment, in the following PR will add examples for treePickerNode component, and add document in that PR

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adding `ancestors` props in order to solve real case problem such as legacy naming as `ancestors`. 

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Passing a node to treePickerNode component, and this node does not contain `path` or `ancestors`
2. The component will throw an error message.

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly. 
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [x] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
