### PR TITLE
fix: fix broken style on action panel long title

### DIFF
--- a/src/components/adslot-ui/ActionPanel/styles.scss
+++ b/src/components/adslot-ui/ActionPanel/styles.scss
@@ -43,6 +43,7 @@
     border: $border-lighter;
 
     .title {
+      @include ellipse;
       font-size: $font-size-header;
       font-weight: $font-weight-bold;
     }

--- a/www/examples/ActionPanelExample.jsx
+++ b/www/examples/ActionPanelExample.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Example from '../components/Example';
 import { Button, ActionPanel } from '../../src';
-import SvgSymbol from 'alexandria/SvgSymbol';
 
 class ActionPanelExample extends React.PureComponent {
   constructor() {
@@ -22,7 +21,7 @@ class ActionPanelExample extends React.PureComponent {
         <h4>Static markup</h4>
         <div>
           <ActionPanel
-            title="Action panel"
+            title="Action panel: Lorem ipsum dolor sit amet, consectetur adipiscing elit."
             size="small"
             onClose={this.toggleActionPanel}
             children={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix broken styles on action panel long title
Resolves https://github.com/Adslot/adslot-ui/issues/904

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
before
![Screen Shot 2019-10-04 at 7 57 13 am](https://user-images.githubusercontent.com/2588669/66167141-afb94a80-e67c-11e9-93b4-26d2ceacad9e.png)

after
![Screen Shot 2019-10-04 at 7 56 15 am](https://user-images.githubusercontent.com/2588669/66167145-b2b43b00-e67c-11e9-91f4-1de2eac5ca02.png)
