### PR TITLE
Tag styling changes

### DIFF
--- a/docs/examples/TagExample.jsx
+++ b/docs/examples/TagExample.jsx
@@ -60,6 +60,7 @@ class TagExample extends React.Component {
             key={tag.id}
             id={tag.id}
             accent={tag.accent}
+            baseClass={tag.baseClass}
             onAction={this.deleteTag}
             inverse
             actionIconSvgHref={tag.actionIconSvgHref}
@@ -105,6 +106,11 @@ const exampleProps = {
         {
           propType: 'accent',
           type: 'string',
+        },
+        {
+          propType: 'baseClass',
+          type: 'string',
+          defaultValue: 'tag-component',
         },
         {
           propType: 'inverse',

--- a/src/components/alexandria/Tag/index.jsx
+++ b/src/components/alexandria/Tag/index.jsx
@@ -1,41 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SvgSymbol from 'alexandria/SvgSymbol';
-import { classSuffixHelper } from 'lib/utils';
+import classnames from 'classnames';
 import './styles.scss';
 
-const componentClass = 'tag-component';
+const defaultComponentClass = 'tag-component';
 
 export const ActionButton = ({ onAction, id, actionIconSvgHref }) => (
   <span className="action-button" onClick={() => onAction(id)}>
-    <SvgSymbol href={actionIconSvgHref} />
+    {actionIconSvgHref ? <SvgSymbol href={actionIconSvgHref} /> : <span className="action-icon">&#x2715;</span>}
   </span>
 );
 
 ActionButton.propTypes = {
   id: PropTypes.string.isRequired,
   onAction: PropTypes.func.isRequired,
-  actionIconSvgHref: PropTypes.string.isRequired,
+  actionIconSvgHref: PropTypes.string,
 };
 
-const Tag = ({ children, inverse, id, onAction, accent, actionIconSvgHref }) => {
-  const classSuffixes = [];
-  if (inverse) {
-    classSuffixes.push('inverse');
-  }
-
-  if (accent) {
-    classSuffixes.push(`accent accent-${accent}`);
-  }
-
-  if (onAction) {
-    classSuffixes.push('actionable');
-  }
-
-  const classes = classSuffixHelper({ classSuffixes, componentClass });
+const Tag = ({ children, inverse, id, onAction, accent, baseClass, actionIconSvgHref }) => {
+  const classes = classnames([
+    defaultComponentClass,
+    {
+      [`${baseClass}-inverse`]: inverse,
+      [`${baseClass}-accent accent-${accent}`]: accent,
+      [`${defaultComponentClass}-actionable`]: onAction,
+      [`${baseClass}`]: baseClass !== defaultComponentClass,
+    },
+  ]);
 
   return (
-    <span className={`${componentClass}${classes}`} data-test-selector={`tag-${id}`}>
+    <span className={classes} data-test-selector={`tag-${id}`}>
       {children}
       {onAction ? <ActionButton {...{ onAction, id, actionIconSvgHref }} /> : null}
     </span>
@@ -48,6 +43,7 @@ Tag.propTypes = {
   children: PropTypes.node.isRequired,
   id: PropTypes.string,
   accent: PropTypes.string,
+  baseClass: PropTypes.string,
   inverse: PropTypes.bool,
   onAction: PropTypes.func,
   actionIconSvgHref: PropTypes.string,
@@ -55,6 +51,7 @@ Tag.propTypes = {
 
 Tag.defaultProps = {
   id: 'default',
+  baseClass: 'tag-component',
 };
 
 export default Tag;

--- a/src/components/alexandria/Tag/index.spec.jsx
+++ b/src/components/alexandria/Tag/index.spec.jsx
@@ -2,7 +2,7 @@
 import _ from 'lodash';
 import React from 'react';
 import sinon from 'sinon';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import SvgSymbol from 'alexandria/SvgSymbol';
 import Tag, { ActionButton } from '.';
 
@@ -69,5 +69,21 @@ describe('Tag', () => {
       </Tag>
     );
     expect(component.find('.child')).to.have.length(2);
+  });
+
+  it('should render a tag with base class', () => {
+    const component = shallow(<Tag baseClass="foo">You are it!</Tag>);
+    expect(component.find('span').prop('className')).to.equal('tag-component foo');
+  });
+
+  it('should render a actionable tag without svg', () => {
+    const component = mount(<Tag onAction={() => sinon.spy()}>You are it!</Tag>);
+    expect(component.find(ActionButton)).to.have.length(1);
+    expect(
+      component
+        .find('span')
+        .at(2)
+        .prop('className')
+    ).to.equal('action-icon');
   });
 });

--- a/src/components/alexandria/Tag/styles.scss
+++ b/src/components/alexandria/Tag/styles.scss
@@ -5,10 +5,11 @@
 @import '~styles/variable';
 
 .tag-component {
-  $tag-height: 22px;
+  $tag-height: 24px;
   $tag-spacing-etalon: 5px;
   $color-tag-inverse: $color-gray-lightest;
   $color-tag-action-inverse: $color-gray;
+  $action-icon-padding: ($tag-height - $svg-icon-size) / 2;
 
   align-items: center;
   background-color: $color-text-light;
@@ -22,7 +23,8 @@
   min-height: $tag-height;
   padding: 0 $tag-spacing-etalon;
 
-  &.tag-component-inverse { // explicit .tag-component to force override of `.accent-n` inverse bg/fill colours
+  &.tag-component-inverse {
+    // explicit .tag-component to force override of `.accent-n` inverse bg/fill colours
     background-color: $color-tag-inverse;
     border-left: 4px solid;
     color: $color-text-light;
@@ -45,13 +47,14 @@
   .action-button {
     box-sizing: border-box;
     cursor: pointer;
-    display: inline-block;
     fill: $color-inverse;
     fill-opacity: .6;
     height: $tag-height;
-    padding-top: ($tag-height - $svg-icon-size) / 2;
     text-align: center;
     width: $tag-height;
+    align-items: center;
+    display: flex;
+    justify-content: center;
 
     &:hover {
       fill-opacity: 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Tag component changes
## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Make svg optional for action button.
Introducing base class which allows to override baseClass of tag component. This will also allow to move away from accent property to completely custom style the tag as needed.
## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
**Default behaviour without svg**
![image](https://user-images.githubusercontent.com/11186508/48817472-be677d80-ed9a-11e8-9fbe-9f5bccccbd43.png)


**Default behaviour with baseClass and no svg**
![image](https://user-images.githubusercontent.com/11186508/48817433-94ae5680-ed9a-11e8-9bed-a2f09f94a28a.png)

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [x] I've fixed or replied to all my code-review comments.
- [x] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
