### PR TITLE
fix: use own implementation of Tabs&Tab

### DIFF
--- a/docs/examples/TabExample.jsx
+++ b/docs/examples/TabExample.jsx
@@ -3,9 +3,25 @@ import Example from '../components/Example';
 import { Empty, SvgSymbol, FlexibleSpacer, Tabs, Tab } from '../../src';
 
 class TabExample extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      activeTab: 'Audience',
+    };
+
+    this.switchTab = this.switchTab.bind(this);
+  }
+
+  switchTab(tabKey) {
+    this.setState({
+      activeTab: tabKey,
+    });
+  }
+
   render() {
     return (
-      <Tabs defaultActiveKey="Audience" animation={false} id="audience-tab">
+      <Tabs activeKey={this.state.activeTab} onSelect={this.switchTab} id="audience-tab">
         <Tab
           eventKey="Audience"
           title={
@@ -55,18 +71,12 @@ const exampleProps = {
   ),
   notes: (
     <p>
-      See{' '}
-      <a href="https://getbootstrap.com/docs/3.3/components/#nav-tabs" target="_blank" rel="noopener noreferrer">
-        Bootstrap documentation
-      </a>{' '}
-      or{' '}
-      <a href="https://react-bootstrap.github.io/components/tabs/" target="_blank" rel="noopener noreferrer">
-        React Bootstrap documentation
-      </a>.
+      This is not a react-bootstrap component. However it implements the same API for switching tabs. Only the props
+      listed are supported.
     </p>
   ),
   exampleCodeSnippet: `
-  <Tabs defaultActiveKey="Audience" animation={false} id="audience-tab">
+  <Tabs activeKey={this.state.activeTab} onSelect={this.switchTab} id="audience-tab">
     <Tab
       eventKey="Audience"
       title={
@@ -74,12 +84,15 @@ const exampleProps = {
           <SvgSymbol href="./docs/assets/svg-symbols.svg#list" />
           <FlexibleSpacer />
           Audience
-        </span>}
+        </span>
+      }
     >
       <Empty
         collection={[]}
         text="No audience details."
-        svgSymbol={{ href: './docs/assets/svg-symbols.svg#checklist-incomplete' }}
+        svgSymbol={{
+          href: './docs/assets/svg-symbols.svg#checklist-incomplete',
+        }}
       />
     </Tab>
     <Tab
@@ -89,7 +102,8 @@ const exampleProps = {
           <SvgSymbol href="./docs/assets/svg-symbols.svg#calendar" />
           <FlexibleSpacer />
           Billing
-        </span>}
+        </span>
+      }
     >
       <Empty
         collection={[]}
@@ -98,7 +112,28 @@ const exampleProps = {
       />
     </Tab>
   </Tabs>`,
-  propTypeSectionArray: [],
+  propTypeSectionArray: [
+    {
+      propTypes: [
+        {
+          propType: 'defaultActiveKey',
+          type: 'oneOfType [string, number]',
+        },
+        {
+          propType: 'activeKey',
+          type: 'oneOfType [string, number]',
+        },
+        {
+          propType: 'onSelect',
+          type: 'func',
+        },
+        {
+          propType: 'id',
+          type: 'string',
+        },
+      ],
+    },
+  ],
 };
 
 export default () => (

--- a/src/components/adslot-ui/Tab/index.jsx
+++ b/src/components/adslot-ui/Tab/index.jsx
@@ -1,0 +1,21 @@
+/* eslint-disable react/no-unused-prop-types */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const Tab = ({ children, show }) => (
+  <div role="tabpanel" aria-hidden={show} className={classnames(['tab-pane', 'fade', { active: show, in: show }])}>
+    {children}
+  </div>
+);
+
+Tab.propTypes = {
+  children: PropTypes.node.isRequired,
+  eventKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  title: PropTypes.node.isRequired,
+  tabClassName: PropTypes.string,
+  disabled: PropTypes.bool,
+  show: PropTypes.bool,
+};
+
+export default Tab;

--- a/src/components/adslot-ui/Tab/index.spec.jsx
+++ b/src/components/adslot-ui/Tab/index.spec.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Tab from '.';
+
+describe('<Tab />', () => {
+  it('should render with props', () => {
+    expect(
+      shallow(
+        <Tab eventKey="first" show={false} title="First">
+          hi
+        </Tab>
+      ).props().className
+    ).to.equal('tab-pane fade');
+    expect(
+      shallow(
+        <Tab eventKey="first" show title="First">
+          hi
+        </Tab>
+      ).props().className
+    ).to.equal('tab-pane fade active in');
+  });
+});

--- a/src/components/adslot-ui/Tabs/index.jsx
+++ b/src/components/adslot-ui/Tabs/index.jsx
@@ -1,0 +1,94 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import classnames from 'classnames';
+import Tab from '../Tab';
+
+class Tabs extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      activeKey: this.props.defaultActiveKey,
+    };
+
+    this.switchTab = this.switchTab.bind(this);
+  }
+
+  get isControlled() {
+    const { activeKey, onSelect } = this.props;
+
+    return !_.isNil(activeKey) && _.isFunction(onSelect);
+  }
+
+  get activeKey() {
+    return this.isControlled ? this.props.activeKey : this.state.activeKey;
+  }
+
+  switchTab(key) {
+    const { onSelect, activeKey } = this.props;
+    return event => {
+      event.preventDefault();
+
+      if (this.isControlled && key !== activeKey) {
+        onSelect(key);
+      } else if (key !== this.state.activeKey) {
+        this.setState({ activeKey: key });
+      }
+    };
+  }
+
+  render() {
+    const { id, children } = this.props;
+
+    const tabs = [];
+    const content = React.Children.map(children, child => {
+      if (child.type === Tab) {
+        const tab = React.cloneElement(child, {
+          show: this.activeKey === child.props.eventKey,
+        });
+        tabs.push(tab);
+
+        return tab;
+      }
+      return child;
+    });
+
+    return (
+      <div id={id}>
+        <ul role="tablist" className="nav nav-tabs">
+          {tabs.map(tab => (
+            <li
+              role="presentation"
+              className={classnames(tab.props.tabClassName, { active: tab.props.show, disabled: tab.props.disabled })}
+              key={tab.props.eventKey}
+            >
+              <a
+                id={`${id}-tab-${tab.props.eventKey}`}
+                role="tab"
+                tabIndex={-1}
+                aria-selected={tab.props.show}
+                onClick={this.switchTab(tab.props.eventKey)}
+                style={tab.props.disabled ? { pointerEvents: 'none' } : {}}
+              >
+                {tab.props.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <div className="tab-content">{content}</div>
+      </div>
+    );
+  }
+}
+
+Tabs.propTypes = {
+  id: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  defaultActiveKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  activeKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onSelect: PropTypes.func,
+};
+
+export default Tabs;

--- a/src/components/adslot-ui/Tabs/index.spec.jsx
+++ b/src/components/adslot-ui/Tabs/index.spec.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import _ from 'lodash';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import Tabs from '.';
+import Tab from '../Tab';
+
+describe('<Tabs />', () => {
+  it('should render with props', () => {
+    const wrapper = shallow(
+      <Tabs defaultActiveKey="first" id="test">
+        <Tab eventKey="first" title="Fist">
+          Tab1
+        </Tab>
+        <Tab eventKey="last" title="Second" disabled>
+          Tab2
+        </Tab>
+      </Tabs>
+    );
+    const links = wrapper.find('a');
+    let content = wrapper.find(Tab);
+    expect(links.length).to.equal(2);
+    expect(content.length).to.equal(2);
+
+    expect(links.last().props().style).to.eql({ pointerEvents: 'none' });
+
+    expect(content.first().props().show).to.equal(true);
+    expect(content.last().props().show).to.equal(false);
+
+    links.last().simulate('click', { preventDefault: _.noop });
+    content = wrapper.find(Tab);
+    expect(content.first().props().show).to.equal(false);
+    expect(content.last().props().show).to.equal(true);
+  });
+
+  it('should work as controlled', () => {
+    const selectSpy = sinon.spy();
+    const wrapper = shallow(
+      <Tabs activeKey="first" onSelect={selectSpy} id="test">
+        <Tab eventKey="first" title="Fist">
+          Tab1
+        </Tab>
+        <Tab eventKey="last" title="Second">
+          Tab2
+        </Tab>
+        <div>other</div>
+      </Tabs>
+    );
+    const links = wrapper.find('a');
+    expect(links.length).to.equal(2);
+
+    links.last().simulate('click', { preventDefault: _.noop });
+    expect(selectSpy.callCount).to.equal(1);
+    expect(selectSpy.calledWith('last')).to.equal(true);
+  });
+
+  it('should not re render when key is the same', () => {
+    const wrapper = shallow(
+      <Tabs defaultActiveKey="first" id="test">
+        <Tab eventKey="first" title="Fist">
+          Tab1
+        </Tab>
+        <Tab eventKey="last" title="Second">
+          Tab2
+        </Tab>
+      </Tabs>
+    );
+    const spy = sinon.spy(wrapper.instance(), 'setState');
+    const links = wrapper.find('a');
+    links.last().simulate('click', { preventDefault: _.noop });
+    links.last().simulate('click', { preventDefault: _.noop });
+    expect(spy.callCount).to.equal(1);
+  });
+});

--- a/src/components/adslot-ui/index.js
+++ b/src/components/adslot-ui/index.js
@@ -17,6 +17,8 @@ import RadioGroup from 'adslot-ui/RadioGroup';
 import Search from 'adslot-ui/Search';
 import SearchBar from 'adslot-ui/SearchBar';
 import SplitPane from 'adslot-ui/SplitPane';
+import Tab from 'adslot-ui/Tab';
+import Tabs from 'adslot-ui/Tabs';
 import Textarea from 'adslot-ui/Textarea';
 import TextEllipsis from 'adslot-ui/TextEllipsis';
 import TreePickerGrid from 'adslot-ui/TreePicker/Grid';
@@ -51,6 +53,8 @@ export {
   Search,
   SearchBar,
   SplitPane,
+  Tab,
+  Tabs,
   Textarea,
   TextEllipsis,
   TreePickerGrid,

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,6 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Pagination from 'react-bootstrap/lib/Pagination';
 import Popover from 'react-bootstrap/lib/Popover';
 import ProgressBar from 'react-bootstrap/lib/ProgressBar';
-import Tab from 'react-bootstrap/lib/Tab';
-import Tabs from 'react-bootstrap/lib/Tabs';
 import NavItem from 'react-bootstrap/lib/NavItem';
 
 import 'styles/_bootstrap-custom.scss';
@@ -67,6 +65,8 @@ import {
   Search,
   SearchBar,
   SplitPane,
+  Tab,
+  Tabs,
   Textarea,
   TextEllipsis,
   TreePickerGrid,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

This PR re-implements the same API with the current `Tabs` & `Tab` component.
but missing animation related props.

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

react-bootstrap `Tabs` and `Tab` components are causing issue https://reactjs.org/docs/error-decoder.html/?invariant=254&args[]=inner

I do not know why. I have also seen some other people on react-bootstrap repo with the same error for Tabs

So my conclusion was: we gotta write our own Tabs.


## Does this PR introduce a breaking change?

<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
