### PR TITLE
[853] display a better error message for Tabs

### DIFF
--- a/src/components/adslot-ui/CheckboxGroup/index.spec.jsx
+++ b/src/components/adslot-ui/CheckboxGroup/index.spec.jsx
@@ -6,6 +6,14 @@ import { Checkbox } from 'adslot-ui';
 import CheckboxGroup from '.';
 
 describe('CheckboxGroup', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => sandbox.restore());
+
   it('should render with props', () => {
     const wrapper = shallow(
       <CheckboxGroup name="movies" value={['terminator', 'predator']} className="custom-class" onChange={sinon.spy}>
@@ -53,7 +61,7 @@ describe('CheckboxGroup', () => {
   });
 
   it('should print warning if child is not a Checkbox component', () => {
-    console.error = sinon.spy();
+    sandbox.spy(console, 'error');
     shallow(
       <CheckboxGroup name="movies" value={['test']} onChange={_.noop}>
         <div>Not a Checkbox</div>

--- a/src/components/adslot-ui/Tabs/index.jsx
+++ b/src/components/adslot-ui/Tabs/index.jsx
@@ -1,8 +1,8 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react';
-import PropTypes from 'prop-types';
 import _ from 'lodash';
 import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Tab from '../Tab';
 
 class Tabs extends React.Component {
@@ -44,15 +44,18 @@ class Tabs extends React.Component {
 
     const tabs = [];
     const content = React.Children.map(children, child => {
-      if (!_.isEmpty(child) && _.isFunction(child.type) && child.type.innerName === Tab.innerName) {
-        const tab = React.cloneElement(child, {
-          show: this.activeKey === child.props.eventKey,
-        });
-        tabs.push(tab);
-
-        return tab;
+      if (_.get(child, 'type.innerName') !== Tab.innerName) {
+        console.error('<Tabs /> children must be instances of <Tab />');
+        return false;
       }
-      return child;
+
+      // child must be a Tab instance at this point
+      const tab = React.cloneElement(child, {
+        show: this.activeKey === child.props.eventKey,
+      });
+      tabs.push(tab);
+
+      return tab;
     });
 
     return (

--- a/src/components/adslot-ui/Tabs/index.spec.jsx
+++ b/src/components/adslot-ui/Tabs/index.spec.jsx
@@ -5,7 +5,21 @@ import sinon from 'sinon';
 import Tabs from '.';
 import Tab from '../Tab';
 
+class MyComponent extends React.PureComponent {
+  render() {
+    return null;
+  }
+}
+
 describe('<Tabs />', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => sandbox.restore());
+
   it('should render with props', () => {
     const wrapper = shallow(
       <Tabs defaultActiveKey="first" id="test">
@@ -34,7 +48,7 @@ describe('<Tabs />', () => {
   });
 
   it('should work as controlled', () => {
-    const selectSpy = sinon.spy();
+    const selectSpy = sandbox.spy();
     const wrapper = shallow(
       <Tabs activeKey="first" onSelect={selectSpy} id="test">
         <Tab eventKey="first" title="Fist">
@@ -65,7 +79,7 @@ describe('<Tabs />', () => {
         </Tab>
       </Tabs>
     );
-    const spy = sinon.spy(wrapper.instance(), 'setState');
+    const spy = sandbox.spy(wrapper.instance(), 'setState');
     const links = wrapper.find('a');
     links.last().simulate('click', { preventDefault: _.noop });
     links.last().simulate('click', { preventDefault: _.noop });
@@ -82,5 +96,19 @@ describe('<Tabs />', () => {
       </Tabs>
     );
     expect(wrapper.find(Tabs).length).to.equal(1);
+  });
+
+  it('should throw error if child of <Tabs /> is not <Tab />', () => {
+    sandbox.stub(console, 'error').callsFake(message => {
+      expect(message).to.equal('<Tabs /> children must be instances of <Tab />');
+    });
+
+    mount(
+      <Tabs id="error">
+        <MyComponent />
+      </Tabs>
+    );
+
+    expect(console.error.called).to.equal(true);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Display a better error message when using Tabs component.

Resolves https://github.com/Adslot/adslot-ui/issues/853
## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [Contributing](CONTRIBUTING.md) document.
- [ ] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [ ] I've squashed my commits into one.
