### PR TITLE
feat: refactor Accordion component

### DIFF
--- a/docs/components/Layout/index.jsx
+++ b/docs/components/Layout/index.jsx
@@ -39,6 +39,7 @@ import SvgSymbolExample from '../../examples/SvgSymbolExample';
 import SvgSymbolCircleExample from '../../examples/SvgSymbolCircleExample';
 import TileGridExample from '../../examples/TileGridExample';
 import AccordionExample from '../../examples/AccordionExample';
+import AccordionPanelExample from '../../examples/AccordionPanelExample';
 import CarouselExample from '../../examples/CarouselExample';
 import ConfirmModalExample from '../../examples/ConfirmModalExample';
 import HelpIconPopoverExample from '../../examples/HelpIconPopoverExample';
@@ -227,6 +228,7 @@ class PageLayout extends React.Component {
             <CardExample />
             <PanelExample />
             <AccordionExample />
+            <AccordionPanelExample />
             <BorderedWellExample />
             <CarouselExample />
             <GridExample />

--- a/docs/components/Navigation/index.jsx
+++ b/docs/components/Navigation/index.jsx
@@ -14,35 +14,29 @@ const contentFactory = navigateTo => componentName => (
   </li>
 );
 
-const panelFactory = (navigateTo, currentOpenPanel) => (section, sectionName) => ({
+const panelFactory = navigateTo => (section, sectionName) => ({
   id: sectionName,
   title: _.startCase(sectionName),
   content: <ul className="list-unstyled">{_.map(section, contentFactory(navigateTo))}</ul>,
-  isCollapsed: sectionName !== currentOpenPanel,
 });
 
 class Navigation extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      currentOpenPanel: initialOpenPanel,
-    };
-    this.togglePanel = this.togglePanel.bind(this);
-  }
-
-  togglePanel(panelId) {
+  togglePanel = panelId => {
     const nextPanel = panelId === this.state.currentOpenPanel ? '' : panelId;
     this.setState({ currentOpenPanel: nextPanel });
-  }
+  };
 
   render() {
-    const panels = _.map(
-      this.props.componentsBySection,
-      panelFactory(this.props.navigateTo, this.state.currentOpenPanel)
-    );
+    const panels = _.map(this.props.componentsBySection, panelFactory(this.props.navigateTo));
     return (
       <div className="adslot-ui-navigation">
-        <Accordion onPanelClick={this.togglePanel} panels={panels} />
+        <Accordion defaultActivePanelIds={[initialOpenPanel]} maxExpand={1}>
+          {_.map(panels, panel => (
+            <Accordion.Panel {...panel} key={panel.id}>
+              {panel.content}
+            </Accordion.Panel>
+          ))}
+        </Accordion>
       </div>
     );
   }

--- a/docs/examples/AccordionExample.jsx
+++ b/docs/examples/AccordionExample.jsx
@@ -1,67 +1,68 @@
 import React from 'react';
-import _ from 'lodash';
-import Immutable from 'seamless-immutable';
 import Example from '../components/Example';
-import { Accordion, Checkbox } from '../../src';
-
-const initialState = {
-  accordionPanels: [
-    {
-      id: '1',
-      icon: { href: './docs/assets/svg-symbols.svg#list' },
-      title: 'Filter by region',
-      isCollapsed: true,
-      content: (
-        <ul className="list-unstyled">
-          <li>
-            <Checkbox label="Australia" />
-          </li>
-          <li>
-            <Checkbox label="New Zealand" />
-          </li>
-        </ul>
-      ),
-    },
-    {
-      id: '2',
-      icon: { href: './docs/assets/svg-symbols.svg#list' },
-      title: 'Filter by device',
-      isCollapsed: false,
-      content: (
-        <ul className="list-unstyled">
-          <li>
-            <Checkbox label="Desktop" />
-          </li>
-          <li>
-            <Checkbox label="Mobile" />
-          </li>
-          <li>
-            <Checkbox label="Tablet" />
-          </li>
-        </ul>
-      ),
-    },
-  ],
-};
+import { Accordion, Checkbox, Panel } from '../../src';
 
 class AccordionExample extends React.Component {
-  constructor() {
-    super();
-    this.state = initialState;
-    this.toggleAccordionPanel = this.toggleAccordionPanel.bind(this);
-  }
+  state = {
+    clickHistory: [],
+  };
 
-  toggleAccordionPanel(panelId) {
-    const nextPanels = Immutable.from(this.state.accordionPanels).asMutable({
-      deep: true,
+  onPanelClick = panelId => {
+    this.setState({
+      clickHistory: [...this.state.clickHistory, `onPanelClick triggered on ${panelId}`],
     });
-    const panelToToggle = _.find(nextPanels, { id: panelId });
-    panelToToggle.isCollapsed = !panelToToggle.isCollapsed;
-    this.setState({ accordionPanels: nextPanels });
-  }
+  };
 
   render() {
-    return <Accordion panels={this.state.accordionPanels} onPanelClick={this.toggleAccordionPanel} />;
+    return (
+      <div className="row">
+        <div className="col-xs-6">
+          <Accordion defaultActivePanelIds={['filter-by-region']} onPanelClick={this.onPanelClick} maxExpand={3}>
+            <Accordion.Panel id="filter-by-region" title="Filter by region">
+              <ul className="list-unstyled">
+                <li>
+                  <Checkbox label="Australia" />
+                </li>
+                <li>
+                  <Checkbox label="New Zealand" />
+                </li>
+              </ul>
+            </Accordion.Panel>
+            <Accordion.Panel id="filter-by-device" title="Filter by device">
+              <ul className="list-unstyled">
+                <li>
+                  <Checkbox label="Desktop" />
+                </li>
+                <li>
+                  <Checkbox label="Mobile" />
+                </li>
+                <li>
+                  <Checkbox label="Tablet" />
+                </li>
+              </ul>
+            </Accordion.Panel>
+            <div>test</div>
+            <Accordion.Panel id="filter-1" title="Filter 1">
+              Filter 1
+            </Accordion.Panel>
+            <Accordion.Panel id="filter-2" title="Filter 2">
+              Filter 2
+            </Accordion.Panel>
+            <Accordion.Panel id="filter-3" title="Filter 3">
+              Filter 3
+            </Accordion.Panel>
+            <Accordion.Panel id="filter-4" title="Filter 4">
+              Filter 4
+            </Accordion.Panel>
+          </Accordion>
+        </div>
+        <div className="col-xs-6">
+          {this.state.clickHistory.map((text, index) => (
+            <div key={`${index}-${text}`}>{text}</div>
+          ))}
+        </div>
+      </div>
+    );
   }
 }
 
@@ -73,7 +74,31 @@ const exampleProps = {
       areas of the list.
     </p>
   ),
-  exampleCodeSnippet: '<Accordion panels={accordionPanels} onPanelClick={this.toggleAccordionPanel} />',
+  exampleCodeSnippet: `<Accordion defaultActivePanelIds={['filter-by-region']} onPanelClick={this.onPanelClick} maxExpand={3}>
+    <Accordion.Panel id="filter-by-region" title="Filter by region">
+      <ul className="list-unstyled">
+        <li>
+          <Checkbox label="Australia" />
+        </li>
+        <li>
+          <Checkbox label="New Zealand" />
+        </li>
+      </ul>
+    </Accordion.Panel>
+    <Accordion.Panel id="filter-by-device" title="Filter by device">
+      <ul className="list-unstyled">
+        <li>
+          <Checkbox label="Desktop" />
+        </li>
+        <li>
+          <Checkbox label="Mobile" />
+        </li>
+        <li>
+          <Checkbox label="Tablet" />
+        </li>
+      </ul>
+    </Accordion.Panel>
+  </Accordion>`,
   propTypeSectionArray: [
     {
       propTypes: [
@@ -83,16 +108,35 @@ const exampleProps = {
           note: 'render `data-test-selector` onto the component. It can be useful for testing.',
         },
         {
-          propType: 'panels',
-          type: (
+          propType: 'onPanelClick',
+          type: 'func',
+          note: (
             <span>
-              arrayOf <a href="#panel-example">Panels</a>
+              <pre>onPanelClick(panelId)</pre>
+              <br />
+              takes in a single parameter which is the id of the clicked panel.
             </span>
           ),
         },
         {
-          propType: 'onPanelClick',
-          type: 'func',
+          propType: 'defaultActivePanelIds',
+          type: 'arrayOf(string)',
+        },
+        {
+          propType: 'maxExpand',
+          type: "oneOfType(number, string('max'))",
+          defaultValue: 'max',
+          note:
+            'determine how many Panels can be expanded, accepted value is a positive number, or `max` to have no restriction',
+        },
+        {
+          propType: 'children',
+          type: 'node',
+          note: (
+            <span>
+              Panel(s) to be rendered inside the Accordion. See <a href="#accordion-panel-example">Accordion.Panels</a>
+            </span>
+          ),
         },
       ],
     },

--- a/docs/examples/AccordionPanelExample.jsx
+++ b/docs/examples/AccordionPanelExample.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Example from '../components/Example';
+import { Accordion } from '../../src';
+
+class AccordionPanelExample extends React.Component {
+  state = {
+    isCollapsed: false,
+  };
+
+  onPanelClick = () => this.setState({ isCollapsed: !this.state.isCollapsed });
+
+  render() {
+    return (
+      <Accordion.Panel id="panel-id" title="demo" isCollapsed={this.state.isCollapsed} onClick={this.onPanelClick}>
+        Panel content
+      </Accordion.Panel>
+    );
+  }
+}
+
+const exampleProps = {
+  componentName: 'Accordion.Panel',
+  designNotes: (
+    <p>
+      See <a href="#panel-example">Panel</a>
+    </p>
+  ),
+  exampleCodeSnippet: `<Accordion.Panel
+    id="panel-id"
+    title="demo"
+    isCollapsed={this.state.isCollapsed}
+    onClick={this.onPanelClick}
+  >
+    Panel content
+  </Accordion.Panel>`,
+  propTypeSectionArray: [],
+};
+
+export default () => (
+  <Example {...exampleProps}>
+    <AccordionPanelExample />
+  </Example>
+);

--- a/docs/examples/PanelExample.jsx
+++ b/docs/examples/PanelExample.jsx
@@ -94,7 +94,6 @@ const exampleProps = {
         {
           propType: 'isCollapsed',
           type: 'boolean',
-          defaultValue: 'false',
           note: '',
         },
         {

--- a/docs/examples/styles.scss
+++ b/docs/examples/styles.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  &.accordion-example,
+  &.accordion-panel-example,
   &.card-example {
     .adslot-ui-example {
       width: 240px;

--- a/src/components/adslot-ui/Accordion/AccordionPanel/index.jsx
+++ b/src/components/adslot-ui/Accordion/AccordionPanel/index.jsx
@@ -1,0 +1,7 @@
+import Panel from '../../Panel';
+
+class AccordionPanel extends Panel {
+  static displayName = 'Accordion.Panel';
+}
+
+export default AccordionPanel;

--- a/src/components/adslot-ui/Accordion/index.jsx
+++ b/src/components/adslot-ui/Accordion/index.jsx
@@ -1,35 +1,91 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import Panel from 'adslot-ui/Panel';
 import Card from 'alexandria/Card';
+import AccordionPanel from './AccordionPanel';
 
-const AccordionComponent = ({ dts, panels, onPanelClick }) => (
-  <Card.Container>
-    <Card.Content fill>
-      {_.map(panels, panel => {
-        const panelDts = dts ? `panel-${panel.id}` : undefined;
-        const panelProps = {
-          key: panel.id,
-          onClick: onPanelClick,
-          dts: panelDts,
-          ..._.omit(panel, ['content', 'onClick']),
-        };
+class AccordionComponent extends React.PureComponent {
+  static propTypes = {
+    dts: PropTypes.string,
+    onPanelClick: PropTypes.func,
+    children: PropTypes.node,
+    defaultActivePanelIds: PropTypes.arrayOf(PropTypes.string),
+    maxExpand: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['max'])]),
+  };
 
-        return <Panel {...panelProps}>{panel.content}</Panel>;
-      })}
-    </Card.Content>
-  </Card.Container>
-);
+  static defaultProps = {
+    maxExpand: 'max',
+  };
 
-const accordionPanelPropTypes = _.pick(Panel.propTypes, ['id', 'icon', 'title', 'isCollapsed']);
+  state = {
+    activePanelIds:
+      this.props.maxExpand === 'max'
+        ? this.props.defaultActivePanelIds
+        : _.slice(this.props.defaultActivePanelIds, 0, this.props.maxExpand),
+  };
 
-accordionPanelPropTypes.content = PropTypes.node;
+  onPanelClick = panelId => {
+    const { maxExpand } = this.props;
 
-AccordionComponent.propTypes = {
-  dts: PropTypes.string,
-  panels: PropTypes.arrayOf(PropTypes.shape(accordionPanelPropTypes)).isRequired,
-  onPanelClick: PropTypes.func.isRequired,
-};
+    if (_.includes(this.state.activePanelIds, panelId)) {
+      // remove panelId out of the active list
+      this.setState({ activePanelIds: _.without(this.state.activePanelIds, panelId) });
+    } else {
+      // drop panels from the beginning if max opened panels count is reached
+      let newActivePanelIds = [...this.state.activePanelIds, panelId];
+      if (maxExpand !== 'max' && newActivePanelIds.length > maxExpand) {
+        newActivePanelIds = _.drop(newActivePanelIds, newActivePanelIds.length - maxExpand);
+      }
+
+      this.setState({ activePanelIds: newActivePanelIds });
+    }
+
+    if (this.props.onPanelClick) {
+      this.props.onPanelClick(panelId);
+    }
+  };
+
+  validateProps() {
+    const { maxExpand } = this.props;
+
+    // validate maxExpand value
+    switch (true) {
+      case _.isNumber(maxExpand) && maxExpand <= 0:
+      case _.isString(maxExpand) && maxExpand !== 'max':
+        throw new Error("maxExpand must be a positive number or 'max'");
+      default:
+        break;
+    }
+  }
+
+  renderPanelFromChildren = child => {
+    const { id, isCollapsed } = child.props;
+
+    // prevent rendering if child is not an instance of Accordion.Panel
+    if (child.type.displayName !== AccordionPanel.displayName) {
+      return null;
+    }
+
+    // respects child.props.isCollapsed for controlled behaviour
+    return React.cloneElement(child, {
+      ...child.props,
+      onClick: this.onPanelClick,
+      isCollapsed: _.isNil(isCollapsed) ? !_.includes(this.state.activePanelIds, id) : isCollapsed,
+    });
+  };
+
+  render() {
+    const { children, dts } = this.props;
+    this.validateProps();
+
+    return (
+      <Card.Container dts={dts}>
+        <Card.Content fill>{React.Children.map(children, this.renderPanelFromChildren)}</Card.Content>
+      </Card.Container>
+    );
+  }
+}
+
+AccordionComponent.Panel = AccordionPanel;
 
 export default AccordionComponent;

--- a/src/components/adslot-ui/Panel/index.jsx
+++ b/src/components/adslot-ui/Panel/index.jsx
@@ -2,38 +2,36 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SvgSymbol from 'alexandria/SvgSymbol';
 import classnames from 'classnames';
+import './styles.scss';
 
-require('./styles.scss');
+class PanelComponent extends React.PureComponent {
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    className: PropTypes.string,
+    dts: PropTypes.string,
+    icon: PropTypes.shape(SvgSymbol.propTypes),
+    title: PropTypes.node.isRequired,
+    isCollapsed: PropTypes.bool,
+    onClick: PropTypes.func,
+    children: PropTypes.node,
+  };
 
-const PanelComponent = ({ id, className, dts, icon, title, isCollapsed, onClick, children }) => {
-  const classesCombined = classnames(['panel-component', className, { collapsed: isCollapsed }]);
+  onHeaderClick = () => this.props.onClick(this.props.id);
 
-  const onHeaderClick = () => onClick(id);
+  render() {
+    const { className, children, dts, icon, isCollapsed, title } = this.props;
+    const classesCombined = classnames(['panel-component', className, { collapsed: isCollapsed }]);
 
-  return (
-    <div className={classesCombined} data-test-selector={dts}>
-      <div className="panel-component-header clearfix" onClick={onHeaderClick}>
-        {icon ? <SvgSymbol href={icon.href} /> : null}
-        {title}
+    return (
+      <div className={classesCombined} data-test-selector={dts}>
+        <div className="panel-component-header clearfix" onClick={this.onHeaderClick}>
+          {icon ? <SvgSymbol href={icon.href} /> : null}
+          {title}
+        </div>
+        <div className="panel-component-content">{children}</div>
       </div>
-      <div className="panel-component-content">{children}</div>
-    </div>
-  );
-};
-
-PanelComponent.propTypes = {
-  id: PropTypes.string.isRequired,
-  className: PropTypes.string,
-  dts: PropTypes.string,
-  icon: PropTypes.shape(SvgSymbol.propTypes),
-  title: PropTypes.node.isRequired,
-  isCollapsed: PropTypes.bool,
-  onClick: PropTypes.func.isRequired,
-  children: PropTypes.node,
-};
-
-PanelComponent.defaultProps = {
-  isCollapsed: false,
-};
+    );
+  }
+}
 
 export default PanelComponent;

--- a/src/components/adslot-ui/Panel/mocks.js
+++ b/src/components/adslot-ui/Panel/mocks.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 const panel1 = {
   id: '1',
   title: 'Panel 1',
+  dts: 'panel-1',
   onClick: _.noop,
 };
 
@@ -24,6 +25,7 @@ const panel3 = {
   className: 'test-class-1 test-class-2',
   onClick: _.noop,
   content: 'Panel 3 content',
+  dts: 'panel-3',
 };
 
 const PanelMocks = immutable({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Refactor Accordion component to take in children as the Panels to be rendered.
- Allow uncontrolled behaviour to collapse/expand Panels.
- Resolves https://github.com/Adslot/adslot-ui/issues/799

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Accordion component has been taking in Panel's props array to render children internally, which can cause some performance issue when dealing with a dynamic list of Panels. By allowing user to define the Panels themselves, we improve the performance on the Accordion, and enhance the readability.

```jsx
<Accordion defaultActivePanelIds={["filter-by-region"]} onPanelClick={this.onPanelClick} maxExpand={1}>
    <Accordion.Panel id="filter-by-region" title="Filter by region">
      <ul className="list-unstyled">
        <li>
          <Checkbox label="Australia" />
        </li>
        <li>
          <Checkbox label="New Zealand" />
        </li>
      </ul>
    </Accordion.Panel>
    <Accordion.Panel id="filter-by-device" title="Filter by device">
      <ul className="list-unstyled">
        <li>
          <Checkbox label="Desktop" />
        </li>
        <li>
          <Checkbox label="Mobile" />
        </li>
        <li>
          <Checkbox label="Tablet" />
        </li>
      </ul>
    </Accordion.Panel>
  </Accordion>
```

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

The API for Accordion is changed, therefore we need to update all places that use the Accordion in the related projects.
Changing from using `props.panels` to actually render `Panel` component in `Accordion` children (as shown in the example)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [x] I've fixed or replied to all my code-review comments.
- [x] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
