### PR TITLE
Docs: Split propTypes to an isolated component

### DIFF
--- a/docs/components/Example/index.jsx
+++ b/docs/components/Example/index.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SyntaxHighlighter, { prism } from 'react-syntax-highlighter/prism';
 import NotePanel from '../NotePanel';
-import { Button, Empty } from '../../../src';
+import PropTypeTable from '../PropTypeTable';
+import { Button } from '../../../src';
 
 import './styles.scss';
 
@@ -30,38 +31,8 @@ class Example extends React.PureComponent {
           </SyntaxHighlighter>
         </div>
 
-        <h3>PropTypes</h3>
-        <div className="adslot-ui-proptype-table">
-          <table className="table table-striped table-bordered">
-            <thead>
-              <tr>
-                <th>PropType</th>
-                <th>Type</th>
-                <th>Default Value</th>
-                <th>Notes</th>
-              </tr>
-            </thead>
-            <tbody>
-              {_.map(propTypes, ({ propType, type, defaultValue, note }) => (
-                <tr key={propType}>
-                  <td>
-                    <pre>{propType}</pre>
-                  </td>
-                  <td>
-                    <pre>{type}</pre>
-                  </td>
-                  <td>{defaultValue}</td>
-                  <td>{note}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          <Empty
-            collection={propTypes}
-            hideIcon
-            text="No PropType definitions for this component, please check the source-code."
-          />
-        </div>
+        <PropTypeTable propTypes={propTypes} />
+
         <Button bsStyle="link" href="#top">
           ↑ Back to top.
         </Button>
@@ -76,14 +47,7 @@ Example.propTypes = {
   notes: PropTypes.node,
   designNotes: PropTypes.node,
   exampleCodeSnippet: PropTypes.string.isRequired,
-  propTypes: PropTypes.arrayOf(
-    PropTypes.shape({
-      propType: PropTypes.string.isRequired,
-      type: PropTypes.node.isRequired,
-      defaultValue: PropTypes.node,
-      note: PropTypes.node,
-    })
-  ).isRequired,
+  propTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 export default Example;

--- a/docs/components/Example/styles.scss
+++ b/docs/components/Example/styles.scss
@@ -8,8 +8,7 @@
     max-width: 940px;
   }
 
-  .adslot-ui-code-snippet,
-  .adslot-ui-proptype-table {
+  .adslot-ui-code-snippet {
     max-width: 1100px;
   }
 
@@ -21,45 +20,5 @@
   h3 {
     margin-bottom: 18px;
     font-size: $font-size-subheader;
-  }
-
-  table {
-
-    + .empty-component {
-      padding: 0;
-    }
-
-    tr {
-      td {
-
-        &:empty {
-          &::before {
-            content: '—';
-          }
-        }
-
-        &:nth-child(1) {
-          width: 10%;
-        }
-
-        &:nth-child(2) {
-          width: 15%;
-        }
-
-        &:nth-child(3) {
-          width: 25%;
-        }
-
-        &:nth-child(4) {
-          width: 50%;
-        }
-
-        pre {
-          white-space: pre-wrap;
-        }
-
-      }
-    }
-
   }
 }

--- a/docs/components/PropTypeTable/index.jsx
+++ b/docs/components/PropTypeTable/index.jsx
@@ -1,0 +1,62 @@
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Empty } from '../../../src';
+
+import './styles.scss';
+
+class PropTypeTable extends React.PureComponent {
+  render() {
+    const { propTypes } = this.props;
+
+    return (
+      <div>
+        <h3>PropTypes</h3>
+        <div className="adslot-ui-proptype-table">
+          <table className="table table-striped table-bordered">
+            <thead>
+              <tr>
+                <th className="col-prop-type">PropType</th>
+                <th className="col-type">Type</th>
+                <th className="col-default-value">Default Value</th>
+                <th className="col-notes">Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {_.map(propTypes, ({ propType, type, defaultValue, note }) => (
+                <tr key={propType}>
+                  <td>
+                    <pre>{propType}</pre>
+                  </td>
+                  <td>
+                    <pre>{type}</pre>
+                  </td>
+                  <td>{defaultValue}</td>
+                  <td>{note}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <Empty
+            collection={propTypes}
+            hideIcon
+            text="No PropType definitions for this component, please check the source-code."
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+PropTypeTable.propTypes = {
+  propTypes: PropTypes.arrayOf(
+    PropTypes.shape({
+      propType: PropTypes.string.isRequired,
+      type: PropTypes.node.isRequired,
+      defaultValue: PropTypes.node,
+      note: PropTypes.node,
+    })
+  ).isRequired,
+};
+
+export default PropTypeTable;

--- a/docs/components/PropTypeTable/styles.scss
+++ b/docs/components/PropTypeTable/styles.scss
@@ -1,0 +1,47 @@
+@import '~styles/variable';
+
+.adslot-ui-proptype-table {
+  max-width: 1100px;
+
+  table {
+
+    + .empty-component {
+      padding: 0;
+    }
+
+    tr {
+      th {
+        &.col-prop-type {
+          width: 10%;
+        }
+
+        &.col-type {
+          width: 15%;
+        }
+
+        &.col-default-value {
+          width: 25%;
+        }
+
+        &.col-notes {
+          width: 50%;
+        }
+      }
+
+      td {
+
+        &:empty {
+          &::before {
+            content: '—';
+          }
+        }
+
+        pre {
+          white-space: pre-wrap;
+        }
+
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Create a new component for proptype table.

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Move proptype table to a separate component for reuse purpose.

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The PR is will update the document, then proptype table component can be reusable. 
After this, in the following PRs, will be able to add multiple proptype tables to one component example.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Not need.

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [x] I've fixed or replied to all my code-review comments.
- [x] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
