### PR TITLE
Set default panel ids for accordion

### DIFF
--- a/src/components/adslot-ui/Accordion/index.jsx
+++ b/src/components/adslot-ui/Accordion/index.jsx
@@ -15,6 +15,7 @@ class AccordionComponent extends React.PureComponent {
 
   static defaultProps = {
     maxExpand: 'max',
+    defaultActivePanelIds: [],
   };
 
   state = {

--- a/src/components/adslot-ui/Accordion/index.spec.jsx
+++ b/src/components/adslot-ui/Accordion/index.spec.jsx
@@ -31,6 +31,17 @@ describe('AccordionComponent', () => {
     expect(cardElement.children()).to.have.length(1);
   });
 
+  it('should have default props', () => {
+    const wrapper = shallow(
+      <Accordion {...makeProps()}>
+        <Accordion.Panel {...panel1}>{panel1.content}</Accordion.Panel>
+      </Accordion>
+    );
+    const instance = wrapper.instance();
+    expect(instance.props.defaultActivePanelIds).to.eql([]);
+    expect(instance.props.maxExpand).to.equal('max');
+  });
+
   it('should render with props', () => {
     const wrapper = shallow(
       <Accordion {...makeProps()}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When not set `defaultPanelIds` and `maxExpand`, the panel is not clickable and throw error on console. Because the defaultPanelIds should be an array not `undefined`

<img width="752" alt="screen shot 2019-01-30 at 9 56 07 am" src="https://user-images.githubusercontent.com/15777593/51946349-50fc5b00-2475-11e9-986c-15b6ea4cdd41.png">


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [Contributing](CONTRIBUTING.md) document.
- [ ] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [ ] I've squashed my commits into one.
