### PR TITLE
fix: fix the status pill colors

### DIFF
--- a/src/components/adslot-ui/StatusPill/styles.scss
+++ b/src/components/adslot-ui/StatusPill/styles.scss
@@ -1,13 +1,13 @@
 @import '~styles/variable';
 
 $color-primary: $color-status-blue;
-$color-primary-background: rgba($color-primary, .35);
+$color-primary-background: $color-status-light-blue;
 $color-success: $color-status-green;
-$color-success-background: rgba($color-success, .35);
+$color-success-background: $color-status-light-green;
 $color-warning: $color-status-orange;
-$color-warning-background: rgba($color-warning, .35);
+$color-warning-background: $color-status-light-orange;
 $color-error: $color-status-red;
-$color-error-background: rgba($color-error, .35);
+$color-error-background: $color-status-light-red;
 $color-light: $color-status-light;
 $color-inverse-border: $color-status-light;
 

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -38,6 +38,11 @@ $color-status-red: $color-red;
 $color-status-orange: #f93;
 $color-status-light: $color-gray-lighter;
 
+$color-status-light-orange: #fec985;
+$color-status-light-red: #f9b7b0;
+$color-status-light-blue: #c1e1ec;
+$color-status-light-green: #c5e6dc;
+
 // Usage: Use these values, not the colours directly
 
 // Informative


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
change the colours of the status pill (without opacity)

## Motivation and Background Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
opacity might look different when the status pill cover with some other background colour

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screen Shot 2019-07-18 at 9 17 06 am](https://user-images.githubusercontent.com/7802760/61418128-dd73da80-a93c-11e9-8a46-6b41fa0c16b7.png)



## Check-list:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [Contributing](CONTRIBUTING.md) document.
- [ ] I've thought about and labelled my PR/commit message appropriately.
- [ ] If this PR introduces breaking changes I've described the impact and migration path for existing applications.
- [ ] CI is green (coverage, linting, tests).
- [ ] I have updated the documentation accordingly.
- [ ] I've two LGTMs/Approvals.
- [ ] I've fixed or replied to all my code-review comments.
- [ ] I've manually tested with a buddy.
- [ ] I've squashed my commits into one.
