### PR TITLE
Upgrade: react-datepicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10386,9 +10386,9 @@
       "dev": true
     },
     "popper.js": {
-      "version": "1.12.9",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
-      "integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM=",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.4.tgz",
+      "integrity": "sha1-juwdj/AqWjoVLdQ0FKFce3n9abY=",
       "dev": true
     },
     "portfinder": {
@@ -12815,15 +12815,13 @@
       }
     },
     "react-datepicker": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-1.1.0.tgz",
-      "integrity": "sha512-PG7+VGMvF2nxlhkqKt+oiJaAyXG/icvpXTOK4M2aYhmkOsHvOtH2PZ/0XKsLJQvbSr6XPIlzOsQlRUEtvvlzUg==",
+      "version": "git+https://github.com/Adslot/react-datepicker.git#6f912842e7dcec6a6e8ff43fd0e3e79af84a8ba6",
       "dev": true,
       "requires": {
         "classnames": "2.2.5",
         "prop-types": "15.6.1",
         "react-onclickoutside": "6.7.1",
-        "react-popper": "0.7.5"
+        "react-popper": "0.9.5"
       }
     },
     "react-deep-force-update": {
@@ -12885,12 +12883,12 @@
       }
     },
     "react-popper": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
-      "integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.9.5.tgz",
+      "integrity": "sha1-AqJO8+7DOvnlToNYq3DrDjMe3QU=",
       "dev": true,
       "requires": {
-        "popper.js": "1.12.9",
+        "popper.js": "1.14.4",
         "prop-types": "15.6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "prettier-check": "^2.0.0",
     "prop-types": "^15.6.1",
     "react-bootstrap": "^0.31.5",
-    "react-datepicker": "^1.1.0",
+    "react-datepicker": "https://github.com/Adslot/react-datepicker.git",
     "react-hot-loader": "^3.1.3",
     "react-redux": "^5.0.6",
     "react-select": "^1.2.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

Use our forked version of react-datepicker to support ref object for `customInputRef`.

Migration:

`customInputRef`: should now be a `React.createRef()`, instead of long deprecated string refs.

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [ ] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
