### PR TITLE
fix: tab crash when child is null

### DIFF
--- a/src/components/adslot-ui/Tabs/index.jsx
+++ b/src/components/adslot-ui/Tabs/index.jsx
@@ -44,7 +44,7 @@ class Tabs extends React.Component {
 
     const tabs = [];
     const content = React.Children.map(children, child => {
-      if (_.isFunction(child.type) && child.type.innerName === Tab.innerName) {
+      if (!_.isEmpty(child) && _.isFunction(child.type) && child.type.innerName === Tab.innerName) {
         const tab = React.cloneElement(child, {
           show: this.activeKey === child.props.eventKey,
         });

--- a/src/components/adslot-ui/Tabs/index.spec.jsx
+++ b/src/components/adslot-ui/Tabs/index.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 import Tabs from '.';
 import Tab from '../Tab';
@@ -70,5 +70,17 @@ describe('<Tabs />', () => {
     links.last().simulate('click', { preventDefault: _.noop });
     links.last().simulate('click', { preventDefault: _.noop });
     expect(spy.callCount).to.equal(1);
+  });
+
+  it('should not crash when child returns null', () => {
+    const wrapper = mount(
+      <Tabs defaultActiveKey="first" id="test">
+        <Tab eventKey="first" title="Fist">
+          Tab1
+        </Tab>
+        {null}
+      </Tabs>
+    );
+    expect(wrapper.find(Tabs).length).to.equal(1);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Fix a bug where the `Tabs` crash when child is null. For instance conditional rendering.

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#817 
## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
