### PR TITLE
[ADS-3552] chore: extend datepicker component to enable/disable inline editing

### DIFF
--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -1,0 +1,35 @@
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactDatePicker from 'react-datepicker';
+import './styles.scss';
+
+const adslotDatePickerPropTypes = {
+  disableInlineEditing: PropTypes.bool,
+};
+
+class DatePicker extends React.PureComponent {
+  handleDateChangeRaw = event => {
+    event.preventDefault();
+  };
+
+  render() {
+    const { disableInlineEditing } = this.props;
+
+    const datePickerProps = disableInlineEditing ? { onChangeRaw: this.handleDateChangeRaw } : {};
+
+    return (
+      <div data-test-selector={this.props.dts}>
+        <ReactDatePicker {..._.omit(this.props, _.keys(adslotDatePickerPropTypes))} {...datePickerProps} />
+      </div>
+    );
+  }
+}
+
+DatePicker.propTypes = { ...adslotDatePickerPropTypes };
+
+DatePicker.defaultProps = {
+  disableInlineEditing: false,
+};
+
+export default DatePicker;

--- a/src/components/DatePicker/index.spec.jsx
+++ b/src/components/DatePicker/index.spec.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import DatePicker from '.';
+
+describe('DatePicker', () => {
+  it('should render with defaults', () => {
+    const component = shallow(<DatePicker className="test" />);
+    expect(component.prop('className')).to.equal('test');
+    expect(component.props().handleDateChangeRaw).toBeUndefined();
+  });
+
+  it('should render with onChangeRaw when disableInlineEditing = true', () => {
+    const component = shallow(<DatePicker className="test" disableInlineEditing="true" />);
+    expect(component.prop('className')).to.equal('test');
+    expect(component.props().hasOwnProperty('handleDateChangeRaw')).toBe(true);
+  });
+});

--- a/src/components/DatePicker/index.spec.jsx
+++ b/src/components/DatePicker/index.spec.jsx
@@ -5,13 +5,11 @@ import DatePicker from '.';
 describe('DatePicker', () => {
   it('should render with defaults', () => {
     const component = shallow(<DatePicker className="test" />);
-    expect(component.prop('className')).to.equal('test');
     expect(component.props().handleDateChangeRaw).toBeUndefined();
   });
 
   it('should render with onChangeRaw when disableInlineEditing = true', () => {
     const component = shallow(<DatePicker className="test" disableInlineEditing={true} />);
-    expect(component.prop('className')).to.equal('test');
     expect(component.props().hasOwnProperty('handleDateChangeRaw')).toBe(true);
   });
 });

--- a/src/components/DatePicker/index.spec.jsx
+++ b/src/components/DatePicker/index.spec.jsx
@@ -10,6 +10,6 @@ describe('DatePicker', () => {
 
   it('should render with onChangeRaw when disableInlineEditing = true', () => {
     const component = shallow(<DatePicker className="test" disableInlineEditing={true} />);
-    expect(component.props().hasOwnProperty('handleDateChangeRaw')).to.be(true);
+    expect(component.props().hasOwnProperty('handleDateChangeRaw')).to.be.true;
   });
 });

--- a/src/components/DatePicker/index.spec.jsx
+++ b/src/components/DatePicker/index.spec.jsx
@@ -10,6 +10,6 @@ describe('DatePicker', () => {
 
   it('should render with onChangeRaw when disableInlineEditing = true', () => {
     const component = shallow(<DatePicker className="test" disableInlineEditing={true} />);
-    expect(component.props().hasOwnProperty('handleDateChangeRaw')).to.be.true;
+    expect(component.props().hasOwnProperty('onChangeRaw')).to.be.true;
   });
 });

--- a/src/components/DatePicker/index.spec.jsx
+++ b/src/components/DatePicker/index.spec.jsx
@@ -5,11 +5,11 @@ import DatePicker from '.';
 describe('DatePicker', () => {
   it('should render with defaults', () => {
     const component = shallow(<DatePicker className="test" />);
-    expect(component.props().handleDateChangeRaw).toBeUndefined();
+    expect(component.props().handleDateChangeRaw).to.be.undefined;
   });
 
   it('should render with onChangeRaw when disableInlineEditing = true', () => {
     const component = shallow(<DatePicker className="test" disableInlineEditing={true} />);
-    expect(component.props().hasOwnProperty('handleDateChangeRaw')).toBe(true);
+    expect(component.props().hasOwnProperty('handleDateChangeRaw')).to.be(true);
   });
 });

--- a/src/components/DatePicker/index.spec.jsx
+++ b/src/components/DatePicker/index.spec.jsx
@@ -10,7 +10,7 @@ describe('DatePicker', () => {
   });
 
   it('should render with onChangeRaw when disableInlineEditing = true', () => {
-    const component = shallow(<DatePicker className="test" disableInlineEditing="true" />);
+    const component = shallow(<DatePicker className="test" disableInlineEditing={true} />);
     expect(component.prop('className')).to.equal('test');
     expect(component.props().hasOwnProperty('handleDateChangeRaw')).toBe(true);
   });

--- a/src/components/DatePicker/styles.scss
+++ b/src/components/DatePicker/styles.scss
@@ -1,0 +1,179 @@
+@import '../../styles/bootstrap-custom';
+@import '../../styles/icon';
+@import '../../../node_modules/react-datepicker/dist/react-datepicker.css';
+
+// sass-lint:disable class-name-format
+.react-datepicker {
+  $datepicker-font-family: $font-family-sans-serif;
+  $datepicker-font-size: $font-size-base;
+  $datepicker-icon-size: 24px;
+  $datepicker-border-color: $color-border-light;
+  $datepicker-border-radius: $border-radius-base;
+  $datepicker-header-bg-color: $color-gray-white;
+  $datepicker-selected-bg-color: $color-primary;
+  $datepicker-hover-bg-color: $color-gray-lighter;
+  $datepicker-color-disabled: $color-disabled;
+
+  border-color: $datepicker-border-color;
+  box-shadow: 0 2px 0 $color-modal-shadow;
+  font-family: $datepicker-font-family;
+  font-size: $datepicker-font-size;
+
+  &__header {
+    background-color: $datepicker-header-bg-color;
+    border-bottom: 0;
+  }
+
+  &,
+  &__day,
+  &__day-name {
+    color: $color-text-form;
+
+    &:hover {
+      border-radius: $datepicker-border-radius;
+    }
+
+    &--outside-month,
+    &--disabled {
+      color: $datepicker-color-disabled;
+    }
+
+    &--selected {
+      background-color: $datepicker-selected-bg-color;
+      color: $color-inverse;
+
+      &,
+      &:hover {
+        border-radius: $datepicker-border-radius;
+      }
+    }
+
+    &__day--in-range {
+      color: $color-inverse;
+    }
+  }
+
+  &__day,
+  &__day-name {
+    width: 1.9 * $datepicker-font-size;
+    line-height: 1.9 * $datepicker-font-size;
+    margin: .166 * $datepicker-font-size;
+  }
+
+  &__month {
+    margin: .7 * $datepicker-font-size;
+  }
+
+  &__current-month {
+    color: $color-text-form;
+    font-size: $datepicker-font-size;
+  }
+
+  &__navigation {
+    width: $datepicker-icon-size;
+    height: $datepicker-icon-size;
+    top: .4 * $datepicker-font-size;
+  }
+
+  &__navigation--next {
+    border: 0;
+    right: 7px;
+
+    &:hover {
+      background-color: $datepicker-hover-bg-color;
+      border-radius: $datepicker-border-radius;
+    }
+
+    &::before {
+      background-image: $icon-arrow-bracket;
+      background-position: center center;
+      background-repeat: no-repeat;
+      content: '';
+      display: block;
+      height: $datepicker-icon-size;
+      transform: scaleX(-1);
+      width: $datepicker-icon-size;
+    }
+  }
+
+  &__navigation--previous {
+    border: 0;
+    left: 7px;
+
+    &:hover {
+      background-color: $datepicker-hover-bg-color;
+      border-radius: $datepicker-border-radius;
+    }
+
+    &::before {
+      background-image: $icon-arrow-bracket;
+      background-position: center center;
+      background-repeat: no-repeat;
+      content: '';
+      display: block;
+      height: $datepicker-icon-size;
+      width: $datepicker-icon-size;
+    }
+  }
+
+  &__tether-element-attached-top {
+    &.react-datepicker__tether-element {
+      margin-top: -5px;
+    }
+  }
+
+  &__tether-element-attached-top &__triangle,
+  &__tether-element-attached-bottom &__triangle {
+    &,
+    &::before {
+      border: 0;
+    }
+  }
+
+  &__tether-element-attached-bottom {
+    &.react-datepicker__tether-element {
+      margin-top: -15px;
+    }
+  }
+
+  &__input-container {
+    display: block;
+
+    input {
+      background-image: $icon-calendar;
+      background-origin: content-box;
+      background-position: center right;
+      background-repeat: no-repeat;
+      cursor: pointer;
+      padding-right: 4px;
+
+      &::-ms-clear {
+        display: none;
+      }
+    }
+  }
+
+  &__close-icon{
+    &::after {
+      background-color: $color-gray-darker;
+      right: 15px
+    }
+  }
+}
+
+// sass-lint:enable class-name-format
+
+.react-datepicker-popper {
+  &[data-placement^='bottom'] {
+    .react-datepicker__triangle {
+      &,
+      &::before {
+        border-bottom-color: $color-gray-white;
+      }
+
+      &::before {
+        border-bottom-color: $color-border-light;
+      }
+    }
+  }
+}

--- a/src/components/DatePicker/styles.scss
+++ b/src/components/DatePicker/styles.scss
@@ -153,7 +153,7 @@
     }
   }
 
-  &__close-icon{
+  &__close-icon {
     &::after {
       background-color: $color-gray-darker;
       right: 15px

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 // Export the consumable components.
-import DatePicker from 'react-datepicker';
 import Dropdown from 'react-bootstrap/lib/Dropdown';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 import Modal from 'react-bootstrap/lib/Modal';
@@ -10,7 +9,6 @@ import NavItem from 'react-bootstrap/lib/NavItem';
 
 import 'styles/_bootstrap-custom.scss';
 import 'styles/_icheck-custom.scss';
-import 'styles/_react-datepicker-custom.scss';
 
 import Button from './components/Button';
 import Popover from './components/Popover';
@@ -43,6 +41,7 @@ import Checkbox from './components/Checkbox';
 import CheckboxGroup from './components/CheckboxGroup';
 import ConfirmModal from './components/ConfirmModal';
 import CountBadge from './components/CountBadge';
+import DatePicker from './components/DatePicker';
 import fastStatelessWrapper from './components/fastStatelessWrapper';
 import FilePicker from './components/FilePicker';
 import FormGroup from './components/FormGroup';

--- a/www/examples/DatePickerExample.jsx
+++ b/www/examples/DatePickerExample.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import Example from '../components/Example';
-import { DatePicker } from '../../src';
+import { DatePicker, Checkbox } from '../../src';
 import moment from 'moment';
 
 class DatePickerExample extends React.PureComponent {
   constructor() {
     super();
-    this.state = { startDate: moment() };
+    this.state = { startDate: moment(), disableInlineEditChecked: false, isClearableChecked: false };
     this.setSelectedDate = this.setSelectedDate.bind(this);
   }
 
@@ -14,26 +14,25 @@ class DatePickerExample extends React.PureComponent {
     this.setState({ startDate: newValue });
   }
 
+  handleDisableInlineEditCheckboxChange = event => this.setState({ disableInlineEditChecked: event.target.checked });
+
   render() {
     return (
       <div>
-        <h3>DatePicker</h3>
-        <DatePicker
-          className="form-control"
-          dateFormat="DD MMM YYYY"
-          selected={this.state.startDate}
-          onChange={this.setSelectedDate}
-          placeholderText="Select Date"
+        <Checkbox
+          label="Disable inline editing"
+          checked={false}
+          inline
+          onChange={this.handleDisableInlineEditCheckboxChange}
         />
-        <h3>DatePicker with inline editing disabled</h3>
         <DatePicker
           className="form-control"
           dateFormat="DD MMM YYYY"
           selected={this.state.startDate}
           onChange={this.setSelectedDate}
           placeholderText="Select Date"
-          disableInlineEditing={true}
-          isClearable="true"
+          disableInlineEditing={this.state.disableInlineEditChecked}
+          isClearable={true}
         />
       </div>
     );
@@ -55,11 +54,11 @@ const exampleProps = {
   ),
   exampleCodeSnippet: `
     <DatePicker
-    className="form-control"
-    dateFormat="DD MMM YYYY"
-    selected={this.state.startDate}
-    onChange={this.setSelectedDate}
-    placeholderText="Date e.g. 03 Sep 2016"
+      className="form-control"
+      dateFormat="DD MMM YYYY"
+      selected={this.state.startDate}
+      onChange={this.setSelectedDate}
+      placeholderText="Date e.g. 03 Sep 2016"
     />`,
   propTypeSectionArray: [
     {

--- a/www/examples/DatePickerExample.jsx
+++ b/www/examples/DatePickerExample.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import moment from 'moment';
 import Example from '../components/Example';
 import { DatePicker } from '../../src';
+import moment from 'moment';
 
-class DatePickerExample extends React.Component {
+class DatePickerExample extends React.PureComponent {
   constructor() {
     super();
     this.state = { startDate: moment() };
@@ -16,13 +16,26 @@ class DatePickerExample extends React.Component {
 
   render() {
     return (
-      <DatePicker
-        className="form-control"
-        dateFormat="DD MMM YYYY"
-        selected={this.state.startDate}
-        onChange={this.setSelectedDate}
-        placeholderText="Date e.g. 03 Sep 2016"
-      />
+      <div>
+        <h3>DatePicker</h3>
+        <DatePicker
+          className="form-control"
+          dateFormat="DD MMM YYYY"
+          selected={this.state.startDate}
+          onChange={this.setSelectedDate}
+          placeholderText="Select Date"
+        />
+        <h3>DatePicker with inline editing disabled</h3>
+        <DatePicker
+          className="form-control"
+          dateFormat="DD MMM YYYY"
+          selected={this.state.startDate}
+          onChange={this.setSelectedDate}
+          placeholderText="Select Date"
+          disableInlineEditing="true"
+          isClearable="true"
+        />
+      </div>
     );
   }
 }
@@ -41,14 +54,26 @@ const exampleProps = {
     </div>
   ),
   exampleCodeSnippet: `
-  <DatePicker
+    <DatePicker
     className="form-control"
     dateFormat="DD MMM YYYY"
     selected={this.state.startDate}
     onChange={this.setSelectedDate}
     placeholderText="Date e.g. 03 Sep 2016"
-  />`,
-  propTypeSectionArray: [],
+    />`,
+  propTypeSectionArray: [
+    {
+      label: '',
+      propTypes: [
+        {
+          propType: 'disableInlineEditing',
+          type: 'bool',
+          note: 'A flag to determine whether date picker inline editing is available or not.',
+          defaultValue: 'false',
+        },
+      ],
+    },
+  ],
 };
 
 export default () => (

--- a/www/examples/DatePickerExample.jsx
+++ b/www/examples/DatePickerExample.jsx
@@ -32,7 +32,7 @@ class DatePickerExample extends React.PureComponent {
           selected={this.state.startDate}
           onChange={this.setSelectedDate}
           placeholderText="Select Date"
-          disableInlineEditing="true"
+          disableInlineEditing={true}
           isClearable="true"
         />
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Extend react-datepicker component to enable/disable inline editing


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
