### PR TITLE
Update: Allow custom class to grid cell component

### DIFF
--- a/docs/examples/GridExample.jsx
+++ b/docs/examples/GridExample.jsx
@@ -23,6 +23,14 @@ class GridExample extends React.PureComponent {
           <GridCell>Content</GridCell>
           <GridCell onClick={cellClicked}>This Cell logs clicks.</GridCell>
         </GridRow>
+        <GridRow>
+          <GridCell addonClassNames={['full-width']}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus finibus suscipit velit quis tempor. Nunc
+            non lorem viverra, tincidunt dui ut, dictum enim. Nam quis ligula ac mi egestas scelerisque. Phasellus
+            posuere tellus quis nisl vulputate efficitur. Nulla laoreet ut ex vitae pharetra. Vivamus felis eros,
+            finibus fringilla turpis ut, convallis maximus mi.
+          </GridCell>
+        </GridRow>
       </Grid>
     );
   }
@@ -30,23 +38,32 @@ class GridExample extends React.PureComponent {
 
 const exampleProps = {
   componentName: 'Grid',
-  exampleCodeSnippet: `<Grid>
-  <GridRow type="header">
-    <GridCell>Header</GridCell>
-    <GridCell>Header</GridCell>
-    <GridCell>Header</GridCell>
-  </GridRow>
-  <GridRow verticalCellBorder>
-    <GridCell stretch>Content</GridCell>
-    <GridCell>Content</GridCell>
-    <GridCell>Content</GridCell>
-  </GridRow>
-  <GridRow>
-    <GridCell>Content</GridCell>
-    <GridCell>Content</GridCell>
-    <GridCell onClick={cellClicked}>This Cell logs clicks.</GridCell>
-  </GridRow>
-</Grid>`,
+  exampleCodeSnippet: `
+  <Grid>
+    <GridRow type="header">
+      <GridCell>Header</GridCell>
+      <GridCell>Header</GridCell>
+      <GridCell>Header</GridCell>
+    </GridRow>
+    <GridRow verticalCellBorder>
+      <GridCell stretch>Content</GridCell>
+      <GridCell>Content</GridCell>
+      <GridCell>Content</GridCell>
+    </GridRow>
+    <GridRow>
+      <GridCell>Content</GridCell>
+      <GridCell>Content</GridCell>
+      <GridCell onClick={cellClicked}>This Cell logs clicks.</GridCell>
+    </GridRow>
+    <GridRow>
+      <GridCell addonClassNames={['full-width']}> //full-width { width: 100%; }
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus finibus suscipit velit quis tempor. Nunc
+      non lorem viverra, tincidunt dui ut, dictum enim. Nam quis ligula ac mi egestas scelerisque. Phasellus
+      posuere tellus quis nisl vulputate efficitur. Nulla laoreet ut ex vitae pharetra. Vivamus felis eros,
+      finibus fringilla turpis ut, convallis maximus mi.
+      </GridCell>
+    </GridRow>
+  </Grid>`,
   propTypes: [
     {
       propType: 'children',

--- a/docs/examples/styles.scss
+++ b/docs/examples/styles.scss
@@ -63,3 +63,7 @@
     }
   }
 }
+
+.full-width {
+  width: 100%;
+}

--- a/src/components/alexandria/Grid/Cell/index.jsx
+++ b/src/components/alexandria/Grid/Cell/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { expandDts, classSuffixHelper } from 'lib/utils';
 import './styles.scss';
 
-const GridCell = ({ children, classSuffixes, onClick, stretch, dts }) => {
+const GridCell = ({ children, classSuffixes, onClick, stretch, dts, addonClassNames }) => {
   const componentClass = 'grid-component-cell';
   const classesList = classSuffixHelper({
     classSuffixes,
@@ -13,10 +13,12 @@ const GridCell = ({ children, classSuffixes, onClick, stretch, dts }) => {
     },
     componentClass,
   });
+  const baseClassNames = `${componentClass}${classesList}`;
+  const className = addonClassNames ? [baseClassNames, ...addonClassNames].join(' ') : baseClassNames;
   const extraProps = onClick ? { onClick } : {};
 
   return (
-    <div className={`${componentClass}${classesList}`} {...extraProps} {...expandDts(dts)}>
+    <div className={className} {...extraProps} {...expandDts(dts)}>
       {children}
     </div>
   );
@@ -25,11 +27,12 @@ const GridCell = ({ children, classSuffixes, onClick, stretch, dts }) => {
 GridCell.displayName = 'AlexandriaGridCellComponent';
 
 GridCell.propTypes = {
+  addonClassNames: PropTypes.arrayOf(PropTypes.string),
   children: PropTypes.node,
   classSuffixes: PropTypes.arrayOf(PropTypes.string),
+  dts: PropTypes.string,
   onClick: PropTypes.func,
   stretch: PropTypes.bool,
-  dts: PropTypes.string,
 };
 
 GridCell.defaultProps = {

--- a/src/components/alexandria/Grid/Cell/index.spec.jsx
+++ b/src/components/alexandria/Grid/Cell/index.spec.jsx
@@ -59,4 +59,9 @@ describe('GridCell', () => {
     const component = shallow(<GridCell dts="this-has-data-test-selector" />);
     expect(component.prop('data-test-selector')).to.equal('this-has-data-test-selector');
   });
+
+  it('should add custom classes when passed addonClassNames', () => {
+    const component = shallow(<GridCell addonClassNames={['addonClass1', 'addonClass2']} />);
+    expect(component.prop('className')).to.equal('grid-component-cell addonClass1 addonClass2');
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
- Add `addonClasses` prop to grid cell component
- Added one example using custom class to doc
- Added test of using custom class

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the real case, when using `GridCell` component for a large paragraph or long text. The text will go out of the border. So adding a custom class like `width: 100%` will solve this problem. 

Moreover, providing custom class will allow customization for this component.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Loading `GridCell` component and passing an array of class names
2. After render, those class names will be added on to the component.

## Screenshots (if appropriate):
![screen shot 2018-02-20 at 11 51 47 am](https://user-images.githubusercontent.com/15777593/36402697-7883be20-1634-11e8-8448-aceee09a3d6e.png)

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [ ] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [x] I've fixed or replied to all my code-review comments.
- [x] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
