### PR TITLE
fix: fix popover with ref showing incorrect arrow position

### DIFF
--- a/src/components/third-party/Popover/Popper.jsx
+++ b/src/components/third-party/Popover/Popper.jsx
@@ -1,8 +1,47 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Popper as ReactPopper } from 'react-popper';
 import { popoverPlacements } from './constants';
+
+// default arrow position in pixel from the corresponding popover edge
+const DEFAULT_ARROW_POSITION = 12;
+
+/**
+ *
+ * @param {string} placement
+ * @param {object} arrowStyles            user-defined arrow styles
+ * @param {Element} container             anchor container
+ */
+export const renderArrowStyles = (placement, arrowStyles, container = null) => {
+  const horizontalPosition =
+    _.get(container, 'clientWidth') >= DEFAULT_ARROW_POSITION * 2 ? DEFAULT_ARROW_POSITION : null;
+  const verticalPosition =
+    _.get(container, 'clientHeight') >= DEFAULT_ARROW_POSITION * 2 ? DEFAULT_ARROW_POSITION : null;
+
+  let calculatedArrowStyles = {};
+  switch (true) {
+    case _.includes(['bottom-start', 'top-start'], placement) && !_.isNull(horizontalPosition):
+      calculatedArrowStyles = { left: horizontalPosition };
+      break;
+    case _.includes(['bottom-end', 'top-end'], placement) && !_.isNull(horizontalPosition):
+      calculatedArrowStyles = { left: 'auto', right: horizontalPosition };
+      break;
+    case _.includes(['left-start', 'right-start'], placement) && !_.isNull(verticalPosition):
+      calculatedArrowStyles = { top: verticalPosition };
+      break;
+    case _.includes(['left-end', 'right-end'], placement) && !_.isNull(verticalPosition):
+      calculatedArrowStyles = { top: 'auto', bottom: verticalPosition };
+      break;
+    default:
+      calculatedArrowStyles = {};
+  }
+
+  return {
+    ...calculatedArrowStyles,
+    ...arrowStyles, // let user override default configuration
+  };
+};
 
 const Popper = ({
   arrowStyles,
@@ -16,43 +55,47 @@ const Popper = ({
   refElement,
   title,
   wrapperStyles,
-}) => (
-  <ReactPopper
-    {...(refElement ? { referenceElement: refElement } : {})}
-    innerRef={innerRef}
-    placement={popperPlacement}
-    modifiers={{
-      preventOverflow: {
-        enabled: true,
-        boundariesElement,
-      },
-      ...modifiers,
-    }}
-  >
-    {({ ref, style, placement, arrowProps, scheduleUpdate }) => (
-      <div
-        className={popoverClass}
-        ref={ref}
-        style={{ ...style, ...wrapperStyles }}
-        data-placement={placement}
-        data-test-selector={dts}
-      >
-        <div className="aui--popover-container">
-          {title ? <div className="popover-title">{title}</div> : null}
-          <div className="popover-content">
-            {_.isFunction(popoverContent) ? popoverContent({ scheduleUpdate }) : popoverContent}
-          </div>
-        </div>
+}) => {
+  const calculatedArrowStyles = renderArrowStyles(popperPlacement, arrowStyles, refElement);
+
+  return (
+    <ReactPopper
+      {...(refElement ? { referenceElement: refElement } : {})}
+      innerRef={innerRef}
+      placement={popperPlacement}
+      modifiers={{
+        preventOverflow: {
+          enabled: true,
+          boundariesElement,
+        },
+        ...modifiers,
+      }}
+    >
+      {({ ref, style, placement, arrowProps, scheduleUpdate }) => (
         <div
-          className="aui--popover-arrow"
+          className={popoverClass}
+          ref={ref}
+          style={{ ...style, ...wrapperStyles }}
           data-placement={placement}
-          ref={arrowProps.ref}
-          style={{ ...arrowProps.style, ...arrowStyles }}
-        />
-      </div>
-    )}
-  </ReactPopper>
-);
+          data-test-selector={dts}
+        >
+          <div className="aui--popover-container">
+            {title ? <div className="popover-title">{title}</div> : null}
+            <div className="popover-content">
+              {_.isFunction(popoverContent) ? popoverContent({ scheduleUpdate }) : popoverContent}
+            </div>
+          </div>
+          <div
+            className="aui--popover-arrow"
+            data-placement={placement}
+            ref={arrowProps.ref}
+            style={{ ...arrowProps.style, ...calculatedArrowStyles }}
+          />
+        </div>
+      )}
+    </ReactPopper>
+  );
+};
 
 Popper.propTypes = {
   arrowStyles: PropTypes.object, // eslint-disable-line react/forbid-prop-types

--- a/src/components/third-party/Popover/index.jsx
+++ b/src/components/third-party/Popover/index.jsx
@@ -72,25 +72,14 @@ class Popover extends React.PureComponent {
 
   referenceRef = React.createRef();
 
+  elementRef = React.createRef();
+
   render() {
     const { theme, title, children, className, dts, popoverClassNames, popoverContent } = this.props;
     const themeClass = _.includes(themes, theme) ? `popover-${theme}` : 'popover-light';
     const elementClass = classnames('aui--popover-element', className);
     const popoverClass = classnames('aui--popover-wrapper', themeClass, popoverClassNames);
     const triggers = _.flattenDeep([this.props.triggers]);
-
-    let arrowStyles = {};
-    switch (true) {
-      case _.includes(['bottom-start', 'top-start'], this.props.placement):
-        arrowStyles = { left: 12 };
-        break;
-      case _.includes(['bottom-end', 'top-end'], this.props.placement):
-        arrowStyles = { left: 'auto', right: 12 };
-        break;
-      default:
-        arrowStyles = {};
-    }
-    arrowStyles = { ...arrowStyles, ...this.props.arrowStyles }; // let user override default configuration
 
     const popoverElement = this.state.isPopoverOpen
       ? ReactDOM.createPortal(
@@ -103,8 +92,9 @@ class Popover extends React.PureComponent {
             dts={dts}
             title={title}
             popoverContent={popoverContent}
-            arrowStyles={arrowStyles}
+            arrowStyles={this.props.arrowStyles}
             innerRef={this.props.popperRef}
+            refElement={this.elementRef.current}
           />,
           this.getBoundedContainer()
         )
@@ -113,10 +103,10 @@ class Popover extends React.PureComponent {
     return (
       <Manager>
         <Reference innerRef={this.referenceRef}>
-          {({ ref }) => (
+          {() => (
             <span
               className={elementClass}
-              ref={ref}
+              ref={this.elementRef}
               {...(triggers.includes('disabled')
                 ? {}
                 : {

--- a/www/examples/PopoverExample.jsx
+++ b/www/examples/PopoverExample.jsx
@@ -1,7 +1,8 @@
+import _ from 'lodash';
 import React from 'react';
 import Example from '../components/Example';
-import _ from 'lodash';
-import { Checkbox, Button, Popover } from '../../src';
+import { Checkbox, Radio, RadioGroup, Button, Popover } from '../../src';
+import { popoverPlacements, themes } from '../../src/components/third-party/Popover/constants';
 
 class PopoverExample extends React.PureComponent {
   state = {
@@ -11,8 +12,6 @@ class PopoverExample extends React.PureComponent {
     isOpen: false,
   };
 
-  placements = ['left', 'top', 'top-start', 'top-end', 'bottom-start', 'bottom', 'bottom-end', 'right'];
-  themes = ['light', 'dark', 'warn', 'error', 'info', 'success'];
   triggers = ['hover', 'click'];
 
   renderPopoverContent = content => (
@@ -22,9 +21,9 @@ class PopoverExample extends React.PureComponent {
     </div>
   );
 
-  handlePlacements = (state, placement) => this.setState({ placement });
-  handleThemes = (state, theme) => this.setState({ theme });
-  handleTriggers = (state, trigger) => this.setState({ trigger });
+  handlePlacement = placement => this.setState({ placement });
+  handleTheme = theme => this.setState({ theme });
+  handleTrigger = trigger => this.setState({ trigger });
   togglePopover = () =>
     this.setState(prevState => ({
       isOpen: !prevState.isOpen,
@@ -39,54 +38,36 @@ class PopoverExample extends React.PureComponent {
         <div className="button-example-container">
           <h3>Popover over element</h3>
           <label>Placements</label>
-          <div className="placement-checkbox">
-            {_.map(this.placements, (placement, index) => (
-              <Checkbox
-                key={index}
-                onChange={this.handlePlacements}
-                value={this.state.placement}
-                name={placement}
-                label={placement}
-                checked={this.state.placement === placement}
-              />
+          <RadioGroup inline name="placement" value={this.state.placement} onChange={this.handlePlacement}>
+            {popoverPlacements.map(placement => (
+              <Radio key={placement} value={placement} label={placement} />
             ))}
-          </div>
+          </RadioGroup>
+
           <label>Themes</label>
-          <div className="theme-checkbox">
-            {_.map(this.themes, (theme, index) => (
-              <Checkbox
-                key={index}
-                onChange={this.handleThemes}
-                value={this.state.theme}
-                name={theme}
-                label={theme}
-                checked={this.state.theme === theme}
-              />
+          <RadioGroup inline name="theme" value={this.state.theme} onChange={this.handleTheme}>
+            {themes.map(theme => (
+              <Radio key={theme} value={theme} label={theme} />
             ))}
-          </div>
+          </RadioGroup>
+
           <label>Triggers</label>
-          <div className="trigger-checkbox">
-            {_.map(this.triggers, (trigger, index) => (
-              <Checkbox
-                key={index}
-                onChange={this.handleTriggers}
-                value={this.state.trigger}
-                name={trigger}
-                label={trigger}
-                checked={this.state.trigger === trigger}
-              />
+          <RadioGroup inline name="trigger" value={this.state.trigger} onChange={this.handleTrigger}>
+            {this.triggers.map(trigger => (
+              <Radio key={trigger} value={trigger} label={trigger} />
             ))}
-          </div>
+          </RadioGroup>
+
           <div className="disabled-popover">
             You can also&nbsp;
             <Checkbox
-              onChange={this.handleTriggers}
-              value={'disabled'}
-              name={'disabled'}
-              label={'Disable'}
+              onChange={() => this.handleTrigger('disabled')}
+              value="disabled"
+              name="disabled"
+              label="Disable"
               checked={this.state.trigger === 'disabled'}
             />
-            &nbsp; the triggers and control the popover with external events
+            &nbsp;the triggers and control the popover with external events
             {this.state.trigger === 'disabled' && (
               <Button onClick={this.togglePopover}>{this.state.isOpen ? 'Close' : 'Open'} Popover</Button>
             )}

--- a/www/examples/PopoverWithRefExample.jsx
+++ b/www/examples/PopoverWithRefExample.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import Example from '../components/Example';
-import _ from 'lodash';
-import { Button, Popover } from '../../src';
+import { Button, Popover, RadioGroup, Radio } from '../../src';
+import { popoverPlacements } from '../../src/components/third-party/Popover/constants';
 
 class PopoverWithRefExample extends React.PureComponent {
   state = {
     isOpen: false,
+    placement: 'left',
   };
 
   myRef = React.createRef();
+
+  handlePlacement = placement => this.setState({ placement });
 
   togglePopover = () =>
     this.setState(prevState => ({
@@ -18,28 +20,35 @@ class PopoverWithRefExample extends React.PureComponent {
 
   render() {
     return (
-      <>
+      <React.Fragment>
+        <label>Placements</label>
+        <RadioGroup inline name="placement" value={this.state.placement} onChange={this.handlePlacement}>
+          {popoverPlacements.map(placement => (
+            <Radio key={placement} value={placement} label={placement} />
+          ))}
+        </RadioGroup>
+
         <Button onClick={this.togglePopover}>Toggle Popover</Button>
-        <div style={{ marginTop: 20 }} ref={this.myRef}>
+        <div className="external-anchor" ref={this.myRef}>
           Anchor
         </div>
         {this.state.isOpen && (
           <Popover.WithRef
             refElement={this.myRef.current}
-            placement="left"
+            placement={this.state.placement}
             title="Popover title"
             theme="dark"
             popoverContent="My initial positioning is left"
             isOpen={this.state.isOpen}
           />
         )}
-      </>
+      </React.Fragment>
     );
   }
 }
 
 const exampleProps = {
-  componentName: 'Popover With External Ref',
+  componentName: 'Popover With Ref',
   exampleCodeSnippet: `
     <Button onClick={this.togglePopover}>Toggle Popover</Button>
     <div ref={this.myRef}>Anchor</div>

--- a/www/examples/styles.scss
+++ b/www/examples/styles.scss
@@ -87,15 +87,8 @@
           margin-left: 5px;
         }
 
-        .placement-checkbox,
-        .theme-checkbox,
-        .example-button,
-        .trigger-checkbox,
         .disabled-popover {
           display: flex;
-        }
-
-        .disabled-popover {
           height: 28px;
 
           .checkbox-component {
@@ -135,6 +128,18 @@
           }
         }
       }
+    }
+  }
+
+  &.popover-with-ref-example {
+    .external-anchor {
+      margin-top: 100px;
+      width: 100px;
+      height: 100px;
+      border: $border-lighter;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves https://github.com/Adslot/adslot-ui/issues/946
Fix Popover incorrect arrow position (see issue for screenshots)

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
![after](https://user-images.githubusercontent.com/2588669/69684704-bf4d9080-110d-11ea-8478-c0095f261399.gif)
