### PR TITLE
refactor: new color for alert input

### DIFF
--- a/src/components/adslot-ui/AlertInput/index.jsx
+++ b/src/components/adslot-ui/AlertInput/index.jsx
@@ -51,6 +51,8 @@ export default class AlertInput extends Component {
 
   render() {
     const {
+      className: customClass,
+      dts,
       defaultValue,
       value,
       type,
@@ -63,7 +65,7 @@ export default class AlertInput extends Component {
       onValueChange,
     } = this.props;
 
-    const className = classnames(`${baseClass}-wrapper`, {
+    const className = classnames(`${baseClass}-wrapper`, customClass, {
       [alertStatus]: alertStatus,
       'is-focused': this.state.isFocused,
     });
@@ -84,7 +86,12 @@ export default class AlertInput extends Component {
           popoverClassNames={popoverClassName}
           theme={theme}
         >
-          <div className={className} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+          <div
+            className={className}
+            data-test-selector={dts}
+            onMouseEnter={this.handleMouseEnter}
+            onMouseLeave={this.handleMouseLeave}
+          >
             {prefixAddon ? <span className={`${baseClass}-wrapper-addon`}>{prefixAddon}</span> : null}
             <span className={`${baseClass}-wrapper-flex-wrapper`}>
               <input
@@ -108,6 +115,8 @@ export default class AlertInput extends Component {
 }
 
 AlertInput.propTypes = {
+  className: PropTypes.string,
+  dts: PropTypes.string,
   defaultValue: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   type: PropTypes.oneOf(['text', 'number']),

--- a/src/components/adslot-ui/AlertInput/index.jsx
+++ b/src/components/adslot-ui/AlertInput/index.jsx
@@ -72,6 +72,8 @@ export default class AlertInput extends Component {
       [alertStatus]: alertStatus,
     });
 
+    const theme = alertStatus === 'warning' ? 'warn' : alertStatus;
+
     return (
       <div className={baseClass}>
         <Popover
@@ -80,6 +82,7 @@ export default class AlertInput extends Component {
           popoverContent={<strong>{alertMessage}</strong>}
           placement="bottom"
           popoverClassNames={popoverClassName}
+          theme={theme}
         >
           <div className={className} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
             {prefixAddon ? <span className={`${baseClass}-wrapper-addon`}>{prefixAddon}</span> : null}

--- a/src/components/adslot-ui/AlertInput/index.spec.jsx
+++ b/src/components/adslot-ui/AlertInput/index.spec.jsx
@@ -174,5 +174,17 @@ describe('AlertInput', () => {
       const componentWrapper = wrapper.find('.alert-input-component-wrapper');
       expect(componentWrapper.prop('className')).to.equal('alert-input-component-wrapper error');
     });
+
+    it('should set correct theme for popover', () => {
+      const props = {
+        alertStatus: 'error',
+      };
+      const wrapper = shallow(<AlertInput {...props} />);
+
+      expect(wrapper.find('Popover').prop('theme')).to.equal('error');
+
+      wrapper.setProps({ alertStatus: 'warning' });
+      expect(wrapper.find('Popover').prop('theme')).to.equal('warn');
+    });
   });
 });

--- a/src/components/adslot-ui/AlertInput/styles.scss
+++ b/src/components/adslot-ui/AlertInput/styles.scss
@@ -71,41 +71,5 @@
       padding: 5px 10px;
       width: auto;
     }
-
-    &.success {
-      border-color: $color-positive;
-      color: $color-positive;
-
-      > .aui--popover-arrow {
-        border-bottom-color: $color-positive;
-      }
-    }
-
-    &.info {
-      border-color: $color-info;
-      color: $color-info;
-
-      > .aui--popover-arrow {
-        border-bottom-color: $color-info;
-      }
-    }
-
-    &.warning {
-      border-color: $color-warning;
-      color: $color-warning;
-
-      > .aui--popover-arrow {
-        border-bottom-color: $color-warning;
-      }
-    }
-
-    &.error {
-      border-color: $color-negative;
-      color: $color-negative;
-
-      > .aui--popover-arrow {
-        border-bottom-color: $color-negative;
-      }
-    }
   }
 }

--- a/src/components/third-party/Popover/constants.js
+++ b/src/components/third-party/Popover/constants.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-export const themes = ['light', 'dark', 'warn', 'error'];
+export const themes = ['light', 'dark', 'warn', 'error', 'info', 'success'];
 
 const basePlacements = ['auto', 'top', 'right', 'bottom', 'left'];
 export const popoverPlacements = _.flatMap(basePlacements, trigger => [trigger, `${trigger}-start`, `${trigger}-end`]);

--- a/src/components/third-party/Popover/index.spec.jsx
+++ b/src/components/third-party/Popover/index.spec.jsx
@@ -180,6 +180,24 @@ describe('Popover Component', () => {
       </div>
     );
     expect(wrapper.find('.aui--popover-wrapper').hasClass('popover-error')).to.equal(true);
+
+    wrapper = mount(
+      <div>
+        <Popover id="popover-example" theme="info" popoverContent={<div />} isOpen>
+          Test message
+        </Popover>
+      </div>
+    );
+    expect(wrapper.find('.aui--popover-wrapper').hasClass('popover-info')).to.equal(true);
+
+    wrapper = mount(
+      <div>
+        <Popover id="popover-example" theme="success" popoverContent={<div />} isOpen>
+          Test message
+        </Popover>
+      </div>
+    );
+    expect(wrapper.find('.aui--popover-wrapper').hasClass('popover-success')).to.equal(true);
   });
 
   it('should default to light theme on invalid theme prop', () => {

--- a/src/components/third-party/Popover/styles.scss
+++ b/src/components/third-party/Popover/styles.scss
@@ -221,6 +221,32 @@ $arrow-border-size: 1px;
     }
   }
 
+  // Info theme
+  &.popover-info {
+    $theme-background-color: $color-cyan;
+    $theme-border-color: $color-cyan;
+    @include theme-popover($theme-background-color, $theme-border-color);
+    color: $color-white;
+
+    .popover-title {
+      background-color: lighten($theme-background-color, 10%);
+      border-bottom-color: $color-white;
+    }
+  }
+
+  // Success theme
+  &.popover-success {
+    $theme-background-color: $color-green;
+    $theme-border-color: $color-green;
+    @include theme-popover($theme-background-color, $theme-border-color);
+    color: $color-white;
+
+    .popover-title {
+      background-color: lighten($theme-background-color, 10%);
+      border-bottom-color: $color-white;
+    }
+  }
+
   // Title
   .popover-title {
     padding: 8px 14px;

--- a/www/examples/AlertInputExample.jsx
+++ b/www/examples/AlertInputExample.jsx
@@ -87,6 +87,14 @@ const exampleProps = {
     {
       propTypes: [
         {
+          propType: 'className',
+          type: 'string',
+        },
+        {
+          propType: 'dts',
+          type: 'string',
+        },
+        {
           propType: 'defaultValue',
           type: 'string',
         },

--- a/www/examples/PopoverExample.jsx
+++ b/www/examples/PopoverExample.jsx
@@ -12,7 +12,7 @@ class PopoverExample extends React.PureComponent {
   };
 
   placements = ['left', 'top', 'top-start', 'top-end', 'bottom-start', 'bottom', 'bottom-end', 'right'];
-  themes = ['light', 'dark', 'warn', 'error'];
+  themes = ['light', 'dark', 'warn', 'error', 'info', 'success'];
   triggers = ['hover', 'click'];
 
   renderPopoverContent = content => (
@@ -188,7 +188,7 @@ const exampleProps = {
         },
         {
           propType: 'theme',
-          type: 'oneOf[light, dark, warn, error]',
+          type: 'oneOf[light, dark, warn, error, info, success]',
           defaultValue: 'light',
         },
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

1. Add 'info' and 'success' theme to popover
2. Make AlertInput popover use default theme color

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Resolves #912 
Resolves #910 

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
Before:
<img width="303" alt="Screen Shot 2019-09-30 at 12 39 17 pm" src="https://user-images.githubusercontent.com/8103605/65846044-c7908600-e37f-11e9-999f-80d1c1f5712d.png">

After:
<img width="304" alt="Screen Shot 2019-09-30 at 12 59 53 pm" src="https://user-images.githubusercontent.com/8103605/65846782-42f33700-e382-11e9-8ced-1ecc1f74a05c.png">

