### PR TITLE
fix: react select border colour

### DIFF
--- a/src/components/adslot-ui/Select/styles.js
+++ b/src/components/adslot-ui/Select/styles.js
@@ -25,8 +25,15 @@ const defaultStyle = {
     ...styles,
     display: 'none',
   }),
-  control: styles => ({
+  control: (styles, state) => ({
     ...styles,
+    ...(state.isFocused
+      ? {
+          boxShadow: '0 0 0 1px #cccccc',
+          ':hover': { borderColor: '#cccccc' },
+          borderColor: '#cccccc',
+        }
+      : {}),
     minHeight: 26,
   }),
   clearIndicator: styles => ({

--- a/src/components/adslot-ui/Select/styles.spec.js
+++ b/src/components/adslot-ui/Select/styles.spec.js
@@ -1,0 +1,33 @@
+import styles from './styles';
+
+describe('Select custom styles', () => {
+  describe('control()', () => {
+    it('should have default styles and update minHeight', () => {
+      const base = { color: 'red' };
+      const state = { isFocused: false };
+
+      expect(styles.control(base, state)).to.eql({
+        color: 'red',
+        minHeight: 26,
+      });
+    });
+
+    it('should override styles on focus', () => {
+      const base = {
+        color: 'red',
+        boxShadow: '0 0 0 1px #123456',
+        ':hover': { borderColor: '#123456' },
+        borderColor: '#123456',
+      };
+      const state = { isFocused: true };
+
+      expect(styles.control(base, state)).to.eql({
+        color: 'red',
+        minHeight: 26,
+        boxShadow: '0 0 0 1px #cccccc',
+        ':hover': { borderColor: '#cccccc' },
+        borderColor: '#cccccc',
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Default react select border colour is blue, which does not align with our existing design.
Update the default code to our light gray colour (see screenshot)

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
before:
![before](https://user-images.githubusercontent.com/2588669/66100328-dc725100-e5ed-11e9-9d64-673630738c94.gif)

after:
![after](https://user-images.githubusercontent.com/2588669/66100332-e09e6e80-e5ed-11e9-8640-715d0aaa79cd.gif)
