### PR TITLE
fix: action panel to render as a body direct child

### DIFF
--- a/src/components/adslot-ui/ActionPanel/index.jsx
+++ b/src/components/adslot-ui/ActionPanel/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import ReactDOM from 'react-dom';
 import Button from 'react-bootstrap/lib/Button';
 import './styles.scss';
 
@@ -15,7 +16,8 @@ class ActionPanel extends React.PureComponent {
 
   render() {
     const { title, className, size, onClose, children, actionButton, isModal, closeIcon } = this.props;
-    return (
+
+    const actionPanel = (
       <React.Fragment>
         <div className={isModal ? 'aui--action-panel-backdrop' : 'hide'} />
         <div className={classNames('aui--action-panel-wrapper', { 'aui--action-panel-modal-wrapper': isModal })}>
@@ -38,6 +40,8 @@ class ActionPanel extends React.PureComponent {
         </div>
       </React.Fragment>
     );
+
+    return isModal ? ReactDOM.createPortal(actionPanel, document.body) : actionPanel;
   }
 }
 

--- a/src/components/adslot-ui/ActionPanel/styles.scss
+++ b/src/components/adslot-ui/ActionPanel/styles.scss
@@ -13,6 +13,7 @@
   z-index: $zindex-popover;
   border: $border-lighter;
   border-radius: 2px;
+  background-color: $color-white;
 
   &.action-modal {
     top: 30px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
This will fixed the issue where action panel (modal) render as a distance sibling of the body but not a direct child of the body. 


## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Found a bug in the latest release where it render the modal, but the backdrop not covering the whole page

Need this to render as a direct child of the body, so the modal will appear top of all the other UI components. 

(https://github.com/Adslot/adslot-ui/issues/878)
## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally in direct-web. Working as expected

## Screenshots (if appropriate):

Before the fix
![Screen Shot 2019-07-11 at 4 02 04 pm](https://user-images.githubusercontent.com/7802760/61025855-47e4c200-a3f5-11e9-8d4e-5316caafe5da.png)

after the fix
![Screen Shot 2019-07-15 at 2 13 29 pm](https://user-images.githubusercontent.com/7802760/61195346-c2218900-a70a-11e9-905a-142fbf8abcbd.png)


## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [Contributing](CONTRIBUTING.md) document.
- [ ] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [ ] I've squashed my commits into one.
