### PR TITLE
Fix: radio box

### DIFF
--- a/docs/examples/CheckboxGroupExample.jsx
+++ b/docs/examples/CheckboxGroupExample.jsx
@@ -8,17 +8,22 @@ class CheckboxGroupExample extends React.PureComponent {
     console.log(checked);
   }
 
-  handleIndividualChange(event) {
-    console.log(event.target.value);
-  }
-
   render() {
     return (
-      <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={this.handleGroupChange}>
-        <Checkbox label="The Terminator" value="terminator" onChange={this.handleIndividualChange} />
-        <Checkbox label="Predator" value="predator" />
-        <Checkbox label="The Sound of Music" value="soundofmusic" />
-      </CheckboxGroup>
+      <React.Fragment>
+        <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={this.handleGroupChange}>
+          <Checkbox label="The Terminator" value="terminator" />
+          <Checkbox label="Predator" value="predator" />
+          <Checkbox label="The Sound of Music" value="soundofmusic" />
+        </CheckboxGroup>
+        <br />
+        <h3>Inline CheckboxGroup</h3>
+        <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={this.handleGroupChange} inline>
+          <Checkbox label="The Terminator" value="terminator" />
+          <Checkbox label="Predator" value="predator" />
+          <Checkbox label="The Sound of Music" value="soundofmusic" />
+        </CheckboxGroup>
+      </React.Fragment>
     );
   }
 }
@@ -26,8 +31,8 @@ class CheckboxGroupExample extends React.PureComponent {
 const exampleProps = {
   componentName: 'CheckboxGroup',
   notes: 'Contains individual checkboxes. The state of child checkboxes is held in an array.',
-  exampleCodeSnippet: `<CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={onChangeGroup}>
-  <Checkbox label="The Terminator" value="terminator" onChange={onChangeIndividual} />
+  exampleCodeSnippet: `<CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={onChangeGroup} inline={true|false}>
+  <Checkbox label="The Terminator" value="terminator" />
   <Checkbox label="Predator" value="predator" />
   <Checkbox label="The Sound of Music" value="soundofmusic" />
 </CheckboxGroup>`,

--- a/docs/examples/RadioGroupExample.jsx
+++ b/docs/examples/RadioGroupExample.jsx
@@ -8,17 +8,22 @@ class RadioGroupExample extends React.PureComponent {
     console.log(value);
   }
 
-  handleIndividualChange(event) {
-    console.log(event.target.value);
-  }
-
   render() {
     return (
-      <RadioGroup name="hobbies" value="badminton" onChange={this.handleGroupChange} dts="radio-group-dts">
-        <Radio value="swimming" label="Swimming" dts="radio-dts" />
-        <Radio value="soccer" label="Soccer" onChange={this.handleIndividualChange} />
-        <Radio value="badminton" label="Badminton" />
-      </RadioGroup>
+      <React.Fragment>
+        <RadioGroup name="hobbies" value="badminton" onChange={this.handleGroupChange} dts="radio-group-dts">
+          <Radio value="swimming" label="Swimming" dts="radio-dts" />
+          <Radio value="soccer" label="Soccer" />
+          <Radio value="badminton" label="Badminton" />
+        </RadioGroup>
+        <br />
+        <h3>Inline RadioGroup</h3>
+        <RadioGroup name="hobbies" value="badminton" onChange={this.handleGroupChange} dts="radio-group-dts" inline>
+          <Radio value="swimming" label="Swimming" dts="radio-dts" />
+          <Radio value="soccer" label="Soccer" />
+          <Radio value="badminton" label="Badminton" />
+        </RadioGroup>
+      </React.Fragment>
     );
   }
 }
@@ -32,9 +37,9 @@ const exampleProps = {
     </p>
   ),
   notes: '',
-  exampleCodeSnippet: `<RadioGroup name="hobbies" value="badminton" onChange={this.onChangeGroup} dts="radio-group-dts">
+  exampleCodeSnippet: `<RadioGroup name="hobbies" value="badminton" onChange={this.onChangeGroup} dts="radio-group-dts" inline={true|false}>
   <Radio value="swimming" label="Swimming" dts="radio-dts" />
-  <Radio value="soccer" label="Soccer" onChange={this.onChangeIndividual} />
+  <Radio value="soccer" label="Soccer" />
   <Radio value="badminton" label="Badminton" />
 </RadioGroup>`,
   propTypeSectionArray: [

--- a/src/components/adslot-ui/Checkbox/index.spec.jsx
+++ b/src/components/adslot-ui/Checkbox/index.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 import Checkbox from '.';
 
@@ -16,6 +16,12 @@ describe('Checkbox', () => {
     expect(component.find('[name="movies"]')).to.have.length(1);
     expect(component.find('[value="terminator"]')).to.have.length(1);
     expect(component.find('[data-test-selector="checkbox-terminator"]')).to.have.length(1);
+  });
+
+  it('should be mounted without error', () => {
+    const component = mount(<Checkbox label="The Terminator" name="movies" value="terminator" />);
+    const checkboxElement = component.find('input[type="checkbox"]');
+    expect(checkboxElement).to.have.length(1);
   });
 
   it('should render with just label', () => {

--- a/src/components/adslot-ui/Radio/index.jsx
+++ b/src/components/adslot-ui/Radio/index.jsx
@@ -32,7 +32,7 @@ class RadioButton extends React.Component {
               name={name}
               checked={checked}
               disabled={disabled}
-              onClick={this.onChangeDefault}
+              onChange={this.onChangeDefault}
               value={value}
               id={id}
               className={className}

--- a/src/components/adslot-ui/Radio/index.spec.jsx
+++ b/src/components/adslot-ui/Radio/index.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 import Radio from '.';
 
@@ -30,6 +30,12 @@ describe('<Radio />', () => {
     expect(component.find('[data-test-selector="radio-dts"]')).to.have.length(1);
   });
 
+  it('should be mounted without error', () => {
+    const component = mount(<Radio {...props} />);
+    expect(component.find('input[type="radio"]')).to.have.length(1);
+    expect(component.text()).to.equal('Radio 1');
+  });
+
   it('should not render label if props.label is undefined', () => {
     delete props.label;
     const component = shallow(<Radio {...props} />);
@@ -38,7 +44,7 @@ describe('<Radio />', () => {
 
   it('should trigger `props.onChange` when the radio button is clicked', () => {
     const component = shallow(<Radio {...props} />);
-    component.find('input').simulate('click');
+    component.find('input').simulate('change');
     expect(props.onChange.calledOnce).to.equal(true);
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A React error 
`ERROR: 'Warning: Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.`

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
- Change `onClick` to `onChange` in Radio component
- Add mount test
- Update docs

Tested on other project, passed all tests

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![screen shot 2018-08-29 at 11 14 21 am](https://user-images.githubusercontent.com/15777593/44759321-c5f0ff00-ab7c-11e8-833f-c916cc451b40.png)

![screen shot 2018-08-29 at 11 14 10 am](https://user-images.githubusercontent.com/15777593/44759323-c9848600-ab7c-11e8-8939-d70fd9bdef05.png)

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
