### PR TITLE
feat: allow toggle switch disabled state

### DIFF
--- a/src/components/adslot-ui/Switch/index.jsx
+++ b/src/components/adslot-ui/Switch/index.jsx
@@ -20,7 +20,7 @@ class Switch extends React.Component {
   };
 
   render() {
-    const { defaultChecked, checked, value, onChange, className, dts } = this.props;
+    const { defaultChecked, checked, value, disabled, onChange, className, dts } = this.props;
 
     if (!_.isNil(checked) && !_.isNil(defaultChecked))
       console.warn(
@@ -39,6 +39,7 @@ class Switch extends React.Component {
           type="checkbox"
           checked={toggleInputChecked}
           value={value}
+          disabled={disabled}
           onChange={this.handleChange}
           className={className}
           dts={dts}
@@ -51,6 +52,7 @@ class Switch extends React.Component {
 
 Switch.defaultProps = {
   value: '',
+  disabled: false,
   dts: 'switch-component',
 };
 
@@ -58,6 +60,7 @@ Switch.propTypes = {
   defaultChecked: PropTypes.bool,
   checked: PropTypes.bool,
   value: PropTypes.string,
+  disabled: PropTypes.bool,
   onChange: PropTypes.func,
   dts: PropTypes.string,
   className: PropTypes.string,

--- a/src/components/adslot-ui/Switch/style.scss
+++ b/src/components/adslot-ui/Switch/style.scss
@@ -50,6 +50,14 @@ input:checked + .aui--switch-slider::before {
   transform: translateX(20px);
 }
 
+input:disabled + .aui--switch-slider {
+  background-color: $color-gray-light;
+}
+
+input:disabled + .aui--switch-slider::before {
+  background-color: $color-gray-dark;
+}
+
 .aui--switch-slider.round {
   border-radius: 34px;
 }

--- a/www/examples/SwitchExample.jsx
+++ b/www/examples/SwitchExample.jsx
@@ -39,6 +39,12 @@ class SwitchExample extends React.PureComponent {
             <Switch checked={this.state.isToggleOn} onChange={this.onChange} />
           </div>
         </div>
+        <div>
+          <div className="component-heading">Disabled Switch</div>
+          <div className="component-container">
+            <Switch checked disabled />
+          </div>
+        </div>
       </React.Fragment>
     );
   }
@@ -48,9 +54,10 @@ const exampleProps = {
   componentName: 'Switch',
   exampleCodeSnippet: `
     <Switch />
-    <Switch defaultValue={true} />
-    <Switch defaultChecked={true} onChange={(nextState) => func(nextState)} />
-    <Switch checked={true} onChange={(nextState) => func(nextState)} />
+    <Switch defaultValue />
+    <Switch defaultChecked onChange={(nextState) => func(nextState)} />
+    <Switch checked onChange={(nextState) => func(nextState)} />
+    <Switch checked disabled />
   `,
   propTypeSectionArray: [
     {
@@ -71,6 +78,11 @@ const exampleProps = {
           propType: 'value',
           type: 'string',
           defaultValue: '',
+        },
+        {
+          propType: 'disabled',
+          type: 'boolean',
+          defaultValue: 'false',
         },
         {
           propType: 'onChange',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Toggle switch is rendered using input with transformations being applied on top of it.
When disabled attribute is set, it doesn't give the gray disabled effect (however, the input is disabled).

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
The objective of this PR is to make the component support greyed disabled effect, also, added disabled attribute to the props list.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->
Disabled example is added to the SwitchExample, so no Manual test is required.

## Screenshots (if appropriate):
<img width="1276" alt="Screen Shot 2019-10-02 at 3 50 38 pm" src="https://user-images.githubusercontent.com/3688957/66021143-ec762c00-e52c-11e9-9dc9-de4f88ec00e3.png">
