### PR TITLE
[ADS-973] Fix wrapAround error on 3rd party carousel lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2896,9 +2896,9 @@
       }
     },
     "create-react-class": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
-      "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
@@ -10115,12 +10115,10 @@
       }
     },
     "nuka-carousel": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nuka-carousel/-/nuka-carousel-3.0.1.tgz",
-      "integrity": "sha512-x7jyXf7ZYMVIk8WpdHMRR6UAXDVxqDDi3jxn6ZFcvGJm8/BLTpAWYZRj+fPrT+yufGM3aw4DRBZQXOdJ7OnaWA==",
+      "version": "git+https://github.com/ChaoLiangSuper/nuka-carousel.git#3c7154d9331b0d54eddfd00fe4ff18fd9432ede7",
       "dev": true,
       "requires": {
-        "create-react-class": "15.6.2",
+        "create-react-class": "15.6.3",
         "exenv": "1.2.2",
         "object-assign": "4.1.1",
         "prop-types": "15.6.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mocha": "=5.0.1",
     "moment": "^2.20.1",
     "node-sass": "^4.7.2",
-    "nuka-carousel": "^3.0.1",
+    "nuka-carousel": "https://github.com/ChaoLiangSuper/nuka-carousel.git#fix-wrap-around",
     "null-loader": "^0.1.1",
     "object-assign": "^4.1.1",
     "postcss-loader": "^2.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
~Upgrade 3rd party carousel lib to 4.0.1 and add fix commit for the first image disappear~
Tried to upgrade to 4.*, but it is not solving this bug. 
Have to fork fjaskolski's fix on (https://github.com/fjaskolski/nuka-carousel)
The version of this lib is still remaining to 3.0.1.
If this bug can be solved on version 4.* , we can upgrade to 4.* later.

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![mar-27-2018 14-48-56](https://user-images.githubusercontent.com/15777593/37945870-1286ca08-31ce-11e8-964b-9296b163c835.gif)

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [x] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
