### PR TITLE
feat: allow tree picker to customize breadcrumb root node

### DIFF
--- a/src/components/adslot-ui/TreePicker/Nav/index.jsx
+++ b/src/components/adslot-ui/TreePicker/Nav/index.jsx
@@ -9,6 +9,7 @@ import TreePickerPropTypes from '../../../prop-types/TreePickerPropTypes';
 require('./styles.scss');
 
 const TreePickerNavComponent = ({
+  breadcrumbRootNode,
   breadcrumbNodes,
   breadcrumbOnClick,
   debounceInterval,
@@ -29,6 +30,13 @@ const TreePickerNavComponent = ({
   if (svgSymbolCancel)
     icons.close = <SvgSymbol href={svgSymbolCancel.href} classSuffixes={svgSymbolCancel.classSuffixes} />;
 
+  const breadcrumbProps = {
+    disabled,
+    nodes: breadcrumbNodes,
+    onClick: breadcrumbOnClick,
+    rootNode: breadcrumbRootNode,
+  };
+
   return (
     <div className={`treepickernav-component ${disabled ? 'disabled' : ''}`} data-test-selector="treepicker-nav-search">
       <Search
@@ -43,13 +51,14 @@ const TreePickerNavComponent = ({
         value={searchValue}
         placeholder={searchPlaceholder || 'Search'}
       />
-      <Breadcrumb disabled={disabled} nodes={breadcrumbNodes} onClick={breadcrumbOnClick} />
+      <Breadcrumb {...breadcrumbProps} />
     </div>
   );
 };
 
 TreePickerNavComponent.displayName = 'AdslotUiTreePickerNavComponent';
 TreePickerNavComponent.propTypes = {
+  breadcrumbRootNode: TreePickerPropTypes.breadCrumbNode,
   breadcrumbNodes: PropTypes.arrayOf(TreePickerPropTypes.breadCrumbNode),
   breadcrumbOnClick: PropTypes.func,
   disabled: PropTypes.bool,

--- a/src/components/adslot-ui/TreePicker/index.jsx
+++ b/src/components/adslot-ui/TreePicker/index.jsx
@@ -18,6 +18,7 @@ export const removeSelected = ({ subtree, selectedNodes }) => {
 
 const TreePickerSimplePureComponent = ({
   additionalClassNames,
+  breadcrumbRootNode,
   breadcrumbNodes,
   breadcrumbOnClick,
   debounceInterval,
@@ -65,6 +66,7 @@ const TreePickerSimplePureComponent = ({
         {hideSearchOnRoot && _.isEmpty(breadcrumbNodes) ? null : (
           <TreePickerNav
             {...{
+              breadcrumbRootNode,
               breadcrumbNodes,
               breadcrumbOnClick,
               debounceInterval,
@@ -127,6 +129,7 @@ TreePickerSimplePureComponent.displayName = 'AdslotUiTreePickerSimplePureCompone
 
 TreePickerSimplePureComponent.propTypes = {
   additionalClassNames: PropTypes.arrayOf(PropTypes.string),
+  breadcrumbRootNode: TreePickerPropTypes.breadCrumbNode,
   breadcrumbNodes: PropTypes.arrayOf(TreePickerPropTypes.breadCrumbNode.isRequired),
   breadcrumbOnClick: PropTypes.func,
   debounceInterval: PropTypes.number,

--- a/www/examples/TreePickerExample.jsx
+++ b/www/examples/TreePickerExample.jsx
@@ -140,6 +140,11 @@ const exampleProps = {
           note: 'Class Names for SplitPane component',
         },
         {
+          propType: 'breadcrumbRootNode',
+          type: '{ id: string/number, label: string }',
+          note: 'Optional. This prop allows customization of the Breadcrumb root node',
+        },
+        {
           propType: 'breadcrumbNodes',
           type: 'arrayOf { id: string/number, label: string }',
           note: `returns node id. This prop is not required,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add an optional prop to TreePicker component to allow customization of breadcrumb root node

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Resolves https://github.com/Adslot/adslot-ui/issues/882

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
