### PR TITLE
feat: add disabled support to AlertInput component

### DIFF
--- a/src/components/adslot-ui/AlertInput/index.jsx
+++ b/src/components/adslot-ui/AlertInput/index.jsx
@@ -54,6 +54,7 @@ export default class AlertInput extends Component {
       className: customClass,
       dts,
       defaultValue,
+      disabled,
       value,
       type,
       min,
@@ -87,7 +88,7 @@ export default class AlertInput extends Component {
           theme={theme}
         >
           <div
-            className={className}
+            className={classnames(className, { [`${baseClass}--disabled`]: disabled })}
             data-test-selector={dts}
             onMouseEnter={this.handleMouseEnter}
             onMouseLeave={this.handleMouseLeave}
@@ -102,6 +103,7 @@ export default class AlertInput extends Component {
                 min={min}
                 placeholder={placeholder}
                 onChange={onValueChange}
+                disabled={disabled}
                 onFocus={this.handleInputFocus}
                 onBlur={this.handleInputBlur}
               />
@@ -118,6 +120,7 @@ AlertInput.propTypes = {
   className: PropTypes.string,
   dts: PropTypes.string,
   defaultValue: PropTypes.string,
+  disabled: PropTypes.bool,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   type: PropTypes.oneOf(['text', 'number']),
   min: PropTypes.number,
@@ -133,4 +136,5 @@ AlertInput.propTypes = {
 
 AlertInput.defaultProps = {
   type: 'text',
+  disabled: false,
 };

--- a/src/components/adslot-ui/AlertInput/index.spec.jsx
+++ b/src/components/adslot-ui/AlertInput/index.spec.jsx
@@ -166,6 +166,27 @@ describe('AlertInput', () => {
       expect(suffixElement.text()).to.equal('.00');
     });
 
+    it('should render with disabled input', () => {
+      const props = {
+        value: 10000,
+        disabled: true,
+        prefixAddon: '$',
+        suffixAddon: '.00',
+      };
+      const wrapper = shallow(<AlertInput {...props} />);
+
+      const componentWrapper = wrapper.find('.alert-input-component-wrapper');
+      expect(componentWrapper.children()).to.have.length(3);
+
+      const prefixElement = componentWrapper.childAt(0);
+      expect(prefixElement.text()).to.equal('$');
+
+      const suffixElement = componentWrapper.childAt(2);
+      expect(suffixElement.text()).to.equal('.00');
+
+      expect(wrapper.find('.alert-input-component--disabled')).to.have.lengthOf(1);
+    });
+
     it('should render with alert status', () => {
       const props = {
         alertStatus: 'error',

--- a/src/components/adslot-ui/AlertInput/styles.scss
+++ b/src/components/adslot-ui/AlertInput/styles.scss
@@ -61,6 +61,22 @@
     }
   }
 
+  &--disabled {
+    background-color: $color-gray-lighter;
+
+    .alert-input-component-wrapper {
+      &-input {
+        &:disabled {
+          background-color: $color-gray-lighter;
+        }
+      }
+
+      &-addon {
+        color: $color-gray;
+      }
+    }
+  }
+
   &-popover {
     border-radius: 4px;
     box-shadow: none;

--- a/www/examples/AlertInputExample.jsx
+++ b/www/examples/AlertInputExample.jsx
@@ -99,6 +99,11 @@ const exampleProps = {
           type: 'string',
         },
         {
+          propType: 'disabled',
+          type: 'bool',
+          defaultValue: 'false',
+        },
+        {
           propType: 'value',
           type: 'string|number',
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Add disabled support to AlertInput. 
Resolves #936  

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Requirement to support AlertInput disabled state,
after the background is grayed the addOn is not clearly visible as it is lighter gray in color,
hence, changing its color to dark gray for visibility.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->
Pass disabled prop to AlertInput and it should be non-editable and appear with gray background.

## Screenshots (if appropriate):
<img width="291" alt="Screen Shot 2019-10-18 at 2 46 19 pm" src="https://user-images.githubusercontent.com/3688957/67064727-58a49100-f1b7-11e9-9f42-bfc734020ad1.png">

changed the suffix to lighter color for distinction, 
![image](https://user-images.githubusercontent.com/3688957/67067850-960f1b80-f1c3-11e9-9731-fa4e8b8d9fec.png)
