### PR TITLE
refactor: deprecate button reason

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -7,79 +7,40 @@ import PropTypes from 'prop-types';
 import BootstrapButton from 'react-bootstrap/lib/Button';
 import Spinner from '../Spinner';
 import { expandDts } from '../../lib/utils';
-import Popover from '../Popover';
 import './styles.scss';
 
 const adslotButtonPropTypes = {
   inverse: PropTypes.bool,
-  reason: PropTypes.node,
   dts: PropTypes.string,
   isLoading: PropTypes.bool,
 };
 
-class Button extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.buttonRef = React.createRef();
-    this.state = {
-      show: false,
-    };
-    this.handleReasonPopover = this.handleReasonPopover.bind(this);
-  }
+const Button = props => {
+  const { inverse, children, dts, className, isLoading, disabled } = props;
+  const baseClass = 'aui--button';
+  const classes = classNames(baseClass, className, {
+    'btn-inverse': inverse && !/btn-inverse/.test(className),
+  });
 
-  handleReasonPopover(value) {
-    this.setState({ show: value });
-  }
+  const renderSpinner = () =>
+    isLoading ? (
+      <div className="spinner-container">
+        <Spinner size={_.includes(['lg', 'large'], props.bsSize) ? 'medium' : 'small'} />
+      </div>
+    ) : null;
 
-  renderSpinner() {
-    if (this.props.isLoading) {
-      return (
-        <div className="spinner-container">
-          <Spinner size={_.includes(['lg', 'large'], this.props.bsSize) ? 'medium' : 'small'} />
-        </div>
-      );
-    }
-
-    return null;
-  }
-
-  render() {
-    const { inverse, children, dts, className, isLoading, disabled, reason } = this.props;
-    const shouldShowReason = !!disabled && !!reason;
-    const classes = classNames('button-component', className, {
-      'btn-inverse': inverse && !/btn-inverse/.test(className),
-    });
-    const reasonProps = shouldShowReason
-      ? {
-          onMouseOver: () => this.handleReasonPopover(true),
-          onMouseOut: () => this.handleReasonPopover(false),
-        }
-      : {};
-
-    return (
-      <BootstrapButton
-        {..._.omit(this.props, _.keys(adslotButtonPropTypes))}
-        disabled={isLoading || disabled}
-        className={classes}
-        {...expandDts(dts)}
-        {...reasonProps}
-        ref={this.buttonRef}
-      >
-        <Popover
-          className="btn-popover-reason"
-          wrapperClassName="btn-popover-wrapper"
-          popoverContent={reason || ''}
-          placement="bottom"
-          isOpen={this.state.show}
-          triggers={['disabled']}
-        >
-          {this.renderSpinner()}
-          <div className={isLoading ? 'button-component-children-container' : null}>{children}</div>
-        </Popover>
-      </BootstrapButton>
-    );
-  }
-}
+  return (
+    <BootstrapButton
+      {..._.omit(props, _.keys(adslotButtonPropTypes))}
+      disabled={isLoading || disabled}
+      className={classes}
+      {...expandDts(dts)}
+    >
+      {renderSpinner()}
+      <div className={isLoading ? 'aui--button-children-container' : null}>{children}</div>
+    </BootstrapButton>
+  );
+};
 
 Button.propTypes = { ...adslotButtonPropTypes, ...BootstrapButton.propTypes };
 

--- a/src/components/Button/index.spec.jsx
+++ b/src/components/Button/index.spec.jsx
@@ -1,8 +1,8 @@
-import { Popover, Spinner } from 'adslot-ui';
+import { Spinner } from 'adslot-ui';
 import { shallow } from 'enzyme';
 import React from 'react';
 import BootstrapButton from 'react-bootstrap/lib/Button';
-import Button from '.';
+import Button from './';
 
 describe('ButtonComponent', () => {
   it('should render Bootstrap Button', () => {
@@ -17,12 +17,12 @@ describe('ButtonComponent', () => {
 
   it('should support legacy classname btn-inverse for non-breaking change', () => {
     const wrapper = shallow(<Button className="btn-inverse">Test</Button>);
-    expect(wrapper.prop('className')).to.equal('button-component btn-inverse');
+    expect(wrapper.prop('className')).to.equal('aui--button btn-inverse');
   });
 
   it('should support className prop', () => {
     const wrapper = shallow(<Button className="all the-classes">Test</Button>);
-    expect(wrapper.prop('className')).to.equal('button-component all the-classes');
+    expect(wrapper.prop('className')).to.equal('aui--button all the-classes');
   });
 
   it('should support valid html attributes', () => {
@@ -41,12 +41,12 @@ describe('ButtonComponent', () => {
         Test
       </Button>
     );
-    expect(wrapper.prop('className')).to.equal('button-component btn-inverse');
+    expect(wrapper.prop('className')).to.equal('aui--button btn-inverse');
   });
 
   it('should render inverse button with btn-inverse class', () => {
     const wrapper = shallow(<Button inverse>Test</Button>);
-    expect(wrapper.prop('className')).to.equal('button-component btn-inverse');
+    expect(wrapper.prop('className')).to.equal('aui--button btn-inverse');
   });
 
   it('should support data-test-selectors', () => {
@@ -54,26 +54,10 @@ describe('ButtonComponent', () => {
     expect(wrapper.prop('data-test-selector')).to.equal('test-button');
   });
 
-  it('should render disabled button without a reason popover if no reason given', () => {
+  it('should render disabled button', () => {
     const wrapper = shallow(<Button disabled>Test</Button>);
-    const popoverWrapper = wrapper.find(Popover);
-    expect(popoverWrapper).to.have.length(1);
-    expect(popoverWrapper.prop('isOpen')).to.eql(false);
-  });
-
-  it('should render disabled button with a reason popover', () => {
-    const wrapper = shallow(
-      <Button disabled reason="Because">
-        Test
-      </Button>
-    );
-    wrapper.simulate('mouseOver');
-    const popoverWrapper = wrapper.find(Popover);
-    expect(popoverWrapper.prop('isOpen')).to.equal(true);
-    wrapper.update();
-    expect(wrapper.find(Popover).prop('popoverContent')).to.eql('Because');
-    wrapper.simulate('mouseOut');
-    expect(wrapper.find(Popover).prop('isOpen')).to.equal(false);
+    const buttonWrapper = wrapper.find(BootstrapButton);
+    expect(buttonWrapper).to.have.length(1);
   });
 
   it('should render Spinner if isLoading is true', () => {

--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -1,19 +1,7 @@
 @import '~styles/variable';
 
-.button-component {
+.aui--button {
   position: relative;
-
-  .popover-wrapper {
-    &[data-placement*='bottom'] {
-      margin-top: 12px;
-
-      .popover-content {
-        max-width: 140px;
-        color: $color-help;
-        font-size: $font-size-small;
-      }
-    }
-  }
 
   &-children-container {
     visibility: hidden; // preserves width and height of button
@@ -37,14 +25,6 @@
           margin-top: -3px;
         }
       }
-    }
-  }
-}
-
-body {
-  >.btn-popover-wrapper {
-    &[data-placement*='bottom'] {
-      margin-top: 12px;
     }
   }
 }

--- a/src/components/ButtonGroup/styles.scss
+++ b/src/components/ButtonGroup/styles.scss
@@ -3,7 +3,7 @@
 .aui--button-group {
   display: flex;
 
-  .button-component {
+  .aui--button {
     margin-right: 0;
     border-radius: 0;
     box-shadow: none;

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -561,27 +561,7 @@
     {
       "description": "",
       "displayName": "Button",
-      "methods": [
-        {
-          "name": "handleReasonPopover",
-          "docblock": null,
-          "modifiers": [],
-          "params": [
-            {
-              "name": "value",
-              "type": null
-            }
-          ],
-          "returns": null
-        },
-        {
-          "name": "renderSpinner",
-          "docblock": null,
-          "modifiers": [],
-          "params": [],
-          "returns": null
-        }
-      ],
+      "methods": [],
       "props": {
         "inverse": {
           "type": {
@@ -593,13 +573,6 @@
             "value": "false",
             "computed": false
           }
-        },
-        "reason": {
-          "type": {
-            "name": "node"
-          },
-          "required": false,
-          "description": ""
         },
         "dts": {
           "type": {

--- a/www/examples/ButtonExample.jsx
+++ b/www/examples/ButtonExample.jsx
@@ -13,14 +13,11 @@ class ButtonExample extends React.PureComponent {
 
   render() {
     return (
-      <div>
-        <Button bsStyle="link" disabled={!this.state.canUndo} reason="There's nothing to undo." onClick={this.onClick}>
-          Undo
-        </Button>
+      <React.Fragment>
         <Button bsStyle="primary" disabled={this.state.canUndo} onClick={this.onClick}>
           Apply
         </Button>
-      </div>
+      </React.Fragment>
     );
   }
 }
@@ -60,23 +57,10 @@ export const exampleProps = {
       Campaign, Save, Reject etc.
     </p>
   ),
-  exampleCodeSnippet: `<div>
-  <Button
-    bsStyle="link"
-    disabled={!this.state.canUndo}
-    reason="There's nothing to undo."
-    onClick={this.onClick}
-  >
-    Undo
-  </Button>
-  <Button
-    bsStyle="primary"
-    disabled={this.state.canUndo}
-    onClick={this.onClick}
-  >
-    Apply
-  </Button>
-</div>`,
+  exampleCodeSnippet: `<Button bsStyle="primary" disabled={this.state.canUndo} onClick={this.onClick}>
+  Apply
+</Button>
+`,
   propTypeSectionArray: [
     {
       propTypes: [
@@ -98,11 +82,6 @@ export const exampleProps = {
           type: 'bool',
           note: 'Renders an inverse button. Can be used with bsStyle to create primary inverse buttons.',
           defaultValue: 'false',
-        },
-        {
-          propType: 'reason',
-          type: 'string',
-          note: 'Used in tandem with the disabled prop to present a popover explaining why the button is disabled.',
         },
         {
           propType: 'onClick',

--- a/www/examples/styles.scss
+++ b/www/examples/styles.scss
@@ -41,6 +41,16 @@
     }
   }
 
+  &.button-example {
+    .adslot-ui-example {
+      display: flex;
+
+      .aui--popover-element {
+        margin-right: 12px;
+      }
+    }
+  }
+
   &.accordion-panel-example,
   &.card-example {
     .adslot-ui-example {
@@ -107,7 +117,7 @@
             margin-top: 1px;
           }
 
-          .button-component {
+          .aui--button {
             position: relative;
             left: 5px;
             top: -5px;

--- a/www/mdexamples/ButtonGroup.mdx
+++ b/www/mdexamples/ButtonGroup.mdx
@@ -6,7 +6,6 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 ```jsx live=true
 const Example = () => {
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
-  buttonRef = React.createRef();
 
   return (
     <React.Fragment>
@@ -27,7 +26,7 @@ const Example = () => {
           popoverContent="I am a Overlay on click!"
           placement="bottom"
         >
-          <Button className="svg-icon" onClick={() => setIsDropdownOpen(!isDropdownOpen)} ref={this.buttonRef}>
+          <Button className="svg-icon" onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
             <SvgSymbol href="./assets/svg-symbols.svg#caret-down" />
           </Button>
         </Popover>

--- a/www/mdexamples/TreePicker.mdx
+++ b/www/mdexamples/TreePicker.mdx
@@ -83,7 +83,7 @@ const Example = () => {
         onChange={setPickerSearchValue}
         searchOnClear={() => setPickerSearchValue('')}
         includeNode={node => setSelectedNodes(_.concat([], selectedNodes, node))}
-        removeNode={node => setSelectedNodes(_.reject(this.state.selectedNodes, { id: node.id }))}
+        removeNode={node => setSelectedNodes(_.reject(selectedNodes, { id: node.id }))}
         additionalClassNames={pickerSearchValue ? undefined : ['background-highlighted', 'test-class']}
         selectedTopSearch={
           <div className="selected-search">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Internally in `Bootstrapbutton`, we wrap `Popover` so user can show a message when button is displayed. This introduces an extra layer of wrapping for the component. Popover are display `inline-flex`, this also makes button styling break intermittently based on parent container's display properties. And putting icons within buttons require more customized styles for each button. This makes is difficult for general use case (which is priority). 

Originally it was decided to conditionally wrap this with popover, however, we now provide an extensive api of Popover so it would be easy for user to implement this.

Hence deprecating `reason` prop from `Button`.

Fixes: #849

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [X] No

## Manual Testing steps
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
