### PR TITLE
feat: allow Panel props to be passed down from Accordion component

### DIFF
--- a/src/components/adslot-ui/Accordion/index.jsx
+++ b/src/components/adslot-ui/Accordion/index.jsx
@@ -9,20 +9,14 @@ const AccordionComponent = ({ dts, panels, onPanelClick }) => (
     <Card.Content fill>
       {_.map(panels, panel => {
         const panelDts = dts ? `panel-${panel.id}` : undefined;
+        const panelProps = {
+          key: panel.id,
+          onClick: onPanelClick,
+          dts: panelDts,
+          ..._.omit(panel, ['content', 'onClick']),
+        };
 
-        return (
-          <Panel
-            key={panel.id}
-            id={panel.id}
-            icon={panel.icon}
-            title={panel.title}
-            isCollapsed={panel.isCollapsed}
-            onClick={onPanelClick}
-            dts={panelDts}
-          >
-            {panel.content}
-          </Panel>
-        );
+        return <Panel {...panelProps}>{panel.content}</Panel>;
       })}
     </Card.Content>
   </Card.Container>

--- a/src/components/adslot-ui/Accordion/index.spec.jsx
+++ b/src/components/adslot-ui/Accordion/index.spec.jsx
@@ -10,17 +10,17 @@ describe('AccordionComponent', () => {
   const { panel1, panel2, panel3 } = PanelMocks;
 
   it('should render with defaults', () => {
-    const component = shallow(<Accordion panels={[]} onPanelClick={_.noop} />);
-    const cardElement = component.find(Card.Content);
+    const wrapper = shallow(<Accordion panels={[]} onPanelClick={_.noop} />);
+    const cardElement = wrapper.find(Card.Content);
     expect(cardElement).to.have.length(1);
     expect(cardElement.children()).to.have.length(0);
   });
 
   it('should render with props', () => {
     const panels = [panel1, panel2, panel3];
-    const component = shallow(<Accordion panels={panels} onPanelClick={_.noop} dts="my-accordian" />);
+    const wrapper = shallow(<Accordion panels={panels} onPanelClick={_.noop} dts="my-accordian" />);
 
-    const cardElement = component.find(Card.Content);
+    const cardElement = wrapper.find(Card.Content);
     expect(cardElement).to.have.length(1);
 
     const panelElements = cardElement.find(Panel);
@@ -43,8 +43,8 @@ describe('AccordionComponent', () => {
   it('should pass onPanelClick down to panels', () => {
     const callback = sinon.spy();
     const panels = [panel1, panel2, panel3];
-    const component = mount(<Accordion panels={panels} onPanelClick={callback} />);
-    const panelElements = component.find(Panel);
+    const wrapper = mount(<Accordion panels={panels} onPanelClick={callback} />);
+    const panelElements = wrapper.find(Panel);
 
     panelElements
       .at(0)
@@ -66,5 +66,23 @@ describe('AccordionComponent', () => {
     expect(callback.firstCall.calledWith('1')).to.equal(true);
     expect(callback.secondCall.calledWith('2')).to.equal(true);
     expect(callback.thirdCall.calledWith('3')).to.equal(true);
+  });
+
+  it('should pass custom props down to panels', () => {
+    const panels = [panel1, panel2, { ...panel3, className: 'test-class', randomProp: 'random-prop-value' }];
+    const wrapper = mount(<Accordion panels={panels} onPanelClick={_.noop} />);
+
+    expect(
+      wrapper
+        .find(Panel)
+        .at(2)
+        .prop('className')
+    ).to.equal('test-class');
+    expect(
+      wrapper
+        .find(Panel)
+        .at(2)
+        .prop('randomProp')
+    ).to.equal('random-prop-value');
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Since https://github.com/Adslot/adslot-ui/pull/786 is merged, `Panel` can accept `className` prop now. However, `Accordion` component doesn't pass down the prop to its child `Panel`. This PR attempts to fix the problem.

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
