### PR TITLE
Fix: list picker pure component after checkbox updated

### DIFF
--- a/docs/examples/ListPickerExample.jsx
+++ b/docs/examples/ListPickerExample.jsx
@@ -14,12 +14,30 @@ const teamMember3 = { givenName: 'Jack', id: 3, surname: 'White' };
 const listPickerItems = [teamMember1, teamMember2, teamMember3];
 const listPickerInitialSelection = [teamMember2];
 const labelFormatter = item => `${item.givenName} ${item.surname}`;
-const addonFormatter = () => <Checkbox />;
+const addonFormatter = () => <UncontrolledCheckbox />;
 const listPickerItemHeaders = {
   label: 'Team',
   toggle: 'Primary',
   addon: 'Secondary',
 };
+
+class UncontrolledCheckbox extends React.PureComponent {
+  constructor() {
+    super();
+    this.state = {
+      checked: false,
+    };
+    this.handleCheck = this.handleCheck.bind(this);
+  }
+
+  handleCheck() {
+    this.setState(prevState => ({ checked: !prevState.checked }));
+  }
+
+  render() {
+    return <Checkbox checked={this.state.checked} onChange={this.handleCheck} />;
+  }
+}
 
 class ListPickerExample extends React.PureComponent {
   constructor() {
@@ -31,7 +49,7 @@ class ListPickerExample extends React.PureComponent {
   }
 
   toggleListPickerModal() {
-    this.setState({ showListPickerModal: !this.state.showListPickerModal });
+    this.setState(prevState => ({ showListPickerModal: !prevState.showListPickerModal }));
   }
 
   render() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
After checkbox changed, the list picker pure component need to mange its own state.

Currenttly the component is broken.
Should be a patch fix, it is not changing the usage. 

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [x] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
