### PR TITLE
Fix: remove checkbox and radio gDSFP

### DIFF
--- a/docs/examples/CheckboxExample.jsx
+++ b/docs/examples/CheckboxExample.jsx
@@ -3,11 +3,22 @@ import React from 'react';
 import Example from '../components/Example';
 import { Checkbox } from '../../src';
 
-const onChange = (value, event, name) => {
-  _.noop();
-};
-
 class CheckboxExample extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isChecked: false,
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange() {
+    this.setState(prevState => ({
+      isChecked: !prevState.isChecked,
+    }));
+  }
+
   render() {
     return (
       <Checkbox
@@ -15,7 +26,8 @@ class CheckboxExample extends React.PureComponent {
         label="Label goes here"
         value="Value goes here"
         dts="data-test-selector-goes-here"
-        onChange={onChange}
+        onChange={this.handleChange}
+        checked={this.state.isChecked}
       />
     );
   }
@@ -25,12 +37,12 @@ const exampleProps = {
   componentName: 'Checkbox',
   notes: '',
   exampleCodeSnippet: `<Checkbox
-	name="Name goes here"
-	label="Label goes here"
-	value="Value goes here"
-	checked={true}
-	disabled={true}
-	dts="data-test-selector-goes-here"
+  name="Name goes here"
+  label="Label goes here"
+  value="Value goes here"
+  dts="data-test-selector-goes-here"
+  onChange={this.handleChange}
+  checked={this.state.isChecked}
 />`,
   propTypeSectionArray: [
     {

--- a/docs/examples/CheckboxGroupExample.jsx
+++ b/docs/examples/CheckboxGroupExample.jsx
@@ -3,19 +3,19 @@ import React from 'react';
 import Example from '../components/Example';
 import { CheckboxGroup, Checkbox } from '../../src';
 
-const onChangeGroup = (value, event, name) => {
-  _.noop();
-};
-
-const onChangeIndividual = (value, event, name) => {
-  _.noop();
-};
-
 class CheckboxGroupExample extends React.PureComponent {
+  handleGroupChange(checked) {
+    console.log(checked);
+  }
+
+  handleIndividualChange(event) {
+    console.log(event.target.value);
+  }
+
   render() {
     return (
-      <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={onChangeGroup}>
-        <Checkbox label="The Terminator" value="terminator" onChange={onChangeIndividual} />
+      <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={this.handleGroupChange}>
+        <Checkbox label="The Terminator" value="terminator" onChange={this.handleIndividualChange} />
         <Checkbox label="Predator" value="predator" />
         <Checkbox label="The Sound of Music" value="soundofmusic" />
       </CheckboxGroup>

--- a/docs/examples/RadioExample.jsx
+++ b/docs/examples/RadioExample.jsx
@@ -3,8 +3,19 @@ import Example from '../components/Example';
 import Radio from 'adslot-ui/Radio';
 
 class RadioExample extends React.PureComponent {
-  onChange(event) {
-    _.noop();
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isSelected: false,
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange() {
+    this.setState(prevState => ({
+      isSelected: !prevState.isSelected,
+    }));
   }
 
   render() {
@@ -14,7 +25,8 @@ class RadioExample extends React.PureComponent {
         label="Radio button label"
         dts="radio-button-data-test-selector"
         value="Radio button value"
-        onChange={this.onChange}
+        checked={this.state.isSelected}
+        onChange={this.handleChange}
       />
     );
   }
@@ -28,7 +40,8 @@ const exampleProps = {
   label="Radio button label"
   dts="radio-button-data-test-selector"
   value="Radio button value"
-  onChange={this.onChange}
+  checked={this.state.isSelected}
+  onChange={this.handleChange}
 />`,
   propTypeSectionArray: [
     {

--- a/docs/examples/RadioGroupExample.jsx
+++ b/docs/examples/RadioGroupExample.jsx
@@ -4,19 +4,19 @@ import RadioGroup from 'adslot-ui/RadioGroup';
 import Radio from 'adslot-ui/Radio';
 
 class RadioGroupExample extends React.PureComponent {
-  onChangeGroup(event) {
-    _.noop();
+  handleGroupChange(value) {
+    console.log(value);
   }
 
-  onChangeIndividual(event) {
-    _.noop();
+  handleIndividualChange(event) {
+    console.log(event.target.value);
   }
 
   render() {
     return (
-      <RadioGroup name="hobbies" value="badminton" onChange={this.onChangeGroup} dts="radio-group-dts">
+      <RadioGroup name="hobbies" value="badminton" onChange={this.handleGroupChange} dts="radio-group-dts">
         <Radio value="swimming" label="Swimming" dts="radio-dts" />
-        <Radio value="soccer" label="Soccer" onChange={this.onChangeIndividual} />
+        <Radio value="soccer" label="Soccer" onChange={this.handleIndividualChange} />
         <Radio value="badminton" label="Badminton" />
       </RadioGroup>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -821,7 +821,7 @@
     "babel-loader": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
-      "integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
+      "integrity": "sha1-9svhInEPGqKvTYgcbVtUNYyiQSY=",
       "dev": true,
       "requires": {
         "find-cache-dir": "1.0.0",
@@ -3638,7 +3638,7 @@
         "object.values": "1.0.4",
         "prop-types": "15.6.1",
         "react-reconciler": "0.7.0",
-        "react-test-renderer": "16.3.2"
+        "react-test-renderer": "16.4.2"
       }
     },
     "enzyme-adapter-utils": {
@@ -3980,7 +3980,7 @@
     "eslint-loader": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.9.0.tgz",
-      "integrity": "sha512-40aN976qSNPyb9ejTqjEthZITpls1SVKtwguahmH1dzGCwQU/vySE+xX33VZmD8csU0ahVNCtFlsPgKqRBiqgg==",
+      "integrity": "sha1-fhvp/t3KMo09z67xrUnVvv/oOhM=",
       "dev": true,
       "requires": {
         "loader-fs-cache": "1.0.1",
@@ -4400,7 +4400,7 @@
         "setprototypeof": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
           "dev": true
         },
         "statuses": {
@@ -6702,12 +6702,6 @@
         "strip-indent": "2.0.0"
       }
     },
-    "icheck": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/icheck/-/icheck-1.0.2.tgz",
-      "integrity": "sha1-BtCNo9R65EjBU7Jjm4bprX/fcSg=",
-      "dev": true
-    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -7500,7 +7494,7 @@
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -12792,9 +12786,9 @@
       }
     },
     "react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
+      "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -12839,9 +12833,9 @@
       "dev": true
     },
     "react-dom": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
-      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
+      "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -12862,27 +12856,6 @@
         "source-map": "0.6.1"
       }
     },
-    "react-icheck": {
-      "version": "git://github.com/omgaz/react-icheck.git#b764cbf852f8d39ffe83760637e4831f042c1a8b",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "5.8.38",
-        "classnames": "2.2.5",
-        "icheck": "1.0.2",
-        "prop-types": "15.6.1"
-      },
-      "dependencies": {
-        "babel-runtime": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-          "dev": true,
-          "requires": {
-            "core-js": "1.2.7"
-          }
-        }
-      }
-    },
     "react-input-autosize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
@@ -12891,12 +12864,6 @@
       "requires": {
         "prop-types": "15.6.1"
       }
-    },
-    "react-is": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.3.2.tgz",
-      "integrity": "sha512-ybEM7YOr4yBgFd6w8dJqwxegqZGJNBZl6U27HnGKuTZmDvVrD5quWOK/wAnMywiZzW+Qsk+l4X2c70+thp/A8Q==",
-      "dev": true
     },
     "react-onclickoutside": {
       "version": "6.7.1",
@@ -12987,15 +12954,23 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.3.2.tgz",
-      "integrity": "sha512-lL8WHIpCTMdSe+CRkt0rfMxBkJFyhVrpdQ54BaJRIrXf9aVmbeHbRA8GFRpTvohPN5tPzMabmrzW2PUfWCfWwQ==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.2.tgz",
+      "integrity": "sha512-vdTPnRMDbxfv4wL4lzN4EkVGXyYs7LE2uImOsqh1FKiP6L5o1oJl8nore5sFi9vxrP9PK3l4rgb/fZ4PVUaWSA==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "object-assign": "4.1.1",
         "prop-types": "15.6.1",
-        "react-is": "16.3.2"
+        "react-is": "16.4.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.4.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.2.tgz",
+          "integrity": "sha512-rI3cGFj/obHbBz156PvErrS5xc6f1eWyTwyV4mo0vF2lGgXgS+mm7EKD5buLJq6jNgIagQescGSVG2YzgXt8Yg==",
+          "dev": true
+        }
       }
     },
     "react-tween-state": {
@@ -14276,7 +14251,7 @@
     "sass-loader": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
-      "integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
+      "integrity": "sha1-6dXmwfFV+qMqSybXqbcQfCJeQPk=",
       "dev": true,
       "requires": {
         "async": "2.6.0",
@@ -14359,7 +14334,7 @@
     "send": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "integrity": "sha1-pw4coh0TgsEdDZ9iMd6ygQgNerM=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -14430,7 +14405,7 @@
     "serve-static": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "integrity": "sha1-TFfVNASnYdjy58HooYpH2/J4pxk=",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.1",
@@ -16546,7 +16521,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -16608,7 +16583,7 @@
         "timers-browserify": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-          "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+          "integrity": "sha1-lspT9LeUpefA4b18yIo3Ipj6AeY=",
           "dev": true,
           "requires": {
             "setimmediate": "1.0.5"

--- a/package.json
+++ b/package.json
@@ -106,11 +106,10 @@
     "react-bootstrap": "^0.31.5",
     "react-datepicker": "^1.1.0",
     "react-hot-loader": "^3.1.3",
-    "react-icheck": "git://github.com/omgaz/react-icheck.git#issue-45-patch-for-react-16-release",
     "react-redux": "^5.0.6",
     "react-select": "^1.2.1",
     "react-syntax-highlighter": "^7.0.0",
-    "react-test-renderer": "^16.3.2",
+    "react-test-renderer": "^16.4.2",
     "redux": "^3.7.2",
     "rimraf": "^2.6.2",
     "sass-lint": "^1.12.1",
@@ -128,8 +127,8 @@
     "diff-match-patch": "^1.0.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.5",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2"
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2"
   },
   "engines": {
     "node": ">=6 <9"

--- a/src/components/adslot-ui/Checkbox/index.jsx
+++ b/src/components/adslot-ui/Checkbox/index.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 import classnames from 'classnames';
 import { expandDts } from '../../../lib/utils';
@@ -5,54 +6,37 @@ import { checkboxPropTypes } from '../../prop-types/inputPropTypes';
 import './styles.scss';
 
 class Checkbox extends React.Component {
-  static getDerivedStateFromProps(newProps, prevState) {
-    return newProps.checked === prevState.checked
-      ? null
-      : {
-          checked: newProps.checked,
-        };
-  }
-
   constructor(props) {
     super(props);
-    this.state = { checked: props.checked };
+
     this.onChangeDefault = this.onChangeDefault.bind(this);
   }
 
   onChangeDefault(event) {
-    const isChecked = Boolean(event.target.checked);
-    this.setState(() => ({ checked: isChecked }));
-    if (this.props.onChange) {
-      this.props.onChange(event, this.props.name);
-    }
+    this.props.onChange(event, this.props.name);
   }
 
   render() {
-    const { name, value, label, dts, disabled, id, className, inline } = this.props;
-    const checkboxInputProps = {
-      type: 'checkbox',
-      name,
-      checked: this.state.checked,
-      disabled,
-      onChange: this.onChangeDefault,
-      value,
-      id,
-      className,
-    };
+    const { name, value, label, dts, disabled, checked, id, className, inline } = this.props;
 
-    const componentClassName = classnames([
-      'checkbox-component',
-      {
-        'checkbox-component-inline': inline,
-      },
-    ]);
+    const componentClassName = classnames(['checkbox-component', { 'checkbox-component-inline': inline }]);
+    const iconClassName = classnames(['selection-component-icon', 'icheckbox', { checked }]);
 
     return (
       <div className={componentClassName} {...expandDts(dts)}>
         <label>
           <div className="checkbox-component-input-container">
-            <span className={`selection-component-icon icheckbox${this.state.checked ? ' checked' : ''}`} />
-            <input {...checkboxInputProps} />
+            <span className={iconClassName} />
+            <input
+              type="checkbox"
+              name={name}
+              checked={checked}
+              disabled={disabled}
+              onChange={this.onChangeDefault}
+              value={value}
+              id={id}
+              className={className}
+            />
           </div>
           {label ? <div className="checkbox-component-label">{label}</div> : null}
         </label>
@@ -67,6 +51,7 @@ Checkbox.defaultProps = {
   dts: '',
   disabled: false,
   checked: false,
+  onChange: _.noop,
 };
 
 export default Checkbox;

--- a/src/components/adslot-ui/Checkbox/index.spec.jsx
+++ b/src/components/adslot-ui/Checkbox/index.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import Checkbox from '.';
 
@@ -30,10 +30,8 @@ describe('Checkbox', () => {
     const onChangeHandler = sinon.spy();
     const component = shallow(<Checkbox onChange={onChangeHandler} />);
     const checkboxElement = component.find('input[type="checkbox"]');
-    const event = { target: { checked: true } };
-    checkboxElement.simulate('change', event);
+    checkboxElement.simulate('change');
     expect(onChangeHandler.callCount).to.equal(1);
-    expect(component.state()).to.eql({ checked: true });
   });
 
   it('should render with id, className', () => {
@@ -43,60 +41,10 @@ describe('Checkbox', () => {
     expect(component.find('#checkboxId')).to.have.length(1);
   });
 
-  it('should handle change event', () => {
-    const onChangeHandler = sinon.spy();
-    const component = shallow(
-      <Checkbox
-        label="The Terminator"
-        name="movies"
-        value="terminator"
-        onChange={onChangeHandler}
-        dts="checkbox-terminator"
-      />
-    );
-    const checkboxElement = component.find('input[type="checkbox"]');
-    const event = { target: { checked: true } };
-    checkboxElement.simulate('change', event);
-    expect(onChangeHandler.callCount).to.equal(1);
-    expect(component.state()).to.eql({ checked: true });
-  });
-
   it('should render without a label', () => {
     const component = shallow(<Checkbox name="movies" value="terminator" />);
     const labelElement = component.find('label');
     expect(labelElement.text()).to.equal('');
-  });
-
-  it('should render with checked and disabled states', () => {
-    const component = shallow(
-      <Checkbox
-        name="movies"
-        value="terminator"
-        checked={true} // eslint-disable-line
-        disabled={true} // eslint-disable-line
-      />
-    );
-    expect(component.state()).to.eql({ checked: true });
-  });
-
-  it('should handle change events without a custom onChange handler', () => {
-    const component = shallow(<Checkbox name="movies" value="terminator" />);
-    const checkboxElement = component.find('input[type="checkbox"]');
-    const event = { target: { checked: true } };
-    checkboxElement.simulate('change', event);
-    expect(component.state()).to.eql({ checked: true });
-  });
-
-  it('should handle props changes', () => {
-    const component = mount(<Checkbox name="movies" value="terminator" />);
-    component.setProps({ checked: true });
-    expect(component.state()).to.eql({ checked: true });
-  });
-
-  it('should handle props changes when no relevant props are given', () => {
-    const component = mount(<Checkbox name="movies" value="terminator" />);
-    component.setProps({ foo: 'bar' });
-    expect(component.state()).to.eql({ checked: false });
   });
 
   it('should add inline class when inline prop in true', () => {

--- a/src/components/adslot-ui/CheckboxGroup/index.spec.jsx
+++ b/src/components/adslot-ui/CheckboxGroup/index.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { Checkbox } from 'adslot-ui';
 import CheckboxGroup from '.';
 
@@ -17,7 +17,7 @@ describe('CheckboxGroup', () => {
     expect(component.hasClass('custom-class')).to.equal(true);
     const childCheckboxes = component.find('Checkbox');
     expect(childCheckboxes.length).to.equal(3);
-    expect(component.state().value).to.eql({ terminator: true, predator: true, soundofmusic: false });
+    expect(component.state().checkedValues).to.eql(['terminator', 'predator']);
   });
 
   it('should handle checkbox change events', () => {
@@ -32,10 +32,8 @@ describe('CheckboxGroup', () => {
     );
 
     const childCheckboxes = component.find('Checkbox');
-    const firstChild = childCheckboxes.at(0);
-    const event = { target: { value: 'terminator', checked: false } };
-    firstChild.simulate('change', event);
-    expect(component.state().value).to.eql({ terminator: false, predator: true, soundofmusic: false });
+    childCheckboxes.at(0).simulate('change', { currentTarget: { value: 'terminator' } });
+    expect(component.state().checkedValues).to.eql(['predator']);
     expect(onChangeGroup.callCount).to.equal(1);
     expect(onChangeIndividual.callCount).to.equal(1);
   });
@@ -54,7 +52,6 @@ describe('CheckboxGroup', () => {
   });
 
   it('should handle change events without a custom onChange handler', () => {
-    const event = { target: { value: 'terminator', checked: true } };
     const component = shallow(
       <CheckboxGroup name="movies">
         <Checkbox label="The Terminator" value="terminator" />
@@ -63,31 +60,7 @@ describe('CheckboxGroup', () => {
       </CheckboxGroup>
     );
     const firstChild = component.find('Checkbox').at(0);
-    firstChild.simulate('change', event);
-    expect(component.state().value).to.eql({ terminator: true, predator: false, soundofmusic: false });
-  });
-
-  it('should handle props changes', () => {
-    const component = mount(
-      <CheckboxGroup name="movies" value={['terminator', 'predator']} className="custom-class">
-        <Checkbox label="The Terminator" value="terminator" />
-        <Checkbox label="Predator" value="predator" />
-        <Checkbox label="The Sound of Music" value="soundofmusic" />
-      </CheckboxGroup>
-    );
-    component.setProps({ value: ['terminator', 'soundofmusic'] });
-    expect(component.state().value).to.eql({ terminator: true, predator: false, soundofmusic: true });
-  });
-
-  it('should handle props changes when no value is given', () => {
-    const component = mount(
-      <CheckboxGroup name="movies" value={['terminator', 'predator']} className="custom-class">
-        <Checkbox label="The Terminator" value="terminator" />
-        <Checkbox label="Predator" value="predator" />
-        <Checkbox label="The Sound of Music" value="soundofmusic" />
-      </CheckboxGroup>
-    );
-    component.setProps({});
-    expect(component.state().value).to.eql({ terminator: true, predator: true, soundofmusic: false });
+    firstChild.simulate('change', { currentTarget: { value: 'terminator' } });
+    expect(component.state().checkedValues).to.eql(['terminator']);
   });
 });

--- a/src/components/adslot-ui/Radio/index.jsx
+++ b/src/components/adslot-ui/Radio/index.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 import classnames from 'classnames';
 import { expandDts } from '../../../lib/utils';
@@ -5,50 +6,37 @@ import { radioButtonPropTypes } from '../../prop-types/inputPropTypes';
 import './styles.scss';
 
 class RadioButton extends React.Component {
-  static getDerivedStateFromProps(newProps, prevState) {
-    return newProps.checked === prevState.checked ? null : { checked: newProps.checked };
-  }
-
   constructor(props) {
     super(props);
-    this.state = { checked: props.checked };
 
     this.onChangeDefault = this.onChangeDefault.bind(this);
   }
 
   onChangeDefault(event) {
-    this.setState({ checked: Boolean(event.target.checked) });
-    if (this.props.onChange) {
-      this.props.onChange(event);
-    }
+    this.props.onChange(event);
   }
 
   render() {
-    const { name, className, label, dts, disabled, id, value, inline } = this.props;
-    const radioInputProps = {
-      type: 'radio',
-      name,
-      checked: this.state.checked,
-      disabled,
-      onChange: this.onChangeDefault,
-      value,
-      id,
-      className,
-    };
+    const { name, className, label, dts, disabled, checked, id, value, inline } = this.props;
 
-    const componentClassName = classnames([
-      'radio-component',
-      {
-        'radio-component-inline': inline,
-      },
-    ]);
+    const componentClassName = classnames(['radio-component', { 'radio-component-inline': inline }]);
+    const iconClassName = classnames(['selection-component-icon', 'iradio', { checked }]);
 
     return (
       <div className={componentClassName} {...expandDts(dts)}>
         <label>
           <div className="radio-component-input-container">
-            <span className={`selection-component-icon iradio${this.state.checked ? ' checked' : ''}`} />
-            <input {...radioInputProps} />
+            <span className={iconClassName} />
+            <input
+              type="radio"
+              name={name}
+              checked={checked}
+              disabled={disabled}
+              onClick={this.onChangeDefault}
+              value={value}
+              id={id}
+              className={className}
+            />
           </div>
           {label ? <div className="radio-component-label">{label}</div> : null}
         </label>
@@ -63,6 +51,7 @@ RadioButton.defaultProps = {
   dts: '',
   disabled: false,
   checked: false,
+  onChange: _.noop,
 };
 
 export default RadioButton;

--- a/src/components/adslot-ui/Radio/index.spec.jsx
+++ b/src/components/adslot-ui/Radio/index.spec.jsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
@@ -37,47 +36,10 @@ describe('<Radio />', () => {
     expect(component.text()).to.equal('');
   });
 
-  it('should trigger state change and `props.onChange` when change event is triggered', () => {
+  it('should trigger `props.onChange` when the radio button is clicked', () => {
     const component = shallow(<Radio {...props} />);
-    const event = { target: { checked: true } };
-
-    expect(component.state('checked')).to.equal(false);
-
-    component.find('input').simulate('change', event);
-    expect(component.state('checked')).to.equal(true);
+    component.find('input').simulate('click');
     expect(props.onChange.calledOnce).to.equal(true);
-  });
-
-  it('should still trigger state change when `props.onChange` is not present', () => {
-    delete props.onChange;
-    const component = shallow(<Radio {...props} />);
-    const event = { target: { checked: true } };
-
-    expect(component.state('checked')).to.equal(false);
-
-    component.find('input').simulate('change', event);
-    expect(component.state('checked')).to.equal(true);
-  });
-
-  it('should override state value when `prop.value` changes', () => {
-    const component = shallow(<Radio {...props} />);
-    expect(component.state('checked')).to.equal(false);
-
-    props.checked = true;
-    component.setProps(props);
-    expect(component.state('checked')).to.equal(true);
-  });
-
-  it('should NOT override state value when other props change', () => {
-    const component = shallow(<Radio {...props} />);
-    expect(component.state('checked')).to.equal(false);
-
-    _.assign(props, {
-      name: 'some-other-name',
-      label: 'New Label',
-    });
-    component.setProps(props);
-    expect(component.state('checked')).to.equal(false);
   });
 
   it('should add inline class when inline prop in true', () => {

--- a/src/components/adslot-ui/RadioGroup/index.jsx
+++ b/src/components/adslot-ui/RadioGroup/index.jsx
@@ -1,13 +1,10 @@
 import _ from 'lodash';
 import React from 'react';
+import classnames from 'classnames';
 import { expandDts } from '../../../lib/utils';
 import { radioGroupPropTypes } from '../../prop-types/inputPropTypes';
 
 class RadioGroup extends React.Component {
-  static getDerivedStateFromProps(nextProps, prevState) {
-    return nextProps.value === prevState.value ? null : { value: nextProps.value };
-  }
-
   constructor(props) {
     super(props);
 
@@ -20,10 +17,9 @@ class RadioGroup extends React.Component {
   }
 
   onChangeDefault(event) {
-    this.setState({ value: event.target.value });
-    if (this.props.onChange) {
-      this.props.onChange(event);
-    }
+    const newValue = event.currentTarget.value;
+    this.setState({ value: newValue });
+    this.props.onChange(newValue);
   }
 
   renderChildren() {
@@ -32,7 +28,7 @@ class RadioGroup extends React.Component {
         name: this.props.name,
         checked: this.state.value === child.props.value,
         onChange: (...args) => {
-          if (child.props.onChange) child.props.onChange(...args);
+          child.props.onChange(...args);
           this.onChangeDefault(...args);
         },
         inline: this.props.inline,
@@ -44,15 +40,10 @@ class RadioGroup extends React.Component {
 
   render() {
     const { dts, className, id } = this.props;
-    const componentProps = {
-      id,
-      className: _(['radio-group-component', className])
-        .compact()
-        .join(' '),
-    };
+    const classNames = classnames(['radio-group-component', className]);
 
     return (
-      <div {...componentProps} {...expandDts(dts)}>
+      <div id={id} className={classNames} {...expandDts(dts)}>
         {this.renderChildren()}
       </div>
     );
@@ -60,5 +51,9 @@ class RadioGroup extends React.Component {
 }
 
 RadioGroup.propTypes = radioGroupPropTypes;
+
+RadioGroup.defaultProps = {
+  onChange: _.noop,
+};
 
 export default RadioGroup;

--- a/src/components/adslot-ui/RadioGroup/index.spec.jsx
+++ b/src/components/adslot-ui/RadioGroup/index.spec.jsx
@@ -46,7 +46,7 @@ describe('<RadioGroup />', () => {
     component
       .find(Radio)
       .at(0)
-      .simulate('change', { target: { value: 'swimming' } });
+      .simulate('change', { currentTarget: { value: 'swimming' } });
     expect(component.state('value')).to.equal('swimming');
     expect(props.onChange.calledOnce).to.equal(true);
   });
@@ -65,7 +65,7 @@ describe('<RadioGroup />', () => {
     component
       .find(Radio)
       .at(1)
-      .simulate('change', { target: { value: 'soccer' } });
+      .simulate('change', { currentTarget: { value: 'soccer' } });
     expect(component.state('value')).to.equal('soccer');
   });
 
@@ -84,36 +84,9 @@ describe('<RadioGroup />', () => {
     component
       .find(Radio)
       .at(0)
-      .simulate('change', { target: { value: 'swimming' } });
+      .simulate('change', { currentTarget: { value: 'swimming' } });
     expect(onChangeSwimming.calledOnce).to.equal(true);
     expect(onChangeSoccer.called).to.equal(false);
     expect(props.onChange.calledOnce).to.equal(true);
-  });
-
-  describe('getDerivedStateFromProps()', () => {
-    let component;
-
-    beforeEach(() => {
-      component = shallow(
-        <RadioGroup {...props}>
-          <Radio label="Swimming" value="swimming" />
-          <Radio label="Soccer" value="soccer" />
-          <Radio label="Badminton" value="badminton" />
-        </RadioGroup>
-      );
-    });
-
-    it('should update selected value when `prop.value` changes', () => {
-      props.value = 'soccer';
-      component.setProps(props);
-      expect(component.state('value')).to.equal('soccer');
-    });
-
-    it('should NOT update selected value when other props attributes change', () => {
-      props.id = 'new-id';
-      props.name = 'some-other-name';
-      component.setProps(props);
-      expect(component.state('value')).to.equal('badminton');
-    });
   });
 });


### PR DESCRIPTION



## Description

- Remove the checkbox, radios gDSFP
- Checkbox and Radio now are always controlled, except when they are used with their group components.

Migration:

before:
```
RadioGroup.onChange(event)
CheckboxGroup.onChange(value, event, name)
```

after:
```
RadioGroup.onChange(value)
CheckboxGroup.onChange(checkedValues, name)
```

## Motivation and Background Context

Because of React 16.4.2 was breaking change for gDSFP

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [X] Yes
- [ ] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [ ] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
