### PR TITLE
Fix: React-Bootstrap Breaking Change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2103,12 +2103,6 @@
         "type-detect": "4.0.5"
       }
     },
-    "chain-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
-      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w=",
-      "dev": true
-    },
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
@@ -13283,9 +13277,9 @@
       }
     },
     "react-bootstrap": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.32.1.tgz",
-      "integrity": "sha512-RbfzKUbsukWsToWqGHfCCyMFq9QQI0TznutdyxyJw6dih2NvIne25Mrssg8LZsprqtPpyQi8bN0L0Fx3fUsL8Q==",
+      "version": "0.31.5",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.31.5.tgz",
+      "integrity": "sha512-xgDihgX4QvYHmHzL87faDBMDnGfYyqcrqV0TEbWY+JizePOG1vfb8M3xJN+6MJ3kUYqDtQSZ7v/Q6Y5YDrkMdA==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
@@ -13295,9 +13289,7 @@
         "keycode": "2.1.9",
         "prop-types": "15.6.0",
         "prop-types-extra": "1.0.1",
-        "react-overlays": "0.8.3",
-        "react-prop-types": "0.4.0",
-        "react-transition-group": "2.2.1",
+        "react-overlays": "0.7.4",
         "uncontrollable": "4.1.0",
         "warning": "3.0.0"
       }
@@ -13381,16 +13373,15 @@
       "dev": true
     },
     "react-overlays": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.8.3.tgz",
-      "integrity": "sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.7.4.tgz",
+      "integrity": "sha512-7vsooMx3siLAuEfTs8FYeP/lAORWWFXTO8PON3KgX0Htq1Oa+po6ioSjGyO0/GO5CVSMNhpWt6V2opeexHgBuQ==",
       "dev": true,
       "requires": {
         "classnames": "2.2.5",
         "dom-helpers": "3.3.1",
         "prop-types": "15.6.0",
         "prop-types-extra": "1.0.1",
-        "react-transition-group": "2.2.1",
         "warning": "3.0.0"
       }
     },
@@ -13402,15 +13393,6 @@
       "requires": {
         "popper.js": "1.12.9",
         "prop-types": "15.6.0"
-      }
-    },
-    "react-prop-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
-      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
-      "dev": true,
-      "requires": {
-        "warning": "3.0.0"
       }
     },
     "react-proxy": {
@@ -13481,20 +13463,6 @@
         "fbjs": "0.8.16",
         "object-assign": "4.1.1",
         "prop-types": "15.6.0"
-      }
-    },
-    "react-transition-group": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
-      "integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
-      "dev": true,
-      "requires": {
-        "chain-function": "1.0.0",
-        "classnames": "2.2.5",
-        "dom-helpers": "3.3.1",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0",
-        "warning": "3.0.0"
       }
     },
     "react-tween-state": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "prettier": "^1.10.2",
     "prettier-check": "^2.0.0",
     "prop-types": "^15.6.0",
-    "react-bootstrap": "^0.32.1",
+    "react-bootstrap": "^0.31.5",
     "react-datepicker": "^1.1.0",
     "react-hot-loader": "^3.1.3",
     "react-icheck": "git://github.com/omgaz/react-icheck.git#issue-45-patch-for-react-16-release",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Fixes a breaking change from react bootstrap

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
react-bootstrap does not follow semver, upgrading from 0.31 to 0.32
introduced breaking changes in our code-base, most notably the
pagination component which has removed all business logic and
separated into `<Pagination>`/`<Pagination.Item>` components. I have
created issue #697

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
