### PR TITLE
Fix checkbox for accepting multiple line label

### DIFF
--- a/docs/examples/CheckboxExample.jsx
+++ b/docs/examples/CheckboxExample.jsx
@@ -51,7 +51,7 @@ const exampleProps = {
         },
         {
           propType: 'label',
-          type: 'string',
+          type: 'node',
         },
         {
           propType: 'value',

--- a/src/components/adslot-ui/Checkbox/index.jsx
+++ b/src/components/adslot-ui/Checkbox/index.jsx
@@ -41,12 +41,12 @@ class Checkbox extends React.Component {
 
     return (
       <div className="checkbox-component" {...expandDts(dts)}>
-        <span className={`selection-component-icon icheckbox${this.state.checked ? ' checked' : ''}`} />
         <label>
           <div className="checkbox-component-input-container">
+            <span className={`selection-component-icon icheckbox${this.state.checked ? ' checked' : ''}`} />
             <input {...checkboxInputProps} />
           </div>
-          {label ? <span>{label}</span> : null}
+          {label ? <div className="checkbox-component-label">{label}</div> : null}
         </label>
       </div>
     );

--- a/src/components/adslot-ui/Checkbox/styles.scss
+++ b/src/components/adslot-ui/Checkbox/styles.scss
@@ -3,14 +3,13 @@
 .checkbox-component {
   label {
     line-height: 18px;
-    margin-left: -16px;
     font-weight: $font-weight-light;
     cursor: pointer;
+  }
 
-    span {
-      margin-left: 5px;
-      vertical-align: bottom;
-    }
+  .checkbox-component-label {
+    display: inline-block;
+    margin-left: 5px;
   }
 
   .checkbox-component-input-container {
@@ -18,19 +17,14 @@
     height: 18px;
     display: inline-block;
     position: relative;
-    vertical-align: middle;
-  }
+    vertical-align: top;
 
-  input {
-    position: absolute;
-    display: block;
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    background: $color-background;
-    border: 0;
-    opacity: 0;
-    cursor: pointer;
+    span {
+      vertical-align: middle;
+    }
+
+    input {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Fix checkbox alignment issue, when the label has multiple lines 
- Change label's propType from `string` to `node`

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

### Before
![screen shot 2018-07-13 at 11 42 09 am](https://user-images.githubusercontent.com/15777593/42668043-e9e83f50-8691-11e8-9622-7057bfe02630.png)

### After 
![screen shot 2018-07-13 at 11 37 05 am](https://user-images.githubusercontent.com/15777593/42668063-02f4e52a-8692-11e8-8a7c-d09897a651ce.png)


## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
