### PR TITLE
fix: action panel backdrop opacity and fade in

### DIFF
--- a/src/components/adslot-ui/ActionPanel/index.jsx
+++ b/src/components/adslot-ui/ActionPanel/index.jsx
@@ -4,26 +4,42 @@ import classNames from 'classnames';
 import Button from 'react-bootstrap/lib/Button';
 import './styles.scss';
 
-const ActionPanel = ({ title, className, size, onClose, children, actionButton, isModal, closeIcon }) => (
-  <div className={classNames('aui--action-panel-wrapper', { 'aui--action-panel-wrapper-backdrop': isModal })}>
-    <div className={classNames('aui--action-panel', className, `is-${size}`, { 'action-modal': isModal })}>
-      <div className={classNames('aui--action-panel-header', { 'has-actions': actionButton })}>
-        <span className="title">{title}</span>
-        <span className="actions">
-          <Button
-            onClick={onClose}
-            className={classNames('close-button', { 'close-svg-icon': !actionButton })}
-            dts="header-close-button"
-          >
-            {actionButton ? 'Cancel' : closeIcon}
-          </Button>
-          {actionButton}
-        </span>
-      </div>
-      <div className="aui--action-panel-body">{children}</div>
-    </div>
-  </div>
-);
+class ActionPanel extends React.PureComponent {
+  componentDidMount() {
+    if (this.props.isModal) document.body.classList.add('modal-open');
+  }
+
+  componentWillUnmount() {
+    if (this.props.isModal) document.body.classList.remove('modal-open');
+  }
+
+  render() {
+    const { title, className, size, onClose, children, actionButton, isModal, closeIcon } = this.props;
+    return (
+      <React.Fragment>
+        <div className={isModal ? 'aui--action-panel-backdrop' : 'hide'} />
+        <div className={classNames('aui--action-panel-wrapper', { 'aui--action-panel-modal-wrapper': isModal })}>
+          <div className={classNames('aui--action-panel', className, `is-${size}`, { 'action-modal': isModal })}>
+            <div className={classNames('aui--action-panel-header', { 'has-actions': actionButton })}>
+              <span className="title">{title}</span>
+              <span className="actions">
+                <Button
+                  onClick={onClose}
+                  className={classNames('close-button', { 'close-svg-icon': !actionButton })}
+                  dts="header-close-button"
+                >
+                  {actionButton ? 'Cancel' : closeIcon}
+                </Button>
+                {actionButton}
+              </span>
+            </div>
+            <div className="aui--action-panel-body">{children}</div>
+          </div>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
 
 ActionPanel.propTypes = {
   title: PropTypes.string.isRequired,

--- a/src/components/adslot-ui/ActionPanel/index.spec.jsx
+++ b/src/components/adslot-ui/ActionPanel/index.spec.jsx
@@ -24,15 +24,23 @@ describe('ActionPanelComponent', () => {
 
     const bodyElement = wrapper.find('.aui--action-panel-body');
     expect(bodyElement).to.have.length(1);
+
+    wrapper.instance().componentWillUnmount();
+    expect(document.body.classList.contains('modal-open')).to.equal(false);
   });
 
   it('should render as a modal', () => {
     const wrapper = shallow(
       <ActionPanel {...makeProps({ isModal: true, size: 'large', actionButton: <Button>Action</Button> })} />
     );
-    expect(wrapper.prop('className')).to.equal('aui--action-panel-wrapper aui--action-panel-wrapper-backdrop');
 
+    expect(document.body.classList.contains('modal-open')).to.equal(true);
+
+    expect(wrapper.find('.aui--action-panel-modal-wrapper')).to.have.length(1);
     const actionPanelElement = wrapper.find('.aui--action-panel');
     expect(actionPanelElement.prop('className')).to.equal('aui--action-panel is-large action-modal');
+
+    wrapper.instance().componentWillUnmount();
+    expect(document.body.classList.contains('modal-open')).to.equal(false);
   });
 });

--- a/src/components/adslot-ui/ActionPanel/styles.scss
+++ b/src/components/adslot-ui/ActionPanel/styles.scss
@@ -4,6 +4,7 @@
 @import '~styles/variable';
 @import '~styles/font-weight';
 @import '~styles/icon';
+@import '~styles/animation';
 
 .aui--action-panel {
   min-width: 300px;
@@ -14,7 +15,6 @@
   border-radius: 2px;
 
   &.action-modal {
-    position: fixed;
     top: 30px;
     background-color: $color-white ;
     margin: 30px auto;
@@ -121,20 +121,28 @@
   &-body {
     padding: 30px;
   }
+}
 
-  &-wrapper-backdrop {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    background-color: $color-gray-dark;
-    width: 100%;
-    z-index: 1040;
-    display: flex;
-    justify-content: center;
-    opacity: .9;
-  }
+.aui--action-panel-backdrop {
+  position: fixed;
+  display: flex;
+  z-index: 1040;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  background-color: $color-gray-dark;
+  width: 100%;
+  opacity: .9;
+  animation: fadein .2s;
 }
 
 
-
+.aui--action-panel-modal-wrapper {
+  position: fixed;
+  width: 100%;
+  z-index: 1040;
+  display: flex;
+  align-content: center;
+  top: 0;
+  left: 0;
+}

--- a/src/styles/animation.scss
+++ b/src/styles/animation.scss
@@ -1,0 +1,9 @@
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: .9;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Fix the opacity of the action panel  backdrop. This will fix the issue where when it is opening as a modal and the modal also has opacity.

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is found while testing the action panel in the direct-web.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before the fix
![Screen Shot 2019-06-27 at 10 52 20 am](https://user-images.githubusercontent.com/7802760/60225351-c0159880-98c9-11e9-977d-e2be0e9b7c1f.png)


After the fix
![Screen Shot 2019-06-27 at 10 52 49 am](https://user-images.githubusercontent.com/7802760/60225362-c7d53d00-98c9-11e9-8729-a537238c9e84.png)

## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing](CONTRIBUTING.md) document.
- [x] I've thought about and labelled my PR/commit message appropriately.
- [x] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [x] CI is green (coverage, linting, tests).
- [x] I have updated the documentation accordingly.
- [x] I've two LGTMs/Approvals.
- [x] I've fixed or replied to all my code-review comments.
- [x] I've manually tested with a buddy.
- [x] I've squashed my commits into one.
