### PR TITLE
Fix: CheckboxGroup & RadioGroup had unnecessary state

### DIFF
--- a/docs/examples/CheckboxGroupExample.jsx
+++ b/docs/examples/CheckboxGroupExample.jsx
@@ -4,14 +4,23 @@ import Example from '../components/Example';
 import { CheckboxGroup, Checkbox } from '../../src';
 
 class CheckboxGroupExample extends React.PureComponent {
-  handleGroupChange(checked) {
-    console.log(checked);
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      movies: ['terminator', 'predator'],
+    };
+    this.handleGroupChange = this.handleGroupChange.bind(this);
+  }
+
+  handleGroupChange(movies) {
+    this.setState({ movies });
   }
 
   render() {
     return (
       <React.Fragment>
-        <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={this.handleGroupChange}>
+        <CheckboxGroup name="movies" value={this.state.movies} onChange={this.handleGroupChange}>
           <Checkbox label="The Terminator" value="terminator" />
           <Checkbox label="Predator" value="predator" />
           <Checkbox label="The Sound of Music" value="soundofmusic" />

--- a/docs/examples/RadioGroupExample.jsx
+++ b/docs/examples/RadioGroupExample.jsx
@@ -4,14 +4,23 @@ import RadioGroup from 'adslot-ui/RadioGroup';
 import Radio from 'adslot-ui/Radio';
 
 class RadioGroupExample extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hobbies: 'badminton',
+    };
+    this.handleGroupChange = this.handleGroupChange.bind(this);
+  }
+
   handleGroupChange(value) {
-    console.log(value);
+    this.setState({ hobbies: value });
   }
 
   render() {
     return (
       <React.Fragment>
-        <RadioGroup name="hobbies" value="badminton" onChange={this.handleGroupChange} dts="radio-group-dts">
+        <RadioGroup name="hobbies" value={this.state.hobbies} onChange={this.handleGroupChange} dts="radio-group-dts">
           <Radio value="swimming" label="Swimming" dts="radio-dts" />
           <Radio value="soccer" label="Soccer" />
           <Radio value="badminton" label="Badminton" />

--- a/src/components/adslot-ui/CheckboxGroup/index.jsx
+++ b/src/components/adslot-ui/CheckboxGroup/index.jsx
@@ -8,42 +8,32 @@ class CheckboxGroup extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      checkedValues: [...this.props.value],
-    };
-
     this.renderChildren = this.renderChildren.bind(this);
     this.onChangeDefault = this.onChangeDefault.bind(this);
   }
 
   onChangeDefault(event) {
-    const { onChange, name } = this.props;
+    const { onChange, name, value } = this.props;
     const checkboxValue = event.currentTarget.value;
-    this.setState(
-      prevState =>
-        _.includes(prevState.checkedValues, checkboxValue)
-          ? {
-              checkedValues: prevState.checkedValues.filter(value => value !== checkboxValue),
-            }
-          : {
-              checkedValues: [...prevState.checkedValues, checkboxValue],
-            },
-      () => {
-        onChange(this.state.checkedValues, name);
-      }
-    );
+
+    const newValues = _.includes(value, checkboxValue)
+      ? value.filter(item => item !== checkboxValue)
+      : [...value, checkboxValue];
+
+    onChange(newValues, name);
   }
 
   renderChildren() {
-    return React.Children.map(this.props.children, child =>
+    const { children, value, name, inline } = this.props;
+    return React.Children.map(children, child =>
       React.cloneElement(child, {
-        name: this.props.name,
-        checked: _.includes(this.state.checkedValues, child.props.value),
+        name,
+        checked: _.includes(value, child.props.value),
         onChange: (...args) => {
           child.props.onChange(...args);
           this.onChangeDefault(...args);
         },
-        inline: this.props.inline,
+        inline,
       })
     );
   }
@@ -61,10 +51,5 @@ class CheckboxGroup extends React.Component {
 }
 
 CheckboxGroup.propTypes = checkboxGroupPropTypes;
-
-CheckboxGroup.defaultProps = {
-  value: [],
-  onChange: _.noop,
-};
 
 export default CheckboxGroup;

--- a/src/components/adslot-ui/CheckboxGroup/index.spec.jsx
+++ b/src/components/adslot-ui/CheckboxGroup/index.spec.jsx
@@ -7,7 +7,7 @@ import CheckboxGroup from '.';
 describe('CheckboxGroup', () => {
   it('should render with props', () => {
     const component = shallow(
-      <CheckboxGroup name="movies" value={['terminator', 'predator']} className="custom-class">
+      <CheckboxGroup name="movies" value={['terminator', 'predator']} className="custom-class" onChange={sinon.spy}>
         <Checkbox label="The Terminator" value="terminator" />
         <Checkbox label="Predator" value="predator" />
         <Checkbox label="The Sound of Music" value="soundofmusic" />
@@ -17,50 +17,37 @@ describe('CheckboxGroup', () => {
     expect(component.hasClass('custom-class')).to.equal(true);
     const childCheckboxes = component.find('Checkbox');
     expect(childCheckboxes.length).to.equal(3);
-    expect(component.state().checkedValues).to.eql(['terminator', 'predator']);
   });
 
-  it('should handle checkbox change events', () => {
+  it('should handle checkbox change events when adding selection', () => {
     const onChangeGroup = sinon.spy();
-    const onChangeIndividual = sinon.spy();
     const component = shallow(
       <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={onChangeGroup}>
-        <Checkbox label="The Terminator" value="terminator" onChange={onChangeIndividual} />
+        <Checkbox label="The Terminator" value="terminator" />
         <Checkbox label="Predator" value="predator" />
         <Checkbox label="The Sound of Music" value="soundofmusic" />
       </CheckboxGroup>
     );
 
-    const childCheckboxes = component.find('Checkbox');
+    const childCheckboxes = component.find(Checkbox);
     childCheckboxes.at(0).simulate('change', { currentTarget: { value: 'terminator' } });
-    expect(component.state().checkedValues).to.eql(['predator']);
     expect(onChangeGroup.callCount).to.equal(1);
-    expect(onChangeIndividual.callCount).to.equal(1);
+    expect(onChangeGroup.calledWith(['predator'], 'movies')).to.equal(true);
   });
 
-  it('should render without onChange or value props', () => {
+  it('should handle checkbox change events when removing selection', () => {
+    const onChangeGroup = sinon.spy();
     const component = shallow(
-      <CheckboxGroup name="movies">
+      <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={onChangeGroup}>
         <Checkbox label="The Terminator" value="terminator" />
         <Checkbox label="Predator" value="predator" />
         <Checkbox label="The Sound of Music" value="soundofmusic" />
       </CheckboxGroup>
     );
 
-    const childCheckboxes = component.find('Checkbox');
-    expect(childCheckboxes.length).to.equal(3);
-  });
-
-  it('should handle change events without a custom onChange handler', () => {
-    const component = shallow(
-      <CheckboxGroup name="movies">
-        <Checkbox label="The Terminator" value="terminator" />
-        <Checkbox label="Predator" value="predator" />
-        <Checkbox label="The Sound of Music" value="soundofmusic" />
-      </CheckboxGroup>
-    );
-    const firstChild = component.find('Checkbox').at(0);
-    firstChild.simulate('change', { currentTarget: { value: 'terminator' } });
-    expect(component.state().checkedValues).to.eql(['terminator']);
+    const childCheckboxes = component.find(Checkbox);
+    childCheckboxes.at(2).simulate('change', { currentTarget: { value: 'soundofmusic' } });
+    expect(onChangeGroup.callCount).to.equal(1);
+    expect(onChangeGroup.calledWith(['terminator', 'predator', 'soundofmusic'], 'movies')).to.equal(true);
   });
 });

--- a/src/components/adslot-ui/RadioGroup/index.jsx
+++ b/src/components/adslot-ui/RadioGroup/index.jsx
@@ -8,17 +8,12 @@ class RadioGroup extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      value: props.value,
-    };
-
     this.onChangeDefault = this.onChangeDefault.bind(this);
     this.renderChildren = this.renderChildren.bind(this);
   }
 
   onChangeDefault(event) {
     const newValue = event.currentTarget.value;
-    this.setState({ value: newValue });
     this.props.onChange(newValue);
   }
 
@@ -26,7 +21,7 @@ class RadioGroup extends React.Component {
     return React.Children.map(this.props.children, child => {
       const childProps = _.assign({}, child.props, {
         name: this.props.name,
-        checked: this.state.value === child.props.value,
+        checked: this.props.value === child.props.value,
         onChange: (...args) => {
           child.props.onChange(...args);
           this.onChangeDefault(...args);
@@ -51,9 +46,5 @@ class RadioGroup extends React.Component {
 }
 
 RadioGroup.propTypes = radioGroupPropTypes;
-
-RadioGroup.defaultProps = {
-  onChange: _.noop,
-};
 
 export default RadioGroup;

--- a/src/components/adslot-ui/RadioGroup/index.spec.jsx
+++ b/src/components/adslot-ui/RadioGroup/index.spec.jsx
@@ -33,7 +33,7 @@ describe('<RadioGroup />', () => {
     expect(component.find('[data-test-selector="radio-group-dts"]')).to.have.length(1);
   });
 
-  it('should update state and trigger props.onChange when selection changes', () => {
+  it('should trigger props.onChange when selection changes', () => {
     const component = shallow(
       <RadioGroup {...props}>
         <Radio label="Swimming" value="swimming" />
@@ -41,32 +41,12 @@ describe('<RadioGroup />', () => {
         <Radio label="Badminton" value="badminton" />
       </RadioGroup>
     );
-
-    expect(component.state('value')).to.equal('badminton');
     component
       .find(Radio)
       .at(0)
       .simulate('change', { currentTarget: { value: 'swimming' } });
-    expect(component.state('value')).to.equal('swimming');
     expect(props.onChange.calledOnce).to.equal(true);
-  });
-
-  it('should still update state when props.onChange is not available', () => {
-    delete props.onChange;
-    const component = shallow(
-      <RadioGroup {...props}>
-        <Radio label="Swimming" value="swimming" />
-        <Radio label="Soccer" value="soccer" />
-        <Radio label="Badminton" value="badminton" />
-      </RadioGroup>
-    );
-
-    expect(component.state('value')).to.equal('badminton');
-    component
-      .find(Radio)
-      .at(1)
-      .simulate('change', { currentTarget: { value: 'soccer' } });
-    expect(component.state('value')).to.equal('soccer');
+    expect(props.onChange.calledWith('swimming')).to.equal(true);
   });
 
   it('should call Radio props.onChange when selecting that radio button', () => {

--- a/src/components/prop-types/inputPropTypes.js
+++ b/src/components/prop-types/inputPropTypes.js
@@ -24,13 +24,13 @@ export const checkboxGroupPropTypes = {
   id: PropTypes.string,
   className: PropTypes.string,
   name: PropTypes.string.isRequired,
-  value: PropTypes.arrayOf(PropTypes.string),
+  value: PropTypes.arrayOf(PropTypes.string).isRequired,
   children: PropTypes.arrayOf(PropTypes.element).isRequired,
-  onChange: PropTypes.func,
+  onChange: PropTypes.func.isRequired,
   dts: PropTypes.string,
   inline: PropTypes.bool,
 };
 
 export const radioGroupPropTypes = _.assign({}, checkboxGroupPropTypes, {
-  value: PropTypes.string,
+  value: PropTypes.string.isRequired,
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
This PR essentially making `CheckboxGroup` and `RadioGroup` always controlled.
`value` and `onChange` will always be need.


## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [ ] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [ ] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
