### PR TITLE
fix: action panel border

### DIFF
--- a/src/components/adslot-ui/ActionPanel/styles.scss
+++ b/src/components/adslot-ui/ActionPanel/styles.scss
@@ -10,7 +10,6 @@
   min-width: 300px;
   min-height: 100px;
   z-index: $zindex-popover;
-  border: $border-lighter;
   border-radius: 2px;
   background-color: $color-white;
 
@@ -41,6 +40,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    border: $border-lighter;
 
     .title {
       font-size: $font-size-header;
@@ -95,6 +95,7 @@
     &.has-actions {
       background-color: $color-blue;
       color: $color-inverse;
+      border: 0;
 
       .actions {
         .btn {
@@ -120,6 +121,8 @@
 
   &-body {
     padding: 30px;
+    border: $border-lighter;
+    border-top: 0;
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
When action panel has actions and there is a background colour other than white, the header shows the white border. 

To fix this - should add the border separately for the header and the body. And when there are actions (has-actions class of the header) should remove the border from the header 

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
Before the fix
![Screen Shot 2019-07-24 at 3 25 39 pm](https://user-images.githubusercontent.com/7802760/61767468-b2e7bd00-ae27-11e9-8d50-6d23532a6860.png)


After the fix
![Screen Shot 2019-07-24 at 3 23 09 pm](https://user-images.githubusercontent.com/7802760/61767482-bbd88e80-ae27-11e9-8b6d-a23e94e3425f.png)
