### PR TITLE
Fix: replace <pre> with <code> to remove console errors

### DIFF
--- a/docs/components/PropTypeTable/index.jsx
+++ b/docs/components/PropTypeTable/index.jsx
@@ -26,13 +26,13 @@ class PropTypeTable extends React.PureComponent {
             {_.map(propTypes, ({ propType, type, defaultValue, note }) => (
               <tr key={propType}>
                 <td>
-                  <pre>{propType}</pre>
+                  <code>{propType}</code>
                 </td>
                 <td>
-                  <pre>{type}</pre>
+                  <code>{type}</code>
                 </td>
                 <td>
-                  <pre>{defaultValue}</pre>
+                  <code>{defaultValue}</code>
                 </td>
                 <td>{note}</td>
               </tr>

--- a/docs/examples/AlertInputExample.jsx
+++ b/docs/examples/AlertInputExample.jsx
@@ -68,9 +68,9 @@ const exampleProps = {
   componentName: 'Alert Input',
   designNotes: (
     <p>
-      <pre className="text-bold">Alert input</pre> provide direct feedback by{' '}
-      <pre className="text-orange text-bold">‘Warning’</pre> the user but not blocking them.{' '}
-      <pre className="text-red text-bold">‘Required’</pre> informing the users there is required information or they
+      <code className="text-bold">Alert input</code> provide direct feedback by{' '}
+      <code className="text-orange text-bold">‘Warning’</code> the user but not blocking them.{' '}
+      <code className="text-red text-bold">‘Required’</code> informing the users there is required information or they
       have entered incorrect information.
     </p>
   ),
@@ -121,9 +121,9 @@ const exampleProps = {
           defaultValue: 'success',
           note: (
             <span>
-              As <pre>success</pre> is assumed, and help is always displayed independently, the accepted pattern is to
-              only use <pre>warning</pre> and <pre>error</pre> feedback states with this component. Otherwise leave type
-              undefined for <pre>success</pre>.
+              As <code>success</code> is assumed, and help is always displayed independently, the accepted pattern is to
+              only use <code>warning</code> and <code>error</code> feedback states with this component. Otherwise leave
+              type undefined for <code>success</code>.
             </span>
           ),
         },

--- a/docs/examples/ButtonExample.jsx
+++ b/docs/examples/ButtonExample.jsx
@@ -85,8 +85,8 @@ export const exampleProps = {
           defaultValue: 'default',
           note: (
             <span>
-              <br />It&apos;s uncommon to use <pre>success</pre>, <pre>info</pre>, <pre>warning</pre>, or{' '}
-              <pre>danger</pre>
+              <br />It&apos;s uncommon to use <code>success</code>, <code>info</code>, <code>warning</code>, or{' '}
+              <code>danger</code>
               which are supported by Bootstrap but not us.
             </span>
           ),
@@ -112,7 +112,7 @@ export const exampleProps = {
           type: 'string',
           note: (
             <span>
-              We rarely use <pre>large</pre>, and should not use <pre>small</pre>.
+              We rarely use <code>large</code>, and should not use <code>small</code>.
             </span>
           ),
         },

--- a/docs/examples/DatePickerExample.jsx
+++ b/docs/examples/DatePickerExample.jsx
@@ -35,7 +35,7 @@ const exampleProps = {
         See <a href="https://github.com/Hacker0x01/react-datepicker">React DatePicker Documentation</a>.
       </p>
       <p>
-        For a Date Range Picker, use two Date Pickers with <pre>minDate</pre> and <pre>maxDate</pre> props for
+        For a Date Range Picker, use two Date Pickers with <code>minDate</code> and <code>maxDate</code> props for
         validation.
       </p>
     </div>

--- a/docs/examples/FilePickerExample.jsx
+++ b/docs/examples/FilePickerExample.jsx
@@ -52,7 +52,7 @@ const exampleProps = {
         {
           propType: 'onSelect',
           type: 'func',
-          note: <pre>{'onSelect({ isClosed, lastModified, lastModifiedDate, name, size, type })'}</pre>,
+          note: <code>{'onSelect({ isClosed, lastModified, lastModifiedDate, name, size, type })'}</code>,
         },
         {
           propType: 'placeholder',

--- a/docs/examples/GridExample.jsx
+++ b/docs/examples/GridExample.jsx
@@ -144,7 +144,7 @@ const exampleProps = {
         {
           propType: 'classSuffixes',
           type: 'arrayOf(String)',
-          defaultValue: <pre>[]</pre>,
+          defaultValue: <code>[]</code>,
           note: `Every element provided in this prop, will generate a className like 'grid-component-cell-something'.`,
         },
         {

--- a/docs/examples/HelpIconPopoverExample.jsx
+++ b/docs/examples/HelpIconPopoverExample.jsx
@@ -30,7 +30,7 @@ const exampleProps = {
   notes: (
     <span>
       Help text icon and popoover of rich-text. Useful in modals, accordions and page headers. For forms, use stacked{' '}
-      <pre>.help-block</pre> text.
+      <code>.help-block</code> text.
     </span>
   ),
   exampleCodeSnippet: `

--- a/docs/examples/ListPickerExample.jsx
+++ b/docs/examples/ListPickerExample.jsx
@@ -117,7 +117,7 @@ const exampleProps = {
         {
           propType: 'initialSelection',
           type: 'array',
-          defaultValue: <pre>[]</pre>,
+          defaultValue: <code>[]</code>,
         },
         {
           propType: 'itemHeaders',
@@ -130,7 +130,7 @@ const exampleProps = {
         {
           propType: 'items',
           type: 'array',
-          defaultValue: <pre>[]</pre>,
+          defaultValue: <code>[]</code>,
         },
         {
           propType: 'itemType',

--- a/docs/examples/SearchBarExample.jsx
+++ b/docs/examples/SearchBarExample.jsx
@@ -50,7 +50,7 @@ const exampleProps = {
         {
           propType: 'additionalClassNames',
           type: 'array',
-          defaultValue: <pre>[]</pre>,
+          defaultValue: <code>[]</code>,
           note: 'array of strings',
         },
         {

--- a/docs/examples/SearchExample.jsx
+++ b/docs/examples/SearchExample.jsx
@@ -71,22 +71,22 @@ const exampleProps = {
         {
           propType: 'onChange',
           type: 'func',
-          note: <pre>onChange(value)</pre>,
+          note: <code>onChange(value)</code>,
         },
         {
           propType: 'onClear',
           type: 'func',
-          note: <pre>onClear(value)</pre>,
+          note: <code>onClear(value)</code>,
         },
         {
           propType: 'onSearch',
           type: 'func',
-          note: <pre>onSearch(value)</pre>,
+          note: <code>onSearch(value)</code>,
         },
         {
           propType: 'placeholder',
           type: 'string',
-          defaultValue: <pre>&apos;&apos;</pre>,
+          defaultValue: <code>&apos;&apos;</code>,
         },
         {
           propType: 'svgSymbolCancel',
@@ -97,10 +97,14 @@ const exampleProps = {
           ),
           defaultValue: (
             <pre>
-              {JSON.stringify({
-                classSuffixes: ['gray-darker'],
-                href: './docs/assets/svg-symbols.svg#cancel',
-              })}
+              {JSON.stringify(
+                {
+                  classSuffixes: ['gray-darker'],
+                  href: './docs/assets/svg-symbols.svg#cancel',
+                },
+                null,
+                2
+              )}
             </pre>
           ),
         },
@@ -113,17 +117,21 @@ const exampleProps = {
           ),
           defaultValue: (
             <pre>
-              {JSON.stringify({
-                classSuffixes: ['gray-light'],
-                href: './docs/assets/svg-symbols.svg#search',
-              })}
+              {JSON.stringify(
+                {
+                  classSuffixes: ['gray-light'],
+                  href: './docs/assets/svg-symbols.svg#search',
+                },
+                null,
+                2
+              )}
             </pre>
           ),
         },
         {
           propType: 'value',
           type: 'string',
-          defaultValue: <pre>&apos;&apos;</pre>,
+          defaultValue: <code>&apos;&apos;</code>,
           note: 'As value within search component is uncontrolled we need to pass in the search value externally.',
         },
         {

--- a/docs/examples/SliceyExample.jsx
+++ b/docs/examples/SliceyExample.jsx
@@ -33,7 +33,7 @@ const exampleProps = {
           note: (
             <span>
               Slicey will represent all values as percentage of the pie based on the sum of all values. Label will
-              provide a className to each slice as <pre>.arc-component-{'${label}'}</pre>.
+              provide a className to each slice as <code>.arc-component-{'${label}'}</code>.
             </span>
           ),
         },

--- a/docs/examples/SplitPaneExample.jsx
+++ b/docs/examples/SplitPaneExample.jsx
@@ -34,7 +34,7 @@ const exampleProps = {
         {
           propType: 'additionalClassNames',
           type: 'array',
-          defaultValue: <pre>[]</pre>,
+          defaultValue: <code>[]</code>,
         },
         {
           propType: 'children',

--- a/docs/examples/TotalsExample.jsx
+++ b/docs/examples/TotalsExample.jsx
@@ -32,12 +32,12 @@ const exampleProps = {
         {
           propType: 'toSum',
           type: 'arrayOf {number: value, string: label, boolean: isHidden}',
-          defaultValue: <pre>[]</pre>,
+          defaultValue: <code>[]</code>,
         },
         {
           propType: 'valueFormatter',
           type: 'func',
-          defaultValue: <pre>(value) =&gt; `$value`</pre>,
+          defaultValue: <code>(value) =&gt; `$value`</code>,
         },
       ],
     },

--- a/docs/examples/TreePickerExample.jsx
+++ b/docs/examples/TreePickerExample.jsx
@@ -123,13 +123,13 @@ const exampleProps = {
         {
           propType: 'debounceInterval',
           type: 'number',
-          defaultValue: <pre>0</pre>,
+          defaultValue: <code>0</code>,
           note: 'Interval time on search',
         },
         {
           propType: 'disabled',
           type: 'bool',
-          defaultValue: <pre>false</pre>,
+          defaultValue: <code>false</code>,
           note: 'disables treepicker including search bar',
         },
         {
@@ -202,13 +202,13 @@ const exampleProps = {
         {
           propType: 'itemType',
           type: 'string',
-          defaultValue: <pre>'node'</pre>,
+          defaultValue: <code>'node'</code>,
           note: 'uses for specific className',
         },
         {
           propType: 'isLoading',
           type: 'bool',
-          defaultValue: <pre>false</pre>,
+          defaultValue: <code>false</code>,
         },
         {
           propType: 'nodeRenderer',
@@ -237,13 +237,13 @@ const exampleProps = {
         {
           propType: 'searchOnChange',
           type: 'bool',
-          defaultValue: <pre>true</pre>,
+          defaultValue: <code>true</code>,
           note: 'When true, search is triggered as soon as the user types in the search field',
         },
         {
           propType: 'searchOnEnterKey',
           type: 'bool',
-          defaultValue: <pre>false</pre>,
+          defaultValue: <code>false</code>,
           note: 'When true, triggers search when the user presses the Enter key',
         },
         {
@@ -284,13 +284,13 @@ const exampleProps = {
         {
           propType: 'displayGroupHeader',
           type: 'bool',
-          defaultValue: <pre>true</pre>,
+          defaultValue: <code>true</code>,
           note: 'e.g: Default Group',
         },
         {
           propType: 'hideSearchOnRoot',
           type: 'bool',
-          defaultValue: <pre>false</pre>,
+          defaultValue: <code>false</code>,
         },
       ],
     },

--- a/docs/examples/UserListPickerExample.jsx
+++ b/docs/examples/UserListPickerExample.jsx
@@ -114,7 +114,7 @@ const exampleProps = {
         {
           propType: 'initialSelection',
           type: 'arrayOf { string: avatar, string: givenName, number: id, string: surname }',
-          defaultValue: <pre>[]</pre>,
+          defaultValue: <code>[]</code>,
         },
         {
           propType: 'modalApply',
@@ -142,12 +142,12 @@ const exampleProps = {
         {
           propType: 'userHeaders',
           type: '{ string: label, string: toggle }',
-          defaultValue: <pre>{JSON.stringify({ label: 'Team', toggle: 'Member' })}</pre>,
+          defaultValue: <code>{JSON.stringify({ label: 'Team', toggle: 'Member' })}</code>,
         },
         {
           propType: 'users',
           type: 'arrayOf {string: avatar, string: givenName, number: id, string: surname}',
-          defaultValue: <pre>[]</pre>,
+          defaultValue: <code>[]</code>,
         },
       ],
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The console was full of errors complaining that `<pre>` elements cannot be contained inside `<p>` elements. Also, we were using `<pre>` as inline elements in a lot of places, which it's not meant to do. This PR replaces all inline instances of `<pre>` with `<code>` elements. 

## Motivation and Background Context
Errors in the console are bad.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only the documentation has been changed, so it won't affect any functionality.

## Screenshots (if appropriate):

### Before

<img width="1426" alt="pre-in-p 01 before" src="https://user-images.githubusercontent.com/3327105/39159600-c17e1d7c-47a9-11e8-91ff-65ccd2fea4a5.png">

### After

<img width="1426" alt="pre-in-p 02 after" src="https://user-images.githubusercontent.com/3327105/39159601-c1ab5d5a-47a9-11e8-8433-bb5e3b5520d3.png">


## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [ ] I've squashed my commits into one.
