### PR TITLE
Fix: Disabled button block popover

### DIFF
--- a/src/components/third-party/bootstrap/Button/index.jsx
+++ b/src/components/third-party/bootstrap/Button/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import BootstrapButton from 'react-bootstrap/lib/Button';
 import BootstrapPopover from 'react-bootstrap/lib/Popover';
-import BootstrapOverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import BootstrapOverlay from 'react-bootstrap/lib/Overlay';
 import Spinner from 'alexandria/Spinner';
 import { expandDts } from 'lib/utils';
 import './styles.scss';
@@ -19,6 +19,19 @@ const adslotButtonPropTypes = {
 };
 
 class Button extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.buttonRef = React.createRef();
+    this.state = {
+      show: false,
+    };
+    this.handleReasonPopover = this.handleReasonPopover.bind(this);
+  }
+
+  handleReasonPopover(value) {
+    this.setState({ show: value });
+  }
+
   renderSpinner() {
     if (this.props.isLoading) {
       return (
@@ -31,24 +44,28 @@ class Button extends React.PureComponent {
     return null;
   }
 
-  renderWithReason() {
-    const popover = (
-      <BootstrapPopover id="btn-reason" className="btn-popover-reason">
-        {this.props.reason}
-      </BootstrapPopover>
-    );
+  renderReason() {
     return (
-      <BootstrapOverlayTrigger trigger={['focus', 'hover']} placement="bottom" overlay={popover}>
-        {this.renderButton()}
-      </BootstrapOverlayTrigger>
+      <BootstrapOverlay placement="bottom" show={this.state.show} target={this.buttonRef.current}>
+        <BootstrapPopover id="btn-reason" className="btn-popover-reason">
+          {this.props.reason}
+        </BootstrapPopover>
+      </BootstrapOverlay>
     );
   }
 
-  renderButton() {
-    const { inverse, children, dts, className, isLoading, disabled } = this.props;
+  render() {
+    const { inverse, children, dts, className, isLoading, disabled, reason } = this.props;
+    const shouldShowReason = !!disabled && !!reason;
     const classes = classNames('button-component', className, {
       'btn-inverse': inverse && !/btn-inverse/.test(className),
     });
+    const reasonProps = shouldShowReason
+      ? {
+          onMouseOver: () => this.handleReasonPopover(true),
+          onMouseOut: () => this.handleReasonPopover(false),
+        }
+      : {};
 
     return (
       <BootstrapButton
@@ -56,16 +73,14 @@ class Button extends React.PureComponent {
         disabled={isLoading || disabled}
         className={classes}
         {...expandDts(dts)}
+        {...reasonProps}
+        ref={this.buttonRef}
       >
         {this.renderSpinner()}
         <div className={isLoading ? 'button-component-children-container' : null}>{children}</div>
+        {this.renderReason()}
       </BootstrapButton>
     );
-  }
-
-  render() {
-    const { disabled, reason } = this.props;
-    return disabled && reason ? this.renderWithReason() : this.renderButton();
   }
 }
 

--- a/src/components/third-party/bootstrap/Button/index.spec.jsx
+++ b/src/components/third-party/bootstrap/Button/index.spec.jsx
@@ -1,88 +1,95 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Overlay from 'react-bootstrap/lib/Overlay';
+import BootstrapPopover from 'react-bootstrap/lib/Popover';
 import BootstrapButton from 'react-bootstrap/lib/Button';
 import { Button } from 'third-party';
 import Spinner from 'alexandria/Spinner';
 
 describe('ButtonComponent', () => {
   it('should render Bootstrap Button', () => {
-    const element = shallow(<Button>Test</Button>);
-    expect(element.type()).to.equal(BootstrapButton);
+    const wrapper = shallow(<Button>Test</Button>);
+    expect(wrapper.find(BootstrapButton)).to.have.length(1);
   });
 
   it('should pass through Bootstrap Button props', () => {
-    const element = shallow(<Button bsStyle="link">Test</Button>);
-    expect(element.prop('bsStyle')).to.equal('link');
+    const wrapper = shallow(<Button bsStyle="link">Test</Button>);
+    expect(wrapper.prop('bsStyle')).to.equal('link');
   });
 
   it('should support legacy classname btn-inverse for non-breaking change', () => {
-    const element = shallow(<Button className="btn-inverse">Test</Button>);
-    expect(element.prop('className')).to.equal('button-component btn-inverse');
+    const wrapper = shallow(<Button className="btn-inverse">Test</Button>);
+    expect(wrapper.prop('className')).to.equal('button-component btn-inverse');
   });
 
   it('should support className prop', () => {
-    const element = shallow(<Button className="all the-classes">Test</Button>);
-    expect(element.prop('className')).to.equal('button-component all the-classes');
+    const wrapper = shallow(<Button className="all the-classes">Test</Button>);
+    expect(wrapper.prop('className')).to.equal('button-component all the-classes');
   });
 
   it('should support valid html attributes', () => {
-    const element = shallow(
+    const wrapper = shallow(
       <Button id="button-id" data-item-name="someDataValue">
         Test
       </Button>
     );
-    expect(element.prop('id')).to.equal('button-id');
-    expect(element.prop('data-item-name')).to.equal('someDataValue');
+    expect(wrapper.prop('id')).to.equal('button-id');
+    expect(wrapper.prop('data-item-name')).to.equal('someDataValue');
   });
 
   it('should not duplicate btn-inverse class if both legacy and new are used', () => {
-    const element = shallow(
+    const wrapper = shallow(
       <Button inverse className="btn-inverse">
         Test
       </Button>
     );
-    expect(element.prop('className')).to.equal('button-component btn-inverse');
+    expect(wrapper.prop('className')).to.equal('button-component btn-inverse');
   });
 
   it('should render inverse button with btn-inverse class', () => {
-    const element = shallow(<Button inverse>Test</Button>);
-    expect(element.prop('className')).to.equal('button-component btn-inverse');
+    const wrapper = shallow(<Button inverse>Test</Button>);
+    expect(wrapper.prop('className')).to.equal('button-component btn-inverse');
   });
 
   it('should support data-test-selectors', () => {
-    const element = shallow(<Button dts="test-button">Test</Button>);
-    expect(element.prop('data-test-selector')).to.equal('test-button');
+    const wrapper = shallow(<Button dts="test-button">Test</Button>);
+    expect(wrapper.prop('data-test-selector')).to.equal('test-button');
   });
 
   it('should render disabled button without a reason popover if no reason given', () => {
-    const element = shallow(<Button disabled>Test</Button>);
-    expect(element.find(OverlayTrigger)).to.have.length(0);
+    const wrapper = shallow(<Button disabled>Test</Button>);
+    const reasonOverlay = wrapper.find(Overlay);
+    expect(reasonOverlay).to.have.length(1);
+    expect(reasonOverlay.prop('show')).to.eql(false);
   });
 
   it('should render disabled button with a reason popover', () => {
-    const element = shallow(
+    const wrapper = shallow(
       <Button disabled reason="Because">
         Test
       </Button>
     );
-    const overlay = element.find(OverlayTrigger);
-    expect(overlay).to.have.length(1);
-    expect(shallow(overlay.prop('overlay')).text()).to.eql('Because');
+    const button = wrapper.find(BootstrapButton);
+    button.simulate('mouseOver');
+    expect(wrapper.find(Overlay).prop('show')).to.eql(true);
+    wrapper.update();
+    expect(wrapper.find(BootstrapPopover).prop('children')).to.eql('Because');
+    button.simulate('mouseOut');
+    expect(wrapper.find(Overlay).prop('show')).to.eql(false);
   });
 
   it('should render Spinner if isLoading is true', () => {
-    const element = shallow(<Button isLoading>Spinner</Button>);
-    expect(element.find(Spinner)).to.have.length(1);
+    const wrapper = shallow(<Button isLoading>Spinner</Button>);
+    expect(wrapper.find(Spinner)).to.have.length(1);
   });
 
   it('should only allow bsSize medium or small on Spinner', () => {
-    const element = shallow(
+    const wrapper = shallow(
       <Button isLoading bsSize="lg">
         Spinner
       </Button>
     );
-    const spinnerEl = element.find(Spinner);
+    const spinnerEl = wrapper.find(Spinner);
     expect(spinnerEl.prop('size')).to.equal('medium');
   });
 });

--- a/src/styles/bootstrapOverrides/Button.scss
+++ b/src/styles/bootstrapOverrides/Button.scss
@@ -32,7 +32,7 @@
 .btn-inverse {
   // :not(:disabled) is used instead of :enabled as various elements (a, div, span)
   // are styled as buttons but do not have an :enabled state
-  &:not(:disabled, [disabled='disabled']) {
+  &:not([disabled]) {
     @include button-variant($color-text-light, $color-inverse, $color-border-light);
 
     &:hover,
@@ -66,16 +66,6 @@
 .btn {
   box-shadow: 0 1px $color-border-light;
   margin-right: 5px;
-
-  // Make border the same colour as the fill.
-  &:not(.btn-inverse, .btn-borderless) {
-
-    &,
-    &:active,
-    &:hover {
-      border-color: transparent;
-    }
-  }
 
   &:last-child {
     margin-right: 0;
@@ -137,7 +127,7 @@
 }
 
 .btn-borderless {
-  &:not(:disabled) {
+  &:not([disabled]) {
     @include button-variant($color-text-light, $color-inverse, $color-white);
     box-shadow: none;
 
@@ -151,7 +141,7 @@
 }
 
 .btn-flat {
-  &:not(:disabled) {
+  &:not([disabled]) {
     @include button-variant($color-text-light, $color-inverse, $color-white);
     border: 0;
     box-shadow: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
The disabled button seems block the hover event, so the popover is not shown properly.

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![nov-13-2018 13-44-33](https://user-images.githubusercontent.com/15777593/48387536-571e4d80-e74a-11e8-9017-5f6be78f5ea6.gif)


## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [ ] I've squashed my commits into one.
