### PR TITLE
fix: add placement support for AlertInput

### DIFF
--- a/src/components/adslot-ui/AlertInput/index.jsx
+++ b/src/components/adslot-ui/AlertInput/index.jsx
@@ -54,6 +54,7 @@ export default class AlertInput extends Component {
       className: customClass,
       dts,
       defaultValue,
+      popoverPlacement,
       disabled,
       value,
       type,
@@ -83,7 +84,7 @@ export default class AlertInput extends Component {
           isOpen={this.state.isPopoverVisible && !_.isEmpty(alertMessage)}
           triggers={['disabled']}
           popoverContent={<strong>{alertMessage}</strong>}
-          placement="bottom"
+          placement={popoverPlacement}
           popoverClassNames={popoverClassName}
           theme={theme}
         >
@@ -128,6 +129,16 @@ AlertInput.propTypes = {
   prefixAddon: PropTypes.node,
   suffixAddon: PropTypes.node,
   alertStatus: PropTypes.oneOf(['success', 'info', 'warning', 'error']),
+  popoverPlacement: PropTypes.oneOf([
+    'left',
+    'top',
+    'top-start',
+    'top-end',
+    'bottom-start',
+    'bottom',
+    'bottom-end',
+    'right',
+  ]),
   alertMessage: PropTypes.string,
   onValueChange: PropTypes.func,
   onBlur: PropTypes.func,
@@ -137,4 +148,5 @@ AlertInput.propTypes = {
 AlertInput.defaultProps = {
   type: 'text',
   disabled: false,
+  popoverPlacement: 'bottom',
 };

--- a/src/components/adslot-ui/AlertInput/index.spec.jsx
+++ b/src/components/adslot-ui/AlertInput/index.spec.jsx
@@ -143,11 +143,10 @@ describe('AlertInput', () => {
     });
 
     it('should also render with default props', () => {
-      expect(
-        shallow(<AlertInput />)
-          .find('input')
-          .prop('type')
-      ).to.equal('text');
+      const wrapper = shallow(<AlertInput />);
+
+      expect(wrapper.find('input').prop('type')).to.equal('text');
+      expect(wrapper.find('Popover').prop('placement')).to.equal('bottom');
     });
 
     it('should render with addons', () => {
@@ -206,6 +205,15 @@ describe('AlertInput', () => {
 
       wrapper.setProps({ alertStatus: 'warning' });
       expect(wrapper.find('Popover').prop('theme')).to.equal('warn');
+    });
+
+    it('should set correct popoverPlacement position for popover', () => {
+      const props = {
+        popoverPlacement: 'left',
+      };
+
+      const wrapper = shallow(<AlertInput {...props} />);
+      expect(wrapper.find('Popover').prop('placement')).to.equal('left');
     });
   });
 });

--- a/www/examples/AlertInputExample.jsx
+++ b/www/examples/AlertInputExample.jsx
@@ -141,6 +141,11 @@ const exampleProps = {
           ),
         },
         {
+          propType: 'popoverPlacement',
+          type: "oneOf: 'left', 'top', 'top-start', 'top-end', 'bottom-start', 'bottom', 'bottom-end', 'right'",
+          defaultValue: 'bottom',
+        },
+        {
           propType: 'alertMessage',
           type: 'string',
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Current AlertInput Popover has a hadcoded bottom placement. we need to allow placement in all directions.

Resolves: #938 

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Allow AlertInput dynamic placement support 

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->
Screenshot included

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3688957/67360285-2a58f400-f5b1-11e9-9d2b-6a6fad8aec33.png)
