### PR TITLE
Fixes issue where selected nodes show expander

### DIFF
--- a/src/components/adslot-ui/TreePicker/Node/index.jsx
+++ b/src/components/adslot-ui/TreePicker/Node/index.jsx
@@ -129,7 +129,6 @@ TreePickerNodeComponent.defaultProps = {
   removeNode: node => {
     throw new Error(`AdslotUi TreePickerNode needs a removeNode handler for ${node}`);
   },
-  expandNode: _.noop,
   selected: false,
   valueFormatter: value => value,
   nodeRenderer: node => node.label,

--- a/src/components/adslot-ui/TreePicker/Node/index.spec.jsx
+++ b/src/components/adslot-ui/TreePicker/Node/index.spec.jsx
@@ -215,6 +215,19 @@ describe('TreePickerNodeComponent', () => {
     expect(props.expandNode.callCount).to.eql(0);
   });
 
+  it('should not show the expander element when the node is expandable and no expandNode is given', () => {
+    const props = {
+      node: _.defaults({ isExpandable: true }, cbrNode),
+      itemType,
+    };
+
+    const component = shallow(<TreePickerNode {...props} />);
+    const rowElement = component.find({
+      dts: `${_.kebabCase(itemType)}-${cbrNode.id}`,
+    });
+    expect(rowElement.find(TreePickerNodeExpander)).to.have.length(0);
+  });
+
   it('should fire includeNode when clicking on the `include` button', () => {
     const nodes = [];
     const includeNode = node => nodes.push(node);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Apparently in #944 I _may_ have broken the display of selected nodes because in every case no one provides an `expandNode` to that selected `TreePickerGrid` so when a default was added it started showing the `TreePickerNodeExpander` for selected parent nodes which have `isExpanded` set (because they came from the selection side).

This PR removes the default value for `expandNode` so it functions the same as it did before

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [X] No

## Manual testing details
<!--- Include details of your testing environment, and the tests you ran to -->
Tested locally on upgrade PR


