### PR TITLE
Don't auto close ListPicker modal on apply

### DIFF
--- a/src/components/adslot-ui/ListPicker/index.jsx
+++ b/src/components/adslot-ui/ListPicker/index.jsx
@@ -74,7 +74,6 @@ class ListPickerComponent extends React.Component {
 
   applyAction() {
     this.props.modalApply(this.state.selectedItems);
-    this.props.modalClose();
   }
 
   render() {

--- a/src/components/adslot-ui/ListPicker/index.spec.jsx
+++ b/src/components/adslot-ui/ListPicker/index.spec.jsx
@@ -248,7 +248,7 @@ describe('ListPickerComponent', () => {
     expect(component.prop('show')).to.equal(false);
   });
 
-  it('should call `modalApply` and `modalClose` when we click Apply', () => {
+  it('should only call `modalApply` when we click Apply', () => {
     let applyCalls = null;
     let closeCalls = 0;
     const applyMock = selectedItems => {
@@ -269,7 +269,7 @@ describe('ListPickerComponent', () => {
     const applyButtonElement = modalFooterElement.find(Button).last();
     applyButtonElement.simulate('click');
     expect(applyCalls).to.deep.equal([teamMember2]);
-    expect(closeCalls).to.equal(1);
+    expect(closeCalls).to.equal(0);
   });
 
   it('should throw when we click Apply without a handler', () => {


### PR DESCRIPTION
## Description
Resolves https://github.com/Adslot/adslot-ui/issues/916

Currently clicking `apply` in `ListPicker` calls both handler below that are specified in props:
- `this.props.modalApply()`
- `this.props.modalClose()`. 

[See this code reference](https://github.com/Adslot/adslot-ui/blob/master/src/components/adslot-ui/ListPicker/index.jsx#L75-L78)

However there can be situation when we don't want to close the modal after clicking `apply`, for example when validations failed or when additional confirmation action is needed.

Hence the proposed change is to not 'auto' close `ListPicker` modal on apply action. 

Note: If we require a non-breaking change, one approach is to add a config prop `closeOnApply` which defaults to `true`.  And if specified `false`, will not close modal on apply. 

## Does this PR introduce a breaking change?

- [x] Yes, usage of ListPicker must now call modalClose explicitly on apply. 
- [ ] No

## Manual testing step?


## Screenshots (if appropriate):
