### PR TITLE
Fix: Button wrapper not forwarding ID Prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9400,9 +9400,9 @@
       }
     },
     "mocha": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
-      "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
+      "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "karma-webpack": "^2.0.9",
     "lint-staged": "^6.1.0",
     "minimist": "^1.2.0",
-    "mocha": "^5.0.0",
+    "mocha": "=5.0.1",
     "moment": "^2.20.1",
     "node-sass": "^4.7.2",
     "nuka-carousel": "^3.0.1",

--- a/src/components/third-party/bootstrap/Button/index.jsx
+++ b/src/components/third-party/bootstrap/Button/index.jsx
@@ -11,6 +11,13 @@ import Spinner from 'alexandria/Spinner';
 import { expandDts } from 'lib/utils';
 import './styles.scss';
 
+const AdslotButtonPropTypes = {
+  inverse: PropTypes.bool,
+  reason: PropTypes.string,
+  dts: PropTypes.string,
+  isLoading: PropTypes.bool,
+};
+
 class Button extends React.PureComponent {
   renderSpinner() {
     if (this.props.isLoading) {
@@ -45,7 +52,7 @@ class Button extends React.PureComponent {
 
     return (
       <BootstrapButton
-        {..._.pick(this.props, _.keys(BootstrapButton.propTypes))}
+        {..._.omit(this.props, _.keys(AdslotButtonPropTypes))}
         disabled={isLoading || disabled}
         className={classes}
         {...expandDts(dts)}
@@ -62,15 +69,7 @@ class Button extends React.PureComponent {
   }
 }
 
-Button.propTypes = _.assign(
-  {
-    inverse: PropTypes.bool,
-    reason: PropTypes.string,
-    dts: PropTypes.string,
-    isLoading: PropTypes.bool,
-  },
-  BootstrapButton.propTypes
-);
+Button.propTypes = _.assign(AdslotButtonPropTypes, BootstrapButton.propTypes);
 
 Button.defaultProps = {
   inverse: false,

--- a/src/components/third-party/bootstrap/Button/index.spec.jsx
+++ b/src/components/third-party/bootstrap/Button/index.spec.jsx
@@ -21,6 +21,16 @@ describe('ButtonComponent', () => {
     expect(element.prop('className')).to.equal('button-component all the-classes');
   });
 
+  it('should support valid html attributes', () => {
+    const element = shallow(
+      <Button id="button-id" data-item-name="someDataValue">
+        Test
+      </Button>
+    );
+    expect(element.prop('id')).to.equal('button-id');
+    expect(element.prop('data-item-name')).to.equal('someDataValue');
+  });
+
   it('should not duplicate btn-inverse class if both legacy and new are used', () => {
     const element = shallow(
       <Button inverse className="btn-inverse">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Omits custom wrapped props when passing to bootstrap button as id and data- attributes were being igored as these do not have to be explicitly declared in the prop type definitions.

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #703

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before
![screen shot 2018-03-13 at 12 15 41](https://user-images.githubusercontent.com/908155/37317509-5d741040-26b9-11e8-9a10-f62fed3aa3c7.png)

After
![screen shot 2018-03-13 at 12 16 11](https://user-images.githubusercontent.com/908155/37317514-63b607c4-26b9-11e8-9598-521898318172.png)


## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [Contributing](CONTRIBUTING.md) document.
- [ ] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [ ] I've squashed my commits into one.
