### PR TITLE
Doc: Allow multiple propType tables in one example

### DIFF
--- a/docs/components/Example/index.jsx
+++ b/docs/components/Example/index.jsx
@@ -10,7 +10,7 @@ import './styles.scss';
 
 class Example extends React.PureComponent {
   render() {
-    const { children, componentName, notes, exampleCodeSnippet, propTypes, designNotes } = this.props;
+    const { children, componentName, notes, exampleCodeSnippet, propTypeSectionArray, designNotes } = this.props;
 
     return (
       <div
@@ -30,8 +30,8 @@ class Example extends React.PureComponent {
             {exampleCodeSnippet}
           </SyntaxHighlighter>
         </div>
-
-        <PropTypeTable propTypes={propTypes} />
+        {_.map(propTypeSectionArray, section => <PropTypeTable propTypes={section.propTypes} label={section.label} />)}
+        {_.isEmpty(propTypeSectionArray) ? <PropTypeTable isEmptyTable /> : null}
 
         <Button bsStyle="link" href="#top">
           ↑ Back to top.
@@ -47,7 +47,7 @@ Example.propTypes = {
   notes: PropTypes.node,
   designNotes: PropTypes.node,
   exampleCodeSnippet: PropTypes.string.isRequired,
-  propTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  propTypeSectionArray: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 export default Example;

--- a/docs/components/PropTypeTable/index.jsx
+++ b/docs/components/PropTypeTable/index.jsx
@@ -7,42 +7,41 @@ import './styles.scss';
 
 class PropTypeTable extends React.PureComponent {
   render() {
-    const { propTypes } = this.props;
+    const { propTypes, label, isEmptyTable } = this.props;
+    const tableTitle = label ? `PropTypes — ${label}` : 'PropTypes';
 
     return (
-      <div>
-        <h3>PropTypes</h3>
-        <div className="adslot-ui-proptype-table">
-          <table className="table table-striped table-bordered">
-            <thead>
-              <tr>
-                <th className="col-prop-type">PropType</th>
-                <th className="col-type">Type</th>
-                <th className="col-default-value">Default Value</th>
-                <th className="col-notes">Notes</th>
+      <div className="adslot-ui-proptype-table">
+        <h3>{tableTitle}</h3>
+        <table className="table table-striped table-bordered">
+          <thead>
+            <tr>
+              <th className="col-prop-type">PropType</th>
+              <th className="col-type">Type</th>
+              <th className="col-default-value">Default Value</th>
+              <th className="col-notes">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {_.map(propTypes, ({ propType, type, defaultValue, note }) => (
+              <tr key={propType}>
+                <td>
+                  <pre>{propType}</pre>
+                </td>
+                <td>
+                  <pre>{type}</pre>
+                </td>
+                <td>
+                  <pre>{defaultValue}</pre>
+                </td>
+                <td>{note}</td>
               </tr>
-            </thead>
-            <tbody>
-              {_.map(propTypes, ({ propType, type, defaultValue, note }) => (
-                <tr key={propType}>
-                  <td>
-                    <pre>{propType}</pre>
-                  </td>
-                  <td>
-                    <pre>{type}</pre>
-                  </td>
-                  <td>{defaultValue}</td>
-                  <td>{note}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          <Empty
-            collection={propTypes}
-            hideIcon
-            text="No PropType definitions for this component, please check the source-code."
-          />
-        </div>
+            ))}
+          </tbody>
+        </table>
+        {isEmptyTable ? (
+          <Empty hideIcon text="No PropType definitions for this component, please check the source-code." />
+        ) : null}
       </div>
     );
   }
@@ -57,6 +56,12 @@ PropTypeTable.propTypes = {
       note: PropTypes.node,
     })
   ).isRequired,
+  label: PropTypes.string,
+  isEmptyTable: PropTypes.bool,
+};
+
+PropTypeTable.defaultProps = {
+  isEmptyTable: false,
 };
 
 export default PropTypeTable;

--- a/docs/components/PropTypeTable/styles.scss
+++ b/docs/components/PropTypeTable/styles.scss
@@ -3,6 +3,10 @@
 .adslot-ui-proptype-table {
   max-width: 1100px;
 
+  & + & {
+    margin-top: $spacing-etalon;
+  }
+
   table {
 
     + .empty-component {

--- a/docs/examples/AccordionExample.jsx
+++ b/docs/examples/AccordionExample.jsx
@@ -74,23 +74,27 @@ const exampleProps = {
     </p>
   ),
   exampleCodeSnippet: '<Accordion panels={accordionPanels} onPanelClick={this.toggleAccordionPanel} />',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'dts',
-      type: 'string',
-      note: 'render `data-test-selector` onto the component. It can be useful for testing.',
-    },
-    {
-      propType: 'panels',
-      type: (
-        <span>
-          arrayOf <a href="#panel-example">Panels</a>
-        </span>
-      ),
-    },
-    {
-      propType: 'onPanelClick',
-      type: 'func',
+      propTypes: [
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+        {
+          propType: 'panels',
+          type: (
+            <span>
+              arrayOf <a href="#panel-example">Panels</a>
+            </span>
+          ),
+        },
+        {
+          propType: 'onPanelClick',
+          type: 'func',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/AlertExample.jsx
+++ b/docs/examples/AlertExample.jsx
@@ -32,19 +32,23 @@ const exampleProps = {
     </div>
   ),
   exampleCodeSnippet: '<Alert type="danger">Unable to save. We can\'t talk to the API, try again in a bit.</Alert>',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'type',
-      type: "oneOf: 'danger', 'warning', 'error', 'success'",
-    },
-    {
-      propType: 'children',
-      type: 'node',
-    },
-    {
-      propType: 'dts',
-      type: 'string',
-      note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+      propTypes: [
+        {
+          propType: 'type',
+          type: "oneOf: 'success', 'info', 'warning', 'danger'",
+        },
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/AlertInputExample.jsx
+++ b/docs/examples/AlertInputExample.jsx
@@ -83,63 +83,67 @@ const exampleProps = {
       onValueChange={(event) => this.changeValue(event.target.value)}
     />
   `,
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'defaultValue',
-      type: 'string',
-    },
-    {
-      propType: 'value',
-      type: 'string|number',
-    },
-    {
-      propType: 'type',
-      type: "oneOf: 'text', 'number'",
-      defaultValue: 'text',
-    },
-    {
-      propType: 'min',
-      type: 'number',
-    },
-    {
-      propType: 'placeholder',
-      type: 'string',
-    },
-    {
-      propType: 'prefixAddon',
-      type: 'node',
-    },
-    {
-      propType: 'suffixAddon',
-      type: 'node',
-    },
-    {
-      propType: 'alertStatus',
-      type: "oneOf: 'success', 'info', 'warning', 'error'",
-      defaultValue: 'success',
-      note: (
-        <span>
-          As <pre>success</pre> is assumed, and help is always displayed independently, the accepted pattern is to only
-          use <pre>warning</pre> and <pre>error</pre> feedback states with this component. Otherwise leave type
-          undefined for <pre>success</pre>.
-        </span>
-      ),
-    },
-    {
-      propType: 'alertMessage',
-      type: 'string',
-    },
-    {
-      propType: 'onValueChange',
-      type: 'func',
-    },
-    {
-      propType: 'onBlur',
-      type: 'func',
-    },
-    {
-      propType: 'onFocus',
-      type: 'func',
+      propTypes: [
+        {
+          propType: 'defaultValue',
+          type: 'string',
+        },
+        {
+          propType: 'value',
+          type: 'string|number',
+        },
+        {
+          propType: 'type',
+          type: "oneOf: 'text', 'number'",
+          defaultValue: 'text',
+        },
+        {
+          propType: 'min',
+          type: 'number',
+        },
+        {
+          propType: 'placeholder',
+          type: 'string',
+        },
+        {
+          propType: 'prefixAddon',
+          type: 'node',
+        },
+        {
+          propType: 'suffixAddon',
+          type: 'node',
+        },
+        {
+          propType: 'alertStatus',
+          type: "oneOf: 'success', 'info', 'warning', 'error'",
+          defaultValue: 'success',
+          note: (
+            <span>
+              As <pre>success</pre> is assumed, and help is always displayed independently, the accepted pattern is to
+              only use <pre>warning</pre> and <pre>error</pre> feedback states with this component. Otherwise leave type
+              undefined for <pre>success</pre>.
+            </span>
+          ),
+        },
+        {
+          propType: 'alertMessage',
+          type: 'string',
+        },
+        {
+          propType: 'onValueChange',
+          type: 'func',
+        },
+        {
+          propType: 'onBlur',
+          type: 'func',
+        },
+        {
+          propType: 'onFocus',
+          type: 'func',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/AvatarExample.jsx
+++ b/docs/examples/AvatarExample.jsx
@@ -22,27 +22,31 @@ const exampleProps = {
     </div>
   ),
   exampleCodeSnippet: '<Avatar givenName="John" surname="Smith" />',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'color',
-      type: 'string',
-    },
-    {
-      propType: 'givenName',
-      type: 'string',
-    },
-    {
-      propType: 'tooltip',
-      type: 'string',
-    },
-    {
-      propType: 'surname',
-      type: 'string',
-    },
-    {
-      propType: 'image',
-      type: 'string',
-      note: 'URL to image source (e.g. Gravatar).',
+      propTypes: [
+        {
+          propType: 'color',
+          type: 'string',
+        },
+        {
+          propType: 'givenName',
+          type: 'string',
+        },
+        {
+          propType: 'tooltip',
+          type: 'string',
+        },
+        {
+          propType: 'surname',
+          type: 'string',
+        },
+        {
+          propType: 'image',
+          type: 'string',
+          note: 'URL to image source (e.g. Gravatar).',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/BorderedWellExample.jsx
+++ b/docs/examples/BorderedWellExample.jsx
@@ -11,10 +11,14 @@ class BorderedWellExample extends React.PureComponent {
 const exampleProps = {
   componentName: 'BorderedWell',
   exampleCodeSnippet: '<BorderedWell>Content body.</BorderedWell>',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'children',
-      type: 'node',
+      propTypes: [
+        {
+          propType: 'children',
+          type: 'node',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/BreadcrumbExample.jsx
+++ b/docs/examples/BreadcrumbExample.jsx
@@ -65,20 +65,24 @@ const exampleProps = {
       onClick={this.onClickHandler}
     />
   `,
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'nodes',
-      type: 'arrayOf { string: id, string: label }',
-    },
-    {
-      propType: 'onClick',
-      type: 'func',
-      note: 'onClick(nodeId)',
-    },
-    {
-      propType: 'disabled',
-      type: 'bool',
-      defaultValue: 'false',
+      propTypes: [
+        {
+          propType: 'nodes',
+          type: 'arrayOf { string: id, string: label }',
+        },
+        {
+          propType: 'onClick',
+          type: 'func',
+          note: 'onClick(nodeId)',
+        },
+        {
+          propType: 'disabled',
+          type: 'bool',
+          defaultValue: 'false',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/ButtonExample.jsx
+++ b/docs/examples/ButtonExample.jsx
@@ -76,48 +76,53 @@ export const exampleProps = {
       Apply
     </Button>
   </div>`,
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'bsStyle',
-      type: 'string, oneOf primary, link, and default.',
-      defaultValue: 'default',
-      note: (
-        <span>
-          <br />It&apos;s uncommon to use <pre>success</pre>, <pre>info</pre>, <pre>warning</pre>, or <pre>danger</pre>
-          which are supported by Bootstrap but not us.
-        </span>
-      ),
-    },
-    {
-      propType: 'inverse',
-      type: 'bool',
-      note: 'Renders an inverse button. Can be used with bsStyle to create primary inverse buttons.',
-      defaultValue: 'false',
-    },
-    {
-      propType: 'reason',
-      type: 'string',
-      note: 'Used in tandem with the disabled prop to present a popover explaining why the button is disabled.',
-    },
-    {
-      propType: 'onClick',
-      type: 'func',
-      note: 'onClick(event)',
-    },
-    {
-      propType: 'bsSize',
-      type: 'string',
-      note: (
-        <span>
-          We rarely use <pre>large</pre>, and should not use <pre>small</pre>.
-        </span>
-      ),
-    },
-    {
-      propType: 'isLoading',
-      type: 'bool',
-      defaultValue: 'false',
-      note: 'set this to true to display Spinner and disable the button',
+      propTypes: [
+        {
+          propType: 'bsStyle',
+          type: 'string, oneOf primary, link, and default.',
+          defaultValue: 'default',
+          note: (
+            <span>
+              <br />It&apos;s uncommon to use <pre>success</pre>, <pre>info</pre>, <pre>warning</pre>, or{' '}
+              <pre>danger</pre>
+              which are supported by Bootstrap but not us.
+            </span>
+          ),
+        },
+        {
+          propType: 'inverse',
+          type: 'bool',
+          note: 'Renders an inverse button. Can be used with bsStyle to create primary inverse buttons.',
+          defaultValue: 'false',
+        },
+        {
+          propType: 'reason',
+          type: 'string',
+          note: 'Used in tandem with the disabled prop to present a popover explaining why the button is disabled.',
+        },
+        {
+          propType: 'onClick',
+          type: 'func',
+          note: 'onClick(event)',
+        },
+        {
+          propType: 'bsSize',
+          type: 'string',
+          note: (
+            <span>
+              We rarely use <pre>large</pre>, and should not use <pre>small</pre>.
+            </span>
+          ),
+        },
+        {
+          propType: 'isLoading',
+          type: 'bool',
+          defaultValue: 'false',
+          note: 'set this to true to display Spinner and disable the button',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/CardExample.jsx
+++ b/docs/examples/CardExample.jsx
@@ -17,26 +17,31 @@ const exampleProps = {
   designNotes: (
     <p>Cards are used as a visual list which usually contain a logo or icon to assist the user in with discovery.</p>
   ),
-  exampleCodeSnippet: `<Card.Container>
-  <Card.Content>Card body.</Card.Content>
-</Card.Container>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <Card.Container>
+    <Card.Content>Card body.</Card.Content>
+  </Card.Container>`,
+  propTypeSectionArray: [
     {
-      propType: 'children',
-      type: 'arrayOf <Card.Content>',
-    },
-    {
-      propType: 'className',
-      type: 'string',
-    },
-    {
-      propType: 'accent',
-      type: 'string',
-    },
-    {
-      propType: 'dts',
-      type: 'string',
-      note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+      propTypes: [
+        {
+          propType: 'children',
+          type: 'arrayOf <Card.Content>',
+        },
+        {
+          propType: 'className',
+          type: 'string',
+        },
+        {
+          propType: 'accent',
+          type: 'string',
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/CarouselExample.jsx
+++ b/docs/examples/CarouselExample.jsx
@@ -39,39 +39,42 @@ const exampleProps = {
     </p>
   ),
   exampleCodeSnippet: `
-<Carousel>
-  <a style={{ display: 'block' }} href="/">
-    <img src="./docs/assets/carousel/carousel-1.jpg" alt="Slide 1" />
-  </a>
-  <img src="./docs/assets/carousel/carousel-2.jpg" alt="Slide 2" />
-  <div style={{ position: 'relative' }}>
-    <h2
-      style={{
-        position: 'absolute',
-        right: 0,
-        left: 0,
-        textAlign: 'center',
-        color: '#fff',
-      }}
-    >ＡＥＳＴＨＥＴＩＣＳ<small>Adslot UI</small></h2>
-    <img src="./docs/assets/carousel/carousel-3.jpg" alt="Slide 3" />
-  </div>
-  <img src="./docs/assets/carousel/carousel-4.jpg" alt="Slide 4" />
-</Carousel>
-`,
-  propTypes: [
+  <Carousel>
+    <a style={{ display: 'block' }} href="/">
+      <img src="./docs/assets/carousel/carousel-1.jpg" alt="Slide 1" />
+    </a>
+    <img src="./docs/assets/carousel/carousel-2.jpg" alt="Slide 2" />
+    <div style={{ position: 'relative' }}>
+      <h2
+        style={{
+          position: 'absolute',
+          right: 0,
+          left: 0,
+          textAlign: 'center',
+          color: '#fff',
+        }}
+      >ＡＥＳＴＨＥＴＩＣＳ<small>Adslot UI</small></h2>
+      <img src="./docs/assets/carousel/carousel-3.jpg" alt="Slide 3" />
+    </div>
+    <img src="./docs/assets/carousel/carousel-4.jpg" alt="Slide 4" />
+  </Carousel>`,
+  propTypeSectionArray: [
     {
-      propType: 'children',
-      type: 'node',
-    },
-    {
-      propType: 'className',
-      type: 'string',
-    },
-    {
-      propType: 'Nuka Carousel prop types',
-      type: '',
-      note: <a href="https://github.com/FormidableLabs/nuka-carousel">See Nuka Carousel docs for other options</a>,
+      propTypes: [
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'className',
+          type: 'string',
+        },
+        {
+          propType: 'Nuka Carousel prop types',
+          type: '',
+          note: <a href="https://github.com/FormidableLabs/nuka-carousel">See Nuka Carousel docs for other options</a>,
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/CheckboxExample.jsx
+++ b/docs/examples/CheckboxExample.jsx
@@ -21,19 +21,23 @@ const exampleProps = {
       See <a href="https://github.com/luqin/react-icheck">React iCheck Documentation</a>
     </p>
   ),
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'label',
-      type: 'node',
-      note: 'Usually fine to rely on a string but can pass HTML e.g. for a url.',
-    },
-    {
-      propType: 'value',
-      type: 'string',
-    },
-    {
-      propType: 'onChange',
-      type: 'func',
+      propTypes: [
+        {
+          propType: 'label',
+          type: 'node',
+          note: 'Usually fine to rely on a string but can pass HTML e.g. for a url.',
+        },
+        {
+          propType: 'value',
+          type: 'string',
+        },
+        {
+          propType: 'onChange',
+          type: 'func',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/ConfirmModalExample.jsx
+++ b/docs/examples/ConfirmModalExample.jsx
@@ -34,44 +34,49 @@ class ConfirmModalExample extends React.PureComponent {
 const exampleProps = {
   componentName: 'Confirm Modal',
   designNotes: <p>Confirm modal are commonly used to verify an action.</p>,
-  exampleCodeSnippet: `<ConfirmModal
-  modalApply={this.toggleConfirmModal}
-  modalClose={this.toggleConfirmModal}
-  show={this.state.showConfirmModal}
-/>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <ConfirmModal
+    modalApply={this.toggleConfirmModal}
+    modalClose={this.toggleConfirmModal}
+    show={this.state.showConfirmModal}
+  />`,
+  propTypeSectionArray: [
     {
-      propType: 'buttonCancelLabel',
-      type: 'string',
-      defaultValue: 'Cancel',
-    },
-    {
-      propType: 'buttonConfirmLabel',
-      type: 'string',
-      defaultValue: 'Confirm',
-    },
-    {
-      propType: 'modalApply',
-      type: 'func',
-      defaultValue: "() => { throw new Error('AdslotUi ConfirmModal needs a modalApply handler'); }",
-    },
-    {
-      propType: 'modalClose',
-      type: 'func',
-    },
-    {
-      propType: 'modalDescription',
-      type: 'string',
-      defaultValue: 'Are you sure?',
-    },
-    {
-      propType: 'modalTitle',
-      type: 'string',
-    },
-    {
-      propType: 'show',
-      type: 'boolean',
-      defaultValue: 'true',
+      propTypes: [
+        {
+          propType: 'buttonCancelLabel',
+          type: 'string',
+          defaultValue: 'Cancel',
+        },
+        {
+          propType: 'buttonConfirmLabel',
+          type: 'string',
+          defaultValue: 'Confirm',
+        },
+        {
+          propType: 'modalApply',
+          type: 'func',
+          defaultValue: "() => { throw new Error('AdslotUi ConfirmModal needs a modalApply handler'); }",
+        },
+        {
+          propType: 'modalClose',
+          type: 'func',
+        },
+        {
+          propType: 'modalDescription',
+          type: 'string',
+          defaultValue: 'Are you sure?',
+        },
+        {
+          propType: 'modalTitle',
+          type: 'string',
+        },
+        {
+          propType: 'show',
+          type: 'boolean',
+          defaultValue: 'true',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/DatePickerExample.jsx
+++ b/docs/examples/DatePickerExample.jsx
@@ -40,14 +40,15 @@ const exampleProps = {
       </p>
     </div>
   ),
-  exampleCodeSnippet: `<DatePicker
-  className="form-control"
-  dateFormat="DD MMM YYYY"
-  selected={this.state.startDate}
-  onChange={this.setSelectedDate}
-  placeholderText="Date e.g. 03 Sep 2016"
-/>`,
-  propTypes: [],
+  exampleCodeSnippet: `
+  <DatePicker
+    className="form-control"
+    dateFormat="DD MMM YYYY"
+    selected={this.state.startDate}
+    onChange={this.setSelectedDate}
+    placeholderText="Date e.g. 03 Sep 2016"
+  />`,
+  propTypeSectionArray: [],
 };
 
 export default () => (

--- a/docs/examples/EmptyExample.jsx
+++ b/docs/examples/EmptyExample.jsx
@@ -34,31 +34,35 @@ const exampleProps = {
       svgSymbol={{ href: './docs/assets/svg-symbols.svg#checklist-incomplete' }}
     />
   `,
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'collection',
-      type: 'node',
-      defaultValue: 'null',
-    },
-    {
-      propType: 'text',
-      type: 'node',
-      defaultValue: 'Nothing to show.',
-    },
-    {
-      propType: 'svgSymbol',
-      type: 'shape',
-      note: (
-        <span>
-          Accepts <a href="#svg-symbol-example">SVG Symbol</a> props such as href.
-        </span>
-      ),
-    },
-    {
-      propType: 'hideIcon',
-      type: 'boolean',
-      defaultValue: 'false',
-      note: 'Whether or not the SVG Symbol should be displayed.',
+      propTypes: [
+        {
+          propType: 'collection',
+          type: 'node',
+          defaultValue: 'null',
+        },
+        {
+          propType: 'text',
+          type: 'node',
+          defaultValue: 'Nothing to show.',
+        },
+        {
+          propType: 'svgSymbol',
+          type: 'shape',
+          note: (
+            <span>
+              Accepts <a href="#svg-symbol-example">SVG Symbol</a> props such as href.
+            </span>
+          ),
+        },
+        {
+          propType: 'hideIcon',
+          type: 'boolean',
+          defaultValue: 'false',
+          note: 'Whether or not the SVG Symbol should be displayed.',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/FilePickerExample.jsx
+++ b/docs/examples/FilePickerExample.jsx
@@ -18,44 +18,48 @@ const exampleProps = {
     </p>
   ),
   exampleCodeSnippet: '<FilePicker onSelect={onSelect} />',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'disabled',
-      type: 'bool',
-      defaultValue: 'false',
-    },
-    {
-      propType: 'dts',
-      type: 'string',
-      note: 'render `data-test-selector` onto the component. It can be useful for testing.',
-    },
-    {
-      propType: 'filter',
-      type: 'string',
-    },
-    {
-      propType: 'isHighlighted',
-      type: 'bool',
-      defaultValue: 'false',
-    },
-    {
-      propType: 'label',
-      type: 'string',
-      defaultValue: 'Select',
-    },
-    {
-      propType: 'onRemove',
-      type: 'func',
-    },
-    {
-      propType: 'onSelect',
-      type: 'func',
-      note: <pre>{'onSelect({ isClosed, lastModified, lastModifiedDate, name, size, type })'}</pre>,
-    },
-    {
-      propType: 'placeholder',
-      type: 'string',
-      defaultValue: 'No file selected',
+      propTypes: [
+        {
+          propType: 'disabled',
+          type: 'bool',
+          defaultValue: 'false',
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+        {
+          propType: 'filter',
+          type: 'string',
+        },
+        {
+          propType: 'isHighlighted',
+          type: 'bool',
+          defaultValue: 'false',
+        },
+        {
+          propType: 'label',
+          type: 'string',
+          defaultValue: 'Select',
+        },
+        {
+          propType: 'onRemove',
+          type: 'func',
+        },
+        {
+          propType: 'onSelect',
+          type: 'func',
+          note: <pre>{'onSelect({ isClosed, lastModified, lastModifiedDate, name, size, type })'}</pre>,
+        },
+        {
+          propType: 'placeholder',
+          type: 'string',
+          defaultValue: 'No file selected',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/FlexibleSpacerExample.jsx
+++ b/docs/examples/FlexibleSpacerExample.jsx
@@ -12,7 +12,7 @@ const exampleProps = {
   componentName: 'Flexible Spacer',
   notes: 'Used to fill a flex container with empty space.',
   exampleCodeSnippet: '<FlexibleSpacer />',
-  propTypes: [],
+  propTypeSectionArray: [],
 };
 
 export default () => (

--- a/docs/examples/GridExample.jsx
+++ b/docs/examples/GridExample.jsx
@@ -14,12 +14,12 @@ class GridExample extends React.PureComponent {
           <GridCell>Header</GridCell>
         </GridRow>
         <GridRow verticalCellBorder>
-          <GridCell stretch>Content</GridCell>
+          <GridCell stretch>Body</GridCell>
           <GridCell>Content</GridCell>
           <GridCell>Content</GridCell>
         </GridRow>
         <GridRow>
-          <GridCell>Content</GridCell>
+          <GridCell>Body</GridCell>
           <GridCell>Content</GridCell>
           <GridCell onClick={cellClicked}>This Cell logs clicks.</GridCell>
         </GridRow>
@@ -30,6 +30,12 @@ class GridExample extends React.PureComponent {
             posuere tellus quis nisl vulputate efficitur. Nulla laoreet ut ex vitae pharetra. Vivamus felis eros,
             finibus fringilla turpis ut, convallis maximus mi.
           </GridCell>
+        </GridRow>
+        <GridRow type="subfooter">
+          <GridCell>Subfooter</GridCell>
+        </GridRow>
+        <GridRow type="footer">
+          <GridCell>Footer</GridCell>
         </GridRow>
       </Grid>
     );
@@ -46,12 +52,12 @@ const exampleProps = {
       <GridCell>Header</GridCell>
     </GridRow>
     <GridRow verticalCellBorder>
-      <GridCell stretch>Content</GridCell>
+      <GridCell stretch>Body</GridCell>
       <GridCell>Content</GridCell>
       <GridCell>Content</GridCell>
     </GridRow>
     <GridRow>
-      <GridCell>Content</GridCell>
+      <GridCell>Body</GridCell>
       <GridCell>Content</GridCell>
       <GridCell onClick={cellClicked}>This Cell logs clicks.</GridCell>
     </GridRow>
@@ -63,16 +69,101 @@ const exampleProps = {
       finibus fringilla turpis ut, convallis maximus mi.
       </GridCell>
     </GridRow>
+    <GridRow type="subfooter">
+      <GridCell>Subfooter</GridCell>
+    </GridRow>
+    <GridRow type="footer">
+      <GridCell>Footer</GridCell>
+    </GridRow>
   </Grid>`,
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'children',
-      type: 'node',
+      label: 'Grid',
+      propTypes: [
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+      ],
     },
     {
-      propType: 'dts',
-      type: 'string',
-      note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+      label: 'GridRow',
+      propTypes: [
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+        {
+          propType: 'horizontalBorder',
+          type: 'bool',
+          defaultValue: 'true',
+          note: 'If setting to true, it will show the border between two GridRows.',
+        },
+        {
+          propType: 'short',
+          type: 'bool',
+          defaultValue: 'false',
+          note: 'If setting to true, it will have less padding.',
+        },
+        {
+          propType: 'type',
+          type: `oneOf('body', 'header', 'subfooter', 'footer')`,
+          defaultValue: `'body'`,
+          note: 'Providing 4 pre-configured styles.',
+        },
+        {
+          propType: 'verticalCellBorder',
+          type: 'bool',
+          defaultValue: 'false',
+          note: 'If setting to true, it will show the border between each GridCells.',
+        },
+      ],
+    },
+    {
+      label: 'GridCell',
+      propTypes: [
+        {
+          propType: 'addonClassNames',
+          type: 'arrayOf(String)',
+          note: 'Used to apply custom classes to this cell.',
+        },
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'classSuffixes',
+          type: 'arrayOf(String)',
+          defaultValue: <pre>[]</pre>,
+          note: `Every element provided in this prop, will generate a className like 'grid-component-cell-something'.`,
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+        {
+          propType: 'onClick',
+          type: 'func',
+          note: 'A function triggerd when user clicks this cell.',
+        },
+        {
+          propType: 'stretch',
+          type: 'bool',
+          defaultValue: 'false',
+          note: `The stretch cell will use most space is this row and minimize other cells' space.`,
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/HelpIconPopoverExample.jsx
+++ b/docs/examples/HelpIconPopoverExample.jsx
@@ -33,24 +33,29 @@ const exampleProps = {
       <pre>.help-block</pre> text.
     </span>
   ),
-  exampleCodeSnippet: `<HelpIconPopover id="help-text-example">
-  <p>Download your <em>latest</em> report.</p>
-</HelpIconPopover>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <HelpIconPopover id="help-text-example">
+    <p>Download your <em>latest</em> report.</p>
+  </HelpIconPopover>`,
+  propTypeSectionArray: [
     {
-      propType: 'id',
-      type: 'string',
-      note: 'A unique identifier for the element.',
-    },
-    {
-      propType: 'children',
-      type: 'node',
-      note: 'Rich-text, html help message.',
-    },
-    {
-      propType: 'placement',
-      type: 'string oneOf top, right, bottom, left',
-      defaultValue: 'right',
+      propTypes: [
+        {
+          propType: 'id',
+          type: 'string',
+          note: 'A unique identifier for the element.',
+        },
+        {
+          propType: 'children',
+          type: 'node',
+          note: 'Rich-text, html help message.',
+        },
+        {
+          propType: 'placement',
+          type: 'string oneOf top, right, bottom, left',
+          defaultValue: 'right',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/HoverDropdownMenuExample.jsx
+++ b/docs/examples/HoverDropdownMenuExample.jsx
@@ -47,66 +47,70 @@ const exampleProps = {
     </div>
   ),
   exampleCodeSnippet: `
-const links = [
-  {
-    title: 'Adslot.com',
-    url: 'http://www.adslot.com',
-    target: '_self',
-    isEnabled: true,
-    onClick: _.noop,
-  },
-  {
-    title: 'Logout',
-    url: '#',
-    target: '_modal',
-    isEnabled: true,
-    onClick: _.noop,
-  },
-];
+  const links = [
+    {
+      title: 'Adslot.com',
+      url: 'http://www.adslot.com',
+      target: '_self',
+      isEnabled: true,
+      onClick: _.noop,
+    },
+    {
+      title: 'Logout',
+      url: '#',
+      target: '_modal',
+      isEnabled: true,
+      onClick: _.noop,
+    },
+  ];
 
-const props = {
-  arrowPosition: 'left',
-  headerText: 'Hello, John Smith',
-  hoverComponent: (<Avatar givenName="John" surname="Smith" />),
-};
+  const props = {
+    arrowPosition: 'left',
+    headerText: 'Hello, John Smith',
+    hoverComponent: (<Avatar givenName="John" surname="Smith" />),
+  };
 
-<div className="hover-dropdown-example">
-  <HoverDropdownMenu {...props}>
-    {_.map(links, (link) => (
-      <HoverDropdownMenu.Item key={link.title} {...link} />
-    ))}
-  </HoverDropdownMenu>
-</div>
-`,
-  propTypes: [
+  <div className="hover-dropdown-example">
+    <HoverDropdownMenu {...props}>
+      {_.map(links, (link) => (
+        <HoverDropdownMenu.Item key={link.title} {...link} />
+      ))}
+    </HoverDropdownMenu>
+  </div>
+  `,
+  propTypeSectionArray: [
     {
-      propType: 'arrowPosition',
-      type: "oneOf ['left', 'right']",
-      defaultValue: 'left',
-      note: 'determine the placement of the popover',
-    },
-    {
-      propType: 'headerText',
-      type: 'string',
-      defaultValue: '',
-      note: 'If set to empty string, header will not be rendered.',
-    },
-    {
-      propType: 'links',
-      type: "arrayOf {oneOf ['_self', '_modal']: target, string: title, string: url, bool: isEnabled}",
-      defaultValue: '[ ]',
-      note: 'Each link will be used to render dropdown item',
-    },
-    {
-      propType: 'hoverComponent',
-      type: 'node',
-      note: 'displayed element to be hovered on, e.g. Avatar component.',
-    },
-    {
-      propType: 'onLinkClick',
-      type: 'func',
-      note: 'onLinkClick(link), callback when user clicks on a dropdown item; link is an object of `links` prop',
-      defaultValue: '_.noop',
+      propTypes: [
+        {
+          propType: 'arrowPosition',
+          type: "oneOf ['left', 'right']",
+          defaultValue: 'left',
+          note: 'determine the placement of the popover',
+        },
+        {
+          propType: 'headerText',
+          type: 'string',
+          defaultValue: '',
+          note: 'If set to empty string, header will not be rendered.',
+        },
+        {
+          propType: 'links',
+          type: "arrayOf {oneOf ['_self', '_modal']: target, string: title, string: url, bool: isEnabled}",
+          defaultValue: '[ ]',
+          note: 'Each link will be used to render dropdown item',
+        },
+        {
+          propType: 'hoverComponent',
+          type: 'node',
+          note: 'displayed element to be hovered on, e.g. Avatar component.',
+        },
+        {
+          propType: 'onLinkClick',
+          type: 'func',
+          note: 'onLinkClick(link), callback when user clicks on a dropdown item; link is an object of `links` prop',
+          defaultValue: '_.noop',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/InformationBoxExample.jsx
+++ b/docs/examples/InformationBoxExample.jsx
@@ -26,23 +26,27 @@ const exampleProps = {
       icon="./docs/assets/svg-symbols.svg#cancel">
         Content body.
     </InformationBox>`,
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'children',
-      type: 'node',
-    },
-    {
-      propType: 'icon',
-      type: 'string',
-      note: (
-        <span>
-          href for <a href="#svg-symbol-example">SVG Symbol</a> component.
-        </span>
-      ),
-    },
-    {
-      propType: 'title',
-      type: 'string',
+      propTypes: [
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'icon',
+          type: 'string',
+          note: (
+            <span>
+              href for <a href="#svg-symbol-example">SVG Symbol</a> component.
+            </span>
+          ),
+        },
+        {
+          propType: 'title',
+          type: 'string',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/ListPickerExample.jsx
+++ b/docs/examples/ListPickerExample.jsx
@@ -84,101 +84,105 @@ const exampleProps = {
       modalTitle="Select User"
       show={this.state.showListPickerModal}
     />
-`,
-  propTypes: [
+  `,
+  propTypeSectionArray: [
     {
-      propType: 'allowEmptySelection',
-      type: 'boolean',
-      defaultValue: 'true',
-    },
-    {
-      propType: 'allowMultiSelection',
-      type: 'boolean',
-      defaultValue: 'true',
-    },
-    {
-      propType: 'emptyIcon',
-      type: 'string',
-    },
-    {
-      propType: 'emptyMessage',
-      type: 'string',
-    },
-    {
-      propType: 'emptySvgSymbol',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-    },
-    {
-      propType: 'initialSelection',
-      type: 'array',
-      defaultValue: <pre>[]</pre>,
-    },
-    {
-      propType: 'itemHeaders',
-      type: 'shapeOf { string: label, string: toggle, string: addon }',
-    },
-    {
-      propType: 'itemInfo',
-      type: 'shapeOf { string: label, arrayOf({ string: label, string: value }): properties, string: addon }',
-    },
-    {
-      propType: 'items',
-      type: 'array',
-      defaultValue: <pre>[]</pre>,
-    },
-    {
-      propType: 'itemType',
-      type: 'string',
-      defaultValue: 'item',
-    },
-    {
-      propType: 'labelFormatter',
-      type: 'func',
-    },
-    {
-      propType: 'addonFormatter',
-      type: 'func',
-    },
-    {
-      propType: 'linkButtons',
-      type: 'arrayOf(node|{ string: label, string: href })',
-    },
-    {
-      propType: 'modalApply',
-      type: 'func',
-      defaultValue: "() => { throw new Error('AdslotUi ListPicker needs a modalApply handler'); }",
-    },
-    {
-      propType: 'modalDescription',
-      type: 'string',
-    },
-    {
-      propType: 'modalClassName',
-      type: 'string',
-      defaultValue: 'listpicker-component',
-    },
-    {
-      propType: 'modalClose',
-      type: 'func',
-      defaultValue: "() => { throw new Error('AdslotUi ListPicker needs a modalClose handler'); }",
-    },
-    {
-      propType: 'modalFootnote',
-      type: 'string',
-    },
-    {
-      propType: 'modalTitle',
-      type: 'string',
-      defaultValue: 'Select Items',
-    },
-    {
-      propType: 'show',
-      type: 'boolean',
-      defaultValue: 'false',
+      propTypes: [
+        {
+          propType: 'allowEmptySelection',
+          type: 'boolean',
+          defaultValue: 'true',
+        },
+        {
+          propType: 'allowMultiSelection',
+          type: 'boolean',
+          defaultValue: 'true',
+        },
+        {
+          propType: 'emptyIcon',
+          type: 'string',
+        },
+        {
+          propType: 'emptyMessage',
+          type: 'string',
+        },
+        {
+          propType: 'emptySvgSymbol',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+        },
+        {
+          propType: 'initialSelection',
+          type: 'array',
+          defaultValue: <pre>[]</pre>,
+        },
+        {
+          propType: 'itemHeaders',
+          type: 'shapeOf { string: label, string: toggle, string: addon }',
+        },
+        {
+          propType: 'itemInfo',
+          type: 'shapeOf { string: label, arrayOf({ string: label, string: value }): properties, string: addon }',
+        },
+        {
+          propType: 'items',
+          type: 'array',
+          defaultValue: <pre>[]</pre>,
+        },
+        {
+          propType: 'itemType',
+          type: 'string',
+          defaultValue: 'item',
+        },
+        {
+          propType: 'labelFormatter',
+          type: 'func',
+        },
+        {
+          propType: 'addonFormatter',
+          type: 'func',
+        },
+        {
+          propType: 'linkButtons',
+          type: 'arrayOf(node|{ string: label, string: href })',
+        },
+        {
+          propType: 'modalApply',
+          type: 'func',
+          defaultValue: "() => { throw new Error('AdslotUi ListPicker needs a modalApply handler'); }",
+        },
+        {
+          propType: 'modalDescription',
+          type: 'string',
+        },
+        {
+          propType: 'modalClassName',
+          type: 'string',
+          defaultValue: 'listpicker-component',
+        },
+        {
+          propType: 'modalClose',
+          type: 'func',
+          defaultValue: "() => { throw new Error('AdslotUi ListPicker needs a modalClose handler'); }",
+        },
+        {
+          propType: 'modalFootnote',
+          type: 'string',
+        },
+        {
+          propType: 'modalTitle',
+          type: 'string',
+          defaultValue: 'Select Items',
+        },
+        {
+          propType: 'show',
+          type: 'boolean',
+          defaultValue: 'false',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/NavigationExample.jsx
+++ b/docs/examples/NavigationExample.jsx
@@ -39,31 +39,36 @@ const exampleProps = {
       <label>Example: Campaign navigation.</label>
     </div>
   ),
-  exampleCodeSnippet: `<Nav activeKey={this.state.activeKey} onSelect={this.onSelect}>
-  <NavItem eventKey={0} href="#" title="Dashboard Home" className="dashboard-tab"}>Dashboard</NavItem>
-  <NavItem eventKey={1} title="Analytics Reporting">Reports</NavItem>
-</Nav>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <Nav activeKey={this.state.activeKey} onSelect={this.onSelect}>
+    <NavItem eventKey={0} href="#" title="Dashboard Home" className="dashboard-tab"}>Dashboard</NavItem>
+    <NavItem eventKey={1} title="Analytics Reporting">Reports</NavItem>
+  </Nav>`,
+  propTypeSectionArray: [
     {
-      propType: 'React Bootstrap Nav prop types',
-      type: '',
-      defaultValue: '',
-      note: (
-        <a href="https://react-bootstrap.github.io/components.html#navs" target="_blank" rel="noopener noreferrer">
-          React Bootstrap Docs
-        </a>
-      ),
-    },
-    {
-      propType: 'dts',
-      type: 'string',
-      note: 'data-test-selector; used for testing purposes',
-    },
-    {
-      propType: 'barPosition',
-      type: "oneOf: 'top', 'bottom'",
-      defaultValue: 'bottom',
-      note: 'Determine the position of selected tab bar indicator',
+      propTypes: [
+        {
+          propType: 'React Bootstrap Nav prop types',
+          type: '',
+          defaultValue: '',
+          note: (
+            <a href="https://react-bootstrap.github.io/components.html#navs" target="_blank" rel="noopener noreferrer">
+              React Bootstrap Docs
+            </a>
+          ),
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'data-test-selector; used for testing purposes',
+        },
+        {
+          propType: 'barPosition',
+          type: "oneOf: 'top', 'bottom'",
+          defaultValue: 'bottom',
+          note: 'Determine the position of selected tab bar indicator',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/PageTitleExample.jsx
+++ b/docs/examples/PageTitleExample.jsx
@@ -23,19 +23,23 @@ const exampleProps = {
     </div>
   ),
   exampleCodeSnippet: '<PageTitle title="Campaign 12345: Adslot"><small>Version 5</small></PageTitle>',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'title',
-      type: 'string',
-    },
-    {
-      propType: 'children',
-      type: 'node',
-    },
-    {
-      propType: 'isFooter',
-      type: 'bool',
-      defaultValue: 'false',
+      propTypes: [
+        {
+          propType: 'title',
+          type: 'string',
+        },
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'isFooter',
+          type: 'bool',
+          defaultValue: 'false',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/PagedGridExample.jsx
+++ b/docs/examples/PagedGridExample.jsx
@@ -25,52 +25,57 @@ class PagedGridExample extends React.PureComponent {
 
 const exampleProps = {
   componentName: 'Paged Grid',
-  exampleCodeSnippet: `<PagedGrid
-  columns={[
-    { key: 'id', label: 'ID' },
-    { key: 'givenName', label: 'Given Name', stretch: true },
-    { key: 'surname', label: 'Surname', stretch: true },
-  ]}
-  items={[
-    { givenName: 'John', id: 1, surname: 'Smith' },
-    { givenName: 'Jane', id: 2, surname: 'Doe' },
-    { givenName: 'Jack', id: 3, surname: 'White' },
-  ]}
-  verticalCellBorder
-  perPage={2}
-/>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <PagedGrid
+    columns={[
+      { key: 'id', label: 'ID' },
+      { key: 'givenName', label: 'Given Name', stretch: true },
+      { key: 'surname', label: 'Surname', stretch: true },
+    ]}
+    items={[
+      { givenName: 'John', id: 1, surname: 'Smith' },
+      { givenName: 'Jane', id: 2, surname: 'Doe' },
+      { givenName: 'Jack', id: 3, surname: 'White' },
+    ]}
+    verticalCellBorder
+    perPage={2}
+  />`,
+  propTypeSectionArray: [
     {
-      propType: 'columns',
-      type: 'arrayOf({ string: key, node: label, bool: stretch })',
-    },
-    {
-      propType: 'emptyIcon',
-      type: 'string',
-    },
-    {
-      propType: 'emptyMessage',
-      type: 'string',
-    },
-    {
-      propType: 'emptySvgSymbol',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-    },
-    {
-      propType: 'items',
-      type: 'arrayOf({ node: id })',
-    },
-    {
-      propType: 'perPage',
-      type: 'number',
-    },
-    {
-      propType: 'verticalCellBorder',
-      type: 'boolean',
+      propTypes: [
+        {
+          propType: 'columns',
+          type: 'arrayOf({ string: key, node: label, bool: stretch })',
+        },
+        {
+          propType: 'emptyIcon',
+          type: 'string',
+        },
+        {
+          propType: 'emptyMessage',
+          type: 'string',
+        },
+        {
+          propType: 'emptySvgSymbol',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+        },
+        {
+          propType: 'items',
+          type: 'arrayOf({ node: id })',
+        },
+        {
+          propType: 'perPage',
+          type: 'number',
+        },
+        {
+          propType: 'verticalCellBorder',
+          type: 'boolean',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/PanelExample.jsx
+++ b/docs/examples/PanelExample.jsx
@@ -44,61 +44,66 @@ const exampleProps = {
       its own.
     </p>
   ),
-  exampleCodeSnippet: `<Panel
-  id="8db886a1-671f-4a40-a000-3c6bf1f87ecd"
-  title="Read more about integration"
-  isCollapsed={this.state.isCollapsed}
-  onClick={this.togglePanel}
->
-  <p>
-    Lorem ipsum amet dolore voluptate veniam nulla dolore nulla adipisicing irure
-    adipisicing qui fugiat veniam. Ullamco reprehenderit cillum irure esse ad eu dolor laboris.
-  </p>
-  <p>Consequat commodo consequat eiusmod sit mollit elit ex nostrud consectetur.</p>
-</Panel>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <Panel
+    id="8db886a1-671f-4a40-a000-3c6bf1f87ecd"
+    title="Read more about integration"
+    isCollapsed={this.state.isCollapsed}
+    onClick={this.togglePanel}
+  >
+    <p>
+      Lorem ipsum amet dolore voluptate veniam nulla dolore nulla adipisicing irure
+      adipisicing qui fugiat veniam. Ullamco reprehenderit cillum irure esse ad eu dolor laboris.
+    </p>
+    <p>Consequat commodo consequat eiusmod sit mollit elit ex nostrud consectetur.</p>
+  </Panel>`,
+  propTypeSectionArray: [
     {
-      propType: 'id',
-      type: 'string',
-      defaultValue: '',
-      note: '',
-    },
-    {
-      propType: 'dts',
-      type: 'string',
-      note: 'render `data-test-selector` onto the component. It can be useful for testing.',
-    },
-    {
-      propType: 'icon',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-    },
-    {
-      propType: 'title',
-      type: 'string',
-      defaultValue: '',
-      note: '',
-    },
-    {
-      propType: 'isCollapsed',
-      type: 'boolean',
-      defaultValue: 'false',
-      note: '',
-    },
-    {
-      propType: 'onClick',
-      type: 'func',
-      defaultValue: '',
-      note: '',
-    },
-    {
-      propType: 'children',
-      type: 'node',
-      defaultValue: '',
-      note: '',
+      propTypes: [
+        {
+          propType: 'id',
+          type: 'string',
+          defaultValue: '',
+          note: '',
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+        {
+          propType: 'icon',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+        },
+        {
+          propType: 'title',
+          type: 'string',
+          defaultValue: '',
+          note: '',
+        },
+        {
+          propType: 'isCollapsed',
+          type: 'boolean',
+          defaultValue: 'false',
+          note: '',
+        },
+        {
+          propType: 'onClick',
+          type: 'func',
+          defaultValue: '',
+          note: '',
+        },
+        {
+          propType: 'children',
+          type: 'node',
+          defaultValue: '',
+          note: '',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/PrettyDiffExample.jsx
+++ b/docs/examples/PrettyDiffExample.jsx
@@ -33,16 +33,20 @@ const exampleProps = {
       }
     />
   `,
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'oldText',
-      type: 'string',
-      defaultValue: '',
-    },
-    {
-      propType: 'newText',
-      type: 'string',
-      defaultValue: '',
+      propTypes: [
+        {
+          propType: 'oldText',
+          type: 'string',
+          defaultValue: '',
+        },
+        {
+          propType: 'newText',
+          type: 'string',
+          defaultValue: '',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/RadioExample.jsx
+++ b/docs/examples/RadioExample.jsx
@@ -26,23 +26,28 @@ const exampleProps = {
       See <a href="https://github.com/luqin/react-icheck">React iCheck Documentation</a>
     </p>
   ),
-  exampleCodeSnippet: `<RadioGroup name="yesNo" className="radiogroup-stacked">
-  <Radio label="Yes" value="true" />
-  <Radio label="No" value="false" />
-</RadioGroup>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <RadioGroup name="yesNo" className="radiogroup-stacked">
+    <Radio label="Yes" value="true" />
+    <Radio label="No" value="false" />
+  </RadioGroup>`,
+  propTypeSectionArray: [
     {
-      propType: 'label',
-      type: 'node',
-      note: 'Usually fine to rely on a string but can pass HTML e.g. for a url.',
-    },
-    {
-      propType: 'value',
-      type: 'string',
-    },
-    {
-      propType: 'onChange',
-      type: 'func',
+      propTypes: [
+        {
+          propType: 'label',
+          type: 'node',
+          note: 'Usually fine to rely on a string but can pass HTML e.g. for a url.',
+        },
+        {
+          propType: 'value',
+          type: 'string',
+        },
+        {
+          propType: 'onChange',
+          type: 'func',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/SearchBarExample.jsx
+++ b/docs/examples/SearchBarExample.jsx
@@ -36,48 +36,53 @@ class SearchBarExample extends React.Component {
 const exampleProps = {
   componentName: 'SearchBar',
   designNotes: <p>Search Bar is commonly used above the pages designed to manage filter pills and search.</p>,
-  exampleCodeSnippet: `<SearchBar
-  searchString={this.state.searchBarString}
-  searchPlaceholder="Enter a word or phrase to find matching items."
-  searchIconHref="./docs/assets/svg-symbols.svg#search"
-  onSearchStringChange={this.setSearchBarString}
-  onSearch={this.performSearchBarSearch}
-/>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <SearchBar
+    searchString={this.state.searchBarString}
+    searchPlaceholder="Enter a word or phrase to find matching items."
+    searchIconHref="./docs/assets/svg-symbols.svg#search"
+    onSearchStringChange={this.setSearchBarString}
+    onSearch={this.performSearchBarSearch}
+  />`,
+  propTypeSectionArray: [
     {
-      propType: 'additionalClassNames',
-      type: 'array',
-      defaultValue: <pre>[]</pre>,
-      note: 'array of strings',
-    },
-    {
-      propType: 'searchString',
-      type: 'string',
-      note: 'required',
-    },
-    {
-      propType: 'searchPlaceholder',
-      type: 'string',
-    },
-    {
-      propType: 'searchIconHref',
-      type: 'string',
-      note: 'required',
-    },
-    {
-      propType: 'onSearchStringChange',
-      type: 'func',
-      note: 'required',
-    },
-    {
-      propType: 'onSearch',
-      type: 'func',
-      note: 'required',
-    },
-    {
-      propType: 'dts',
-      type: 'string',
-      note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+      propTypes: [
+        {
+          propType: 'additionalClassNames',
+          type: 'array',
+          defaultValue: <pre>[]</pre>,
+          note: 'array of strings',
+        },
+        {
+          propType: 'searchString',
+          type: 'string',
+          note: 'required',
+        },
+        {
+          propType: 'searchPlaceholder',
+          type: 'string',
+        },
+        {
+          propType: 'searchIconHref',
+          type: 'string',
+          note: 'required',
+        },
+        {
+          propType: 'onSearchStringChange',
+          type: 'func',
+          note: 'required',
+        },
+        {
+          propType: 'onSearch',
+          type: 'func',
+          note: 'required',
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/SearchExample.jsx
+++ b/docs/examples/SearchExample.jsx
@@ -46,99 +46,104 @@ const exampleProps = {
       begin typing.
     </p>
   ),
-  exampleCodeSnippet: `<Search
-  value={this.state.value}
-  onChange={this.onChange}
-  onSearch={this.onSearch}
-  debounceInterval={350}
-  isLoading={this.state.isLoading}
-/>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <Search
+    value={this.state.value}
+    onChange={this.onChange}
+    onSearch={this.onSearch}
+    debounceInterval={350}
+    isLoading={this.state.isLoading}
+  />`,
+  propTypeSectionArray: [
     {
-      propType: 'disabled',
-      type: 'bool',
-      defaultValue: 'false',
-      note: 'determine if the Search bar is disabled',
-    },
-    {
-      propType: 'isLoading',
-      type: 'bool',
-      defaultValue: 'false',
-    },
-    {
-      propType: 'onChange',
-      type: 'func',
-      note: <pre>onChange(value)</pre>,
-    },
-    {
-      propType: 'onClear',
-      type: 'func',
-      note: <pre>onClear(value)</pre>,
-    },
-    {
-      propType: 'onSearch',
-      type: 'func',
-      note: <pre>onSearch(value)</pre>,
-    },
-    {
-      propType: 'placeholder',
-      type: 'string',
-      defaultValue: <pre>&apos;&apos;</pre>,
-    },
-    {
-      propType: 'svgSymbolCancel',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-      defaultValue: (
-        <pre>
-          {JSON.stringify({
-            classSuffixes: ['gray-darker'],
-            href: './docs/assets/svg-symbols.svg#cancel',
-          })}
-        </pre>
-      ),
-    },
-    {
-      propType: 'svgSymbolSearch',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-      defaultValue: (
-        <pre>
-          {JSON.stringify({
-            classSuffixes: ['gray-light'],
-            href: './docs/assets/svg-symbols.svg#search',
-          })}
-        </pre>
-      ),
-    },
-    {
-      propType: 'value',
-      type: 'string',
-      defaultValue: <pre>&apos;&apos;</pre>,
-      note: 'As value within search component is uncontrolled we need to pass in the search value externally.',
-    },
-    {
-      propType: 'searchOnChange',
-      type: 'bool',
-      defaultValue: 'true',
-      note: 'determine if onSearch() will be fired upon text changes',
-    },
-    {
-      propType: 'searchOnEnterKey',
-      type: 'bool',
-      defaultValue: 'false',
-      note: 'determine if onSearch() will be fired upon pressing Enter key',
-    },
-    {
-      propType: 'debounceInterval',
-      type: 'number',
-      defaultValue: '0',
+      propTypes: [
+        {
+          propType: 'disabled',
+          type: 'bool',
+          defaultValue: 'false',
+          note: 'determine if the Search bar is disabled',
+        },
+        {
+          propType: 'isLoading',
+          type: 'bool',
+          defaultValue: 'false',
+        },
+        {
+          propType: 'onChange',
+          type: 'func',
+          note: <pre>onChange(value)</pre>,
+        },
+        {
+          propType: 'onClear',
+          type: 'func',
+          note: <pre>onClear(value)</pre>,
+        },
+        {
+          propType: 'onSearch',
+          type: 'func',
+          note: <pre>onSearch(value)</pre>,
+        },
+        {
+          propType: 'placeholder',
+          type: 'string',
+          defaultValue: <pre>&apos;&apos;</pre>,
+        },
+        {
+          propType: 'svgSymbolCancel',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+          defaultValue: (
+            <pre>
+              {JSON.stringify({
+                classSuffixes: ['gray-darker'],
+                href: './docs/assets/svg-symbols.svg#cancel',
+              })}
+            </pre>
+          ),
+        },
+        {
+          propType: 'svgSymbolSearch',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+          defaultValue: (
+            <pre>
+              {JSON.stringify({
+                classSuffixes: ['gray-light'],
+                href: './docs/assets/svg-symbols.svg#search',
+              })}
+            </pre>
+          ),
+        },
+        {
+          propType: 'value',
+          type: 'string',
+          defaultValue: <pre>&apos;&apos;</pre>,
+          note: 'As value within search component is uncontrolled we need to pass in the search value externally.',
+        },
+        {
+          propType: 'searchOnChange',
+          type: 'bool',
+          defaultValue: 'true',
+          note: 'determine if onSearch() will be fired upon text changes',
+        },
+        {
+          propType: 'searchOnEnterKey',
+          type: 'bool',
+          defaultValue: 'false',
+          note: 'determine if onSearch() will be fired upon pressing Enter key',
+        },
+        {
+          propType: 'debounceInterval',
+          type: 'number',
+          defaultValue: '0',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/SelectExample.jsx
+++ b/docs/examples/SelectExample.jsx
@@ -60,7 +60,7 @@ const exampleProps = {
     value={this.state.selected}
     onChange={this.onChangeHandler}
   />`,
-  propTypes: [],
+  propTypeSectionArray: [],
 };
 
 export default () => (

--- a/docs/examples/SliceyExample.jsx
+++ b/docs/examples/SliceyExample.jsx
@@ -15,39 +15,44 @@ class SliceyExample extends React.PureComponent {
 
 const exampleProps = {
   componentName: 'Slicey',
-  exampleCodeSnippet: `<Slicey
-  dataset={[
-    { label: 'info', value: 35 },
-    { label: 'positive', value: 123 },
-    { label: 'negative', value: 15 },
-  ]}
-  diameter={100}
-/>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <Slicey
+    dataset={[
+      { label: 'info', value: 35 },
+      { label: 'positive', value: 123 },
+      { label: 'negative', value: 15 },
+    ]}
+    diameter={100}
+  />`,
+  propTypeSectionArray: [
     {
-      propType: 'dataset',
-      type: 'arrayOf {string: label, number: value}',
-      note: (
-        <span>
-          Slicey will represent all values as percentage of the pie based on the sum of all values. Label will provide a
-          className to each slice as <pre>.arc-component-{'${label}'}</pre>.
-        </span>
-      ),
-    },
-    {
-      propType: 'diameter',
-      type: 'number',
-      defaultValue: '100',
-    },
-    {
-      propType: 'marker',
-      type: 'number',
-      note: 'Add a line across the radius at a set fraction of the whole e.g. .25 for ¼.',
-    },
-    {
-      propType: 'donut',
-      type: 'bool',
-      note: 'Set to true if you wish the pie chart to have a hollow hole in the centre, like a donut :9',
+      propTypes: [
+        {
+          propType: 'dataset',
+          type: 'arrayOf {string: label, number: value}',
+          note: (
+            <span>
+              Slicey will represent all values as percentage of the pie based on the sum of all values. Label will
+              provide a className to each slice as <pre>.arc-component-{'${label}'}</pre>.
+            </span>
+          ),
+        },
+        {
+          propType: 'diameter',
+          type: 'number',
+          defaultValue: '100',
+        },
+        {
+          propType: 'marker',
+          type: 'number',
+          note: 'Add a line across the radius at a set fraction of the whole e.g. .25 for ¼.',
+        },
+        {
+          propType: 'donut',
+          type: 'bool',
+          note: 'Set to true if you wish the pie chart to have a hollow hole in the centre, like a donut :9',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/SpinnerExample.jsx
+++ b/docs/examples/SpinnerExample.jsx
@@ -19,16 +19,20 @@ const exampleProps = {
     </div>
   ),
   exampleCodeSnippet: '<Spinner />',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'size',
-      type: "oneOf: 'large', medium', 'small'",
-      defaultValue: 'large',
-    },
-    {
-      propType: 'colourStyle',
-      type: 'string',
-      defaultValue: 'default',
+      propTypes: [
+        {
+          propType: 'size',
+          type: "oneOf: 'large', medium', 'small'",
+          defaultValue: 'large',
+        },
+        {
+          propType: 'colourStyle',
+          type: 'string',
+          defaultValue: 'default',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/SplitPaneExample.jsx
+++ b/docs/examples/SplitPaneExample.jsx
@@ -19,28 +19,33 @@ class SplitPaneExample extends React.PureComponent {
 
 const exampleProps = {
   componentName: 'SplitPane',
-  exampleCodeSnippet: `<div style={{ display: 'flex' }}>
-  <SplitPane dts="left-side">
-    <p>First pane</p>
-  </SplitPane>
-  <SplitPane dts="right-side">
-    <p>Second pane</p>
-  </SplitPane>
-</div>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <div style={{ display: 'flex' }}>
+    <SplitPane dts="left-side">
+      <p>First pane</p>
+    </SplitPane>
+    <SplitPane dts="right-side">
+      <p>Second pane</p>
+    </SplitPane>
+  </div>`,
+  propTypeSectionArray: [
     {
-      propType: 'additionalClassNames',
-      type: 'array',
-      defaultValue: <pre>[]</pre>,
-    },
-    {
-      propType: 'children',
-      type: 'node',
-    },
-    {
-      propType: 'dts',
-      type: 'string',
-      note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+      propTypes: [
+        {
+          propType: 'additionalClassNames',
+          type: 'array',
+          defaultValue: <pre>[]</pre>,
+        },
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+          note: 'render `data-test-selector` onto the component. It can be useful for testing.',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/StatisticExample.jsx
+++ b/docs/examples/StatisticExample.jsx
@@ -12,22 +12,26 @@ const exampleProps = {
   componentName: 'Statistic',
   notes: 'Used for metadata stats and pricing information.',
   exampleCodeSnippet: '<Statistic value="50 Million" label="Page Views" />',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'inline',
-      type: 'boolean',
-      note: 'Horizontal layout as opposed to stacked.',
-      defaultValue: 'false',
-    },
-    {
-      propType: 'label',
-      type: 'string',
-      note: 'Preferred TitleCase (aka. PascalCase, StartCase)',
-    },
-    {
-      propType: 'value',
-      type: 'string',
-      note: "Where value is a number consider human readable strings e.g 'Million' instead of 000,000.",
+      propTypes: [
+        {
+          propType: 'inline',
+          type: 'boolean',
+          note: 'Horizontal layout as opposed to stacked.',
+          defaultValue: 'false',
+        },
+        {
+          propType: 'label',
+          type: 'string',
+          note: 'Preferred TitleCase (aka. PascalCase, StartCase)',
+        },
+        {
+          propType: 'value',
+          type: 'string',
+          note: "Where value is a number consider human readable strings e.g 'Million' instead of 000,000.",
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/SvgSymbolCircleExample.jsx
+++ b/docs/examples/SvgSymbolCircleExample.jsx
@@ -16,18 +16,22 @@ const exampleProps = {
     </p>
   ),
   exampleCodeSnippet: '<SvgSymbolCircle href="./docs/assets/svg-symbols.svg#calendar" classSuffixes={[\'50\']} />',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'href',
-      type: 'string',
-    },
-    {
-      propType: 'classSuffixes',
-      type: 'arrayOf string',
-    },
-    {
-      propType: 'onClick',
-      type: 'func',
+      propTypes: [
+        {
+          propType: 'href',
+          type: 'string',
+        },
+        {
+          propType: 'classSuffixes',
+          type: 'arrayOf string',
+        },
+        {
+          propType: 'onClick',
+          type: 'func',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/SvgSymbolExample.jsx
+++ b/docs/examples/SvgSymbolExample.jsx
@@ -27,18 +27,22 @@ const exampleProps = {
   ),
   exampleCodeSnippet:
     '<SvgSymbol href="./docs/assets/svg-symbols.svg#checklist-incomplete" classSuffixes={[\'70\']} />',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'href',
-      type: 'string',
-    },
-    {
-      propType: 'classSuffixes',
-      type: 'arrayOf string',
-    },
-    {
-      propType: 'onClick',
-      type: 'func',
+      propTypes: [
+        {
+          propType: 'href',
+          type: 'string',
+        },
+        {
+          propType: 'classSuffixes',
+          type: 'arrayOf string',
+        },
+        {
+          propType: 'onClick',
+          type: 'func',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/TabExample.jsx
+++ b/docs/examples/TabExample.jsx
@@ -65,39 +65,40 @@ const exampleProps = {
       </a>.
     </p>
   ),
-  exampleCodeSnippet: `<Tabs defaultActiveKey="Audience" animation={false} id="audience-tab">
-  <Tab
-    eventKey="Audience"
-    title={
-      <span className="flexible-wrapper-inline">
-        <SvgSymbol href="./docs/assets/svg-symbols.svg#list" />
-        <FlexibleSpacer />
-        Audience
-      </span>}
-  >
-    <Empty
-      collection={[]}
-      text="No audience details."
-      svgSymbol={{ href: './docs/assets/svg-symbols.svg#checklist-incomplete' }}
-    />
-  </Tab>
-  <Tab
-    eventKey="Billing"
-    title={
-      <span className="flexible-wrapper-inline">
-        <SvgSymbol href="./docs/assets/svg-symbols.svg#calendar" />
-        <FlexibleSpacer />
-        Billing
-      </span>}
-  >
-    <Empty
-      collection={[]}
-      text="No billing information."
-      svgSymbol={{ href: './docs/assets/svg-symbols.svg#calendar' }}
-    />
-  </Tab>
-</Tabs>`,
-  propTypes: [],
+  exampleCodeSnippet: `
+  <Tabs defaultActiveKey="Audience" animation={false} id="audience-tab">
+    <Tab
+      eventKey="Audience"
+      title={
+        <span className="flexible-wrapper-inline">
+          <SvgSymbol href="./docs/assets/svg-symbols.svg#list" />
+          <FlexibleSpacer />
+          Audience
+        </span>}
+    >
+      <Empty
+        collection={[]}
+        text="No audience details."
+        svgSymbol={{ href: './docs/assets/svg-symbols.svg#checklist-incomplete' }}
+      />
+    </Tab>
+    <Tab
+      eventKey="Billing"
+      title={
+        <span className="flexible-wrapper-inline">
+          <SvgSymbol href="./docs/assets/svg-symbols.svg#calendar" />
+          <FlexibleSpacer />
+          Billing
+        </span>}
+    >
+      <Empty
+        collection={[]}
+        text="No billing information."
+        svgSymbol={{ href: './docs/assets/svg-symbols.svg#calendar' }}
+      />
+    </Tab>
+  </Tabs>`,
+  propTypeSectionArray: [],
 };
 
 export default () => (

--- a/docs/examples/TagExample.jsx
+++ b/docs/examples/TagExample.jsx
@@ -80,40 +80,45 @@ const exampleProps = {
       the input field.
     </p>
   ),
-  exampleCodeSnippet: `<Tag
-  id="0ac7d4ce-af36-4fd9-b142-6377f8ad5f17"
-  accent="positive"
-  onAction={this.deleteTag}
-  inverse
-  actionIconSvgHref="./docs/assets/svg-symbols.svg#cancel"
->
-  Display
-</Tag>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <Tag
+    id="0ac7d4ce-af36-4fd9-b142-6377f8ad5f17"
+    accent="positive"
+    onAction={this.deleteTag}
+    inverse
+    actionIconSvgHref="./docs/assets/svg-symbols.svg#cancel"
+  >
+    Display
+  </Tag>`,
+  propTypeSectionArray: [
     {
-      propType: 'children',
-      type: 'node',
-    },
-    {
-      propType: 'id',
-      type: 'string',
-      defaultValue: 'default',
-    },
-    {
-      propType: 'accent',
-      type: 'string',
-    },
-    {
-      propType: 'inverse',
-      type: 'boolean',
-    },
-    {
-      propType: 'onAction',
-      type: 'func',
-    },
-    {
-      propType: 'actionIconSvgHref',
-      type: 'string',
+      propTypes: [
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'id',
+          type: 'string',
+          defaultValue: 'default',
+        },
+        {
+          propType: 'accent',
+          type: 'string',
+        },
+        {
+          propType: 'inverse',
+          type: 'boolean',
+        },
+        {
+          propType: 'onAction',
+          type: 'func',
+        },
+        {
+          propType: 'actionIconSvgHref',
+          type: 'string',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/TextEllipsisExample.jsx
+++ b/docs/examples/TextEllipsisExample.jsx
@@ -26,42 +26,46 @@ const exampleProps = {
   ),
   notes: 'Useful for single line truncation of text values, also provides a hover over displaying the full text.',
   exampleCodeSnippet: `<TextEllipsis>${loremIpsum}</TextEllipsis>`,
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'children',
-      type: 'node',
-    },
-    {
-      propType: 'overlayTriggerProps',
-      type: 'shape',
-      note: (
-        <span>
-          See
-          <a
-            href="https://react-bootstrap.github.io/components.html#overlays-trigger-props"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            React Bootstrap Docs
-          </a>.
-        </span>
-      ),
-    },
-    {
-      propType: 'popoverProps',
-      type: 'shape',
-      note: (
-        <span>
-          See
-          <a
-            href="https://react-bootstrap.github.io/components.html#popover-props"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            React Bootstrap Docs
-          </a>.
-        </span>
-      ),
+      propTypes: [
+        {
+          propType: 'children',
+          type: 'node',
+        },
+        {
+          propType: 'overlayTriggerProps',
+          type: 'shape',
+          note: (
+            <span>
+              See
+              <a
+                href="https://react-bootstrap.github.io/components.html#overlays-trigger-props"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                React Bootstrap Docs
+              </a>.
+            </span>
+          ),
+        },
+        {
+          propType: 'popoverProps',
+          type: 'shape',
+          note: (
+            <span>
+              See
+              <a
+                href="https://react-bootstrap.github.io/components.html#popover-props"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                React Bootstrap Docs
+              </a>.
+            </span>
+          ),
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/TextareaExample.jsx
+++ b/docs/examples/TextareaExample.jsx
@@ -18,19 +18,23 @@ const exampleProps = {
     </p>
   ),
   exampleCodeSnippet: '<Textarea maxLength={250} />',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'maxLength',
-      type: 'number',
-    },
-    {
-      propType: 'statusClass',
-      type: 'string',
-      defaultValue: '',
-    },
-    {
-      propType: 'onChange',
-      type: 'func',
+      propTypes: [
+        {
+          propType: 'maxLength',
+          type: 'number',
+        },
+        {
+          propType: 'statusClass',
+          type: 'string',
+          defaultValue: '',
+        },
+        {
+          propType: 'onChange',
+          type: 'func',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/TileGridExample.jsx
+++ b/docs/examples/TileGridExample.jsx
@@ -30,28 +30,33 @@ class TileGridExample extends React.PureComponent {
 
 const exampleProps = {
   componentName: 'Tile Grid',
-  exampleCodeSnippet: `<TileGrid
-  title="Browse by category"
-  items={[
-    { id: '0', classSuffix: 'news', title: 'News' },
-    { id: '1', classSuffix: 'sport', title: 'Sport' },
-    { id: '2', classSuffix: 'health', title: 'Health & Fitness' },
-    { id: '3', classSuffix: 'tech', title: 'Technology & Computing' },
-  ]}
-  onItemClick={this.onClick}
-/>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <TileGrid
+    title="Browse by category"
+    items={[
+      { id: '0', classSuffix: 'news', title: 'News' },
+      { id: '1', classSuffix: 'sport', title: 'Sport' },
+      { id: '2', classSuffix: 'health', title: 'Health & Fitness' },
+      { id: '3', classSuffix: 'tech', title: 'Technology & Computing' },
+    ]}
+    onItemClick={this.onClick}
+  />`,
+  propTypeSectionArray: [
     {
-      propType: 'title',
-      type: 'string',
-    },
-    {
-      propType: 'items',
-      type: 'arrayOf { string: id, string: classSuffix, string: title }',
-    },
-    {
-      propType: 'onItemClick',
-      type: 'func',
+      propTypes: [
+        {
+          propType: 'title',
+          type: 'string',
+        },
+        {
+          propType: 'items',
+          type: 'arrayOf { string: id, string: classSuffix, string: title }',
+        },
+        {
+          propType: 'onItemClick',
+          type: 'func',
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/TotalsExample.jsx
+++ b/docs/examples/TotalsExample.jsx
@@ -19,24 +19,27 @@ class TotalsExample extends React.PureComponent {
 const exampleProps = {
   componentName: 'Totals',
   exampleCodeSnippet: `
-    <Totals
-      toSum={[
-        { value: 10, isHidden: true },
-        { label: 'Movies Category - Medium Rectangle', value: 1000 },
-        { label: 'Selected', value: 36.80 },
-      ]}
-    />
-  `,
-  propTypes: [
+  <Totals
+    toSum={[
+      { value: 10, isHidden: true },
+      { label: 'Movies Category - Medium Rectangle', value: 1000 },
+      { label: 'Selected', value: 36.80 },
+    ]}
+  />`,
+  propTypeSectionArray: [
     {
-      propType: 'toSum',
-      type: 'arrayOf {number: value, string: label, boolean: isHidden}',
-      defaultValue: <pre>[]</pre>,
-    },
-    {
-      propType: 'valueFormatter',
-      type: 'func',
-      defaultValue: <pre>(value) =&gt; `$value`</pre>,
+      propTypes: [
+        {
+          propType: 'toSum',
+          type: 'arrayOf {number: value, string: label, boolean: isHidden}',
+          defaultValue: <pre>[]</pre>,
+        },
+        {
+          propType: 'valueFormatter',
+          type: 'func',
+          defaultValue: <pre>(value) =&gt; `$value`</pre>,
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/TreePickerExample.jsx
+++ b/docs/examples/TreePickerExample.jsx
@@ -88,206 +88,211 @@ const exampleProps = {
       selection.
     </p>
   ),
-  exampleCodeSnippet: `<TreePickerSimplePure
-  itemType={this.state.itemType}
-  hideIcon
-  selectedNodes={[]}
-  subtree={this.state.treePickerPureSubtree}
-  emptySelectedListText={<div><b>Choose items of interest</b></div>}
-  initialStateNode={<div><b>Start by searching for items</b></div>}
-  searchValue={this.state.pickerSearchValue}
-  onChange={this.setPickerSearchValue}
-  searchOnClear={this.pickerSearchOnClear}
-  additionalClassNames={this.state.pickerSearchValue ? undefined : ['background-highlighted', 'test-class']}
-/>`,
-  propTypes: [
+  exampleCodeSnippet: `
+  <TreePickerSimplePure
+    itemType={this.state.itemType}
+    hideIcon
+    selectedNodes={[]}
+    subtree={this.state.treePickerPureSubtree}
+    emptySelectedListText={<div><b>Choose items of interest</b></div>}
+    initialStateNode={<div><b>Start by searching for items</b></div>}
+    searchValue={this.state.pickerSearchValue}
+    onChange={this.setPickerSearchValue}
+    searchOnClear={this.pickerSearchOnClear}
+    additionalClassNames={this.state.pickerSearchValue ? undefined : ['background-highlighted', 'test-class']}
+  />`,
+  propTypeSectionArray: [
     {
-      propType: 'additionalClassNames',
-      type: 'arrayOf(string)',
-      note: 'Class Names for SplitPane component',
-    },
-    {
-      propType: 'breadcrumbNodes',
-      type: 'arrayOf { id: string/number, label: string }',
-      note: `returns node id. This prop is not required,
-        but an empty array is not allowed. At least one element is required in the array.`,
-    },
-    {
-      propType: 'breadcrumbOnClick',
-      type: 'func',
-      note: 'This propType creates a list of breadcrumb node',
-    },
-    {
-      propType: 'debounceInterval',
-      type: 'number',
-      defaultValue: <pre>0</pre>,
-      note: 'Interval time on search',
-    },
-    {
-      propType: 'disabled',
-      type: 'bool',
-      defaultValue: <pre>false</pre>,
-      note: 'disables treepicker including search bar',
-    },
-    {
-      propType: 'disableInclude',
-      type: 'bool',
-      note: `disables treepicker's grid item`,
-    },
-    {
-      propType: 'emptySvgSymbol',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-      note: `displays this svg symbol when there will be no item on both left or right Grid`,
-    },
-    {
-      propType: 'emptySelectedListSvgSymbol',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-      note: `displays this svg symbol when there will be no item on right Grid(Selected list)`,
-    },
-    {
-      propType: 'emptyText',
-      type: 'node',
-      note: `displays this text when there will be no item on left Grid. Prefer type 'string', but rich text can be used here.`,
-    },
-    {
-      propType: 'emptySelectedListText',
-      type: 'node',
-      note: `displays this text when there will be no item on right Grid(Selected list). Prefer type 'string', but rich text can be used here.`,
-    },
-    {
-      propType: 'expandNode',
-      type: 'func',
-      note: `triggers when clicking any item in the left Grid`,
-    },
-    {
-      propType: 'groupFormatter',
-      type: 'func',
-      note: `this function use to transform keys of the list item in the left Grid`,
-    },
-    {
-      propType: 'hideIcon',
-      type: 'bool',
-      note: `hides icon when displays empty symbol`,
-    },
-    {
-      propType: 'includeNode',
-      type: 'func',
-      note: `onclick event on '+' button of each list Item`,
-    },
-    {
-      propType: 'initialStateNode',
-      type: 'node',
-      note: 'same as emptyText',
-    },
-    {
-      propType: 'initialStateSymbol',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-      note: 'same as emptySymbol',
-    },
-    {
-      propType: 'itemType',
-      type: 'string',
-      defaultValue: <pre>'node'</pre>,
-      note: 'uses for specific className',
-    },
-    {
-      propType: 'isLoading',
-      type: 'bool',
-      defaultValue: <pre>false</pre>,
-    },
-    {
-      propType: 'nodeRenderer',
-      type: 'func',
-      note: 'uses for rendering custom node',
-    },
-    {
-      propType: 'removeNode',
-      type: 'func',
-    },
-    {
-      propType: 'onChange',
-      type: 'func',
-      note: 'onChange function triggers, when search input changes',
-    },
-    {
-      propType: 'onClear',
-      type: 'func',
-      note: 'onClear function triggers, when the user clicks the clear button on search input',
-    },
-    {
-      propType: 'onSearch',
-      type: 'func',
-      note: 'not specified',
-    },
-    {
-      propType: 'searchOnChange',
-      type: 'bool',
-      defaultValue: <pre>true</pre>,
-      note: 'When true, search is triggered as soon as the user types in the search field',
-    },
-    {
-      propType: 'searchOnEnterKey',
-      type: 'bool',
-      defaultValue: <pre>false</pre>,
-      note: 'When true, triggers search when the user presses the Enter key',
-    },
-    {
-      propType: 'searchPlaceholder',
-      type: 'string',
-    },
-    {
-      propType: 'searchValue',
-      type: 'string',
-    },
-    {
-      propType: 'selectedNodes',
-      type: 'arrayOf Treepicker Nodes',
-      note: 'required',
-    },
-    {
-      propType: 'subtree',
-      type: 'arrayOf Treepicker Nodes',
-      note: `A list of available unselected nodes. This prop is not required,
-        but an empty array is not allowed. At least one element is required in the array.`,
-    },
-    {
-      propType: 'svgSymbolCancel',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-    },
-    {
-      propType: 'svgSymbolSearch',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-example">SVG Symbol</a> prop types.
-        </span>
-      ),
-    },
-    {
-      propType: 'displayGroupHeader',
-      type: 'bool',
-      defaultValue: <pre>true</pre>,
-      note: 'e.g: Default Group',
-    },
-    {
-      propType: 'hideSearchOnRoot',
-      type: 'bool',
-      defaultValue: <pre>false</pre>,
+      propTypes: [
+        {
+          propType: 'additionalClassNames',
+          type: 'arrayOf(string)',
+          note: 'Class Names for SplitPane component',
+        },
+        {
+          propType: 'breadcrumbNodes',
+          type: 'arrayOf { id: string/number, label: string }',
+          note: `returns node id. This prop is not required,
+          but an empty array is not allowed. At least one element is required in the array.`,
+        },
+        {
+          propType: 'breadcrumbOnClick',
+          type: 'func',
+          note: 'This propType creates a list of breadcrumb node',
+        },
+        {
+          propType: 'debounceInterval',
+          type: 'number',
+          defaultValue: <pre>0</pre>,
+          note: 'Interval time on search',
+        },
+        {
+          propType: 'disabled',
+          type: 'bool',
+          defaultValue: <pre>false</pre>,
+          note: 'disables treepicker including search bar',
+        },
+        {
+          propType: 'disableInclude',
+          type: 'bool',
+          note: `disables treepicker's grid item`,
+        },
+        {
+          propType: 'emptySvgSymbol',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+          note: `displays this svg symbol when there will be no item on both left or right Grid`,
+        },
+        {
+          propType: 'emptySelectedListSvgSymbol',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+          note: `displays this svg symbol when there will be no item on right Grid(Selected list)`,
+        },
+        {
+          propType: 'emptyText',
+          type: 'node',
+          note: `displays this text when there will be no item on left Grid. Prefer type 'string', but rich text can be used here.`,
+        },
+        {
+          propType: 'emptySelectedListText',
+          type: 'node',
+          note: `displays this text when there will be no item on right Grid(Selected list). Prefer type 'string', but rich text can be used here.`,
+        },
+        {
+          propType: 'expandNode',
+          type: 'func',
+          note: `triggers when clicking any item in the left Grid`,
+        },
+        {
+          propType: 'groupFormatter',
+          type: 'func',
+          note: `this function use to transform keys of the list item in the left Grid`,
+        },
+        {
+          propType: 'hideIcon',
+          type: 'bool',
+          note: `hides icon when displays empty symbol`,
+        },
+        {
+          propType: 'includeNode',
+          type: 'func',
+          note: `onclick event on '+' button of each list Item`,
+        },
+        {
+          propType: 'initialStateNode',
+          type: 'node',
+          note: 'same as emptyText',
+        },
+        {
+          propType: 'initialStateSymbol',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+          note: 'same as emptySymbol',
+        },
+        {
+          propType: 'itemType',
+          type: 'string',
+          defaultValue: <pre>'node'</pre>,
+          note: 'uses for specific className',
+        },
+        {
+          propType: 'isLoading',
+          type: 'bool',
+          defaultValue: <pre>false</pre>,
+        },
+        {
+          propType: 'nodeRenderer',
+          type: 'func',
+          note: 'uses for rendering custom node',
+        },
+        {
+          propType: 'removeNode',
+          type: 'func',
+        },
+        {
+          propType: 'onChange',
+          type: 'func',
+          note: 'onChange function triggers, when search input changes',
+        },
+        {
+          propType: 'onClear',
+          type: 'func',
+          note: 'onClear function triggers, when the user clicks the clear button on search input',
+        },
+        {
+          propType: 'onSearch',
+          type: 'func',
+          note: 'not specified',
+        },
+        {
+          propType: 'searchOnChange',
+          type: 'bool',
+          defaultValue: <pre>true</pre>,
+          note: 'When true, search is triggered as soon as the user types in the search field',
+        },
+        {
+          propType: 'searchOnEnterKey',
+          type: 'bool',
+          defaultValue: <pre>false</pre>,
+          note: 'When true, triggers search when the user presses the Enter key',
+        },
+        {
+          propType: 'searchPlaceholder',
+          type: 'string',
+        },
+        {
+          propType: 'searchValue',
+          type: 'string',
+        },
+        {
+          propType: 'selectedNodes',
+          type: 'arrayOf Treepicker Nodes',
+          note: 'required',
+        },
+        {
+          propType: 'subtree',
+          type: 'arrayOf Treepicker Nodes',
+          note: `A list of available unselected nodes. This prop is not required,
+          but an empty array is not allowed. At least one element is required in the array.`,
+        },
+        {
+          propType: 'svgSymbolCancel',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+        },
+        {
+          propType: 'svgSymbolSearch',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+        },
+        {
+          propType: 'displayGroupHeader',
+          type: 'bool',
+          defaultValue: <pre>true</pre>,
+          note: 'e.g: Default Group',
+        },
+        {
+          propType: 'hideSearchOnRoot',
+          type: 'bool',
+          defaultValue: <pre>false</pre>,
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/UserListPickerExample.jsx
+++ b/docs/examples/UserListPickerExample.jsx
@@ -81,71 +81,75 @@ const exampleProps = {
       users={listPickerItems}
     />
   `,
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: 'allowEmptySelection',
-      type: 'bool',
-      defaultValue: 'false',
-    },
-    {
-      propType: 'avatarColor',
-      type: 'func',
-      note: 'avatarColor({ avatar, givenName, id, surname })',
-    },
-    {
-      propType: 'emptyIcon',
-      type: 'string',
-    },
-    {
-      propType: 'emptyMessage',
-      type: 'string',
-      defaultValue: 'No users.',
-    },
-    {
-      propType: 'emptySvgSymbol',
-      type: (
-        <span>
-          shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
-        </span>
-      ),
-    },
-    {
-      propType: 'initialSelection',
-      type: 'arrayOf { string: avatar, string: givenName, number: id, string: surname }',
-      defaultValue: <pre>[]</pre>,
-    },
-    {
-      propType: 'modalApply',
-      type: 'func',
-    },
-    {
-      propType: 'modalDescription',
-      type: 'string',
-      defaultValue: 'Select users.',
-    },
-    {
-      propType: 'modalClose',
-      type: 'func',
-    },
-    {
-      propType: 'modalTitle',
-      type: 'string',
-      defaultValue: 'Select Users',
-    },
-    {
-      propType: 'show',
-      type: 'bool',
-      defaultValue: 'false',
-    },
-    {
-      propType: 'userHeaders',
-      type: '{ string: label, string: toggle }',
-      defaultValue: <pre>{JSON.stringify({ label: 'Team', toggle: 'Member' })}</pre>,
-    },
-    {
-      propType: 'users',
-      type: 'arrayOf {string: avatar, string: givenName, number: id, string: surname}',
-      defaultValue: <pre>[]</pre>,
+      propTypes: [
+        {
+          propType: 'allowEmptySelection',
+          type: 'bool',
+          defaultValue: 'false',
+        },
+        {
+          propType: 'avatarColor',
+          type: 'func',
+          note: 'avatarColor({ avatar, givenName, id, surname })',
+        },
+        {
+          propType: 'emptyIcon',
+          type: 'string',
+        },
+        {
+          propType: 'emptyMessage',
+          type: 'string',
+          defaultValue: 'No users.',
+        },
+        {
+          propType: 'emptySvgSymbol',
+          type: (
+            <span>
+              shapeOf <a href="#svg-symbol-component">SVG Symbol</a> prop types.
+            </span>
+          ),
+        },
+        {
+          propType: 'initialSelection',
+          type: 'arrayOf { string: avatar, string: givenName, number: id, string: surname }',
+          defaultValue: <pre>[]</pre>,
+        },
+        {
+          propType: 'modalApply',
+          type: 'func',
+        },
+        {
+          propType: 'modalDescription',
+          type: 'string',
+          defaultValue: 'Select users.',
+        },
+        {
+          propType: 'modalClose',
+          type: 'func',
+        },
+        {
+          propType: 'modalTitle',
+          type: 'string',
+          defaultValue: 'Select Users',
+        },
+        {
+          propType: 'show',
+          type: 'bool',
+          defaultValue: 'false',
+        },
+        {
+          propType: 'userHeaders',
+          type: '{ string: label, string: toggle }',
+          defaultValue: <pre>{JSON.stringify({ label: 'Team', toggle: 'Member' })}</pre>,
+        },
+        {
+          propType: 'users',
+          type: 'arrayOf {string: avatar, string: givenName, number: id, string: surname}',
+          defaultValue: <pre>[]</pre>,
+        },
+      ],
     },
   ],
 };

--- a/docs/examples/template.jsx
+++ b/docs/examples/template.jsx
@@ -12,12 +12,17 @@ const exampleProps = {
   componentName: 'xxx',
   notes: '',
   exampleCodeSnippet: '<xxx />',
-  propTypes: [
+  propTypeSectionArray: [
     {
-      propType: '',
-      type: '',
-      defaultValue: '',
-      note: '',
+      label: '',
+      propTypes: [
+        {
+          propType: '',
+          type: '',
+          defaultValue: '',
+          note: '',
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Allow one component example to have multiple propType tables.
- Adding `GridRow` proptype table and `GridCell` proptype table to `Grid` component

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Changed example structures
Before:
``` 
propTypes: [
  {
    propType: '',
    type: '',
    defaultValue: '',
    note: '',
  },
]
```
Current: 
```
propTypeSectionArray: [
  {
    label: '',
    propTypes: [
      {
        propType: '',
        type: '',
        defaultValue: '',
        note: '',
      },
    ],
  },
]
```
So it will allow one component to have several propType tables.

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For instance, it is needed to show propType table for `GridRow` and `GridCell`, but there is no need to have isolated examples. So those propType tables need to append to `Grid` component.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![screen shot 2018-02-22 at 3 03 47 pm](https://user-images.githubusercontent.com/15777593/36522863-e8ef034e-17f2-11e8-93b8-a62f1a10a9f4.png)

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [x] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
