### PR TITLE
[ADS-3552] chore: extend datepicker component to enable/disable inline editing

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -25,6 +25,7 @@ if (file) {
 // npm run test[:watch] --file=path [--coverage]
 let cmd = 'KARMA_BROWSERS="${npm_config_browsers}" karma start';
 if (watch) cmd += ' --autoWatch=true --singleRun=false';
+if (process.env.npm_config_browsers) cmd += ' --browsers='+ process.env.npm_config_browsers;
 try {
   execSync(cmd, { stdio: [0, 1, 2] });
 } catch (err) {

--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -1,0 +1,35 @@
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactDatePicker from 'react-datepicker';
+import './styles.scss';
+
+const adslotDatePickerPropTypes = {
+  disableInlineEditing: PropTypes.bool,
+};
+
+class DatePicker extends React.PureComponent {
+  handleDateChangeRaw = event => {
+    event.preventDefault();
+  };
+
+  render() {
+    const { disableInlineEditing } = this.props;
+
+    const datePickerProps = disableInlineEditing ? { onChangeRaw: this.handleDateChangeRaw } : {};
+
+    return (
+      <div className="aui--date-picker" data-test-selector={this.props.dts}>
+        <ReactDatePicker {..._.omit(this.props, _.keys(adslotDatePickerPropTypes))} {...datePickerProps} />
+      </div>
+    );
+  }
+}
+
+DatePicker.propTypes = { ...adslotDatePickerPropTypes };
+
+DatePicker.defaultProps = {
+  disableInlineEditing: false,
+};
+
+export default DatePicker;

--- a/src/components/DatePicker/index.spec.jsx
+++ b/src/components/DatePicker/index.spec.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import sinon from 'sinon';
+import ReactDatePicker from 'react-datepicker';
+import { shallow } from 'enzyme';
+import DatePicker from '.';
+
+describe('DatePicker', () => {
+  it('should render with defaults', () => {
+    const component = shallow(<DatePicker className="test" />);
+    expect(component.find(ReactDatePicker).prop('onChangeRaw')).to.equal(undefined);
+  });
+
+  it('should render with onChangeRaw when disableInlineEditing = true', () => {
+    const component = shallow(<DatePicker className="test" disableInlineEditing />);
+    expect(component.find(ReactDatePicker).prop('onChangeRaw')).to.be.a('function');
+  });
+
+  it('should call event.preventDeault function', () => {
+    const component = shallow(<DatePicker className="test" disableInlineEditing />);
+    const event = new Event('change');
+    sinon.spy(event, 'preventDefault');
+    component.find(ReactDatePicker).prop('onChangeRaw')(event);
+    expect(event.preventDefault.called).to.equal(true);
+  });
+});

--- a/src/components/DatePicker/styles.scss
+++ b/src/components/DatePicker/styles.scss
@@ -1,6 +1,6 @@
-@import './bootstrap-custom';
-@import './icon';
-@import '../../node_modules/react-datepicker/dist/react-datepicker.css';
+@import '../../styles/bootstrap-custom';
+@import '../../styles/icon';
+@import '../../../node_modules/react-datepicker/dist/react-datepicker.css';
 
 // sass-lint:disable class-name-format
 .react-datepicker {
@@ -150,6 +150,13 @@
       &::-ms-clear {
         display: none;
       }
+    }
+  }
+
+  &__close-icon {
+    &::after {
+      background-color: $color-gray-darker;
+      right: 15px;
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 // Export the consumable components.
-import DatePicker from 'react-datepicker';
 import Dropdown from 'react-bootstrap/lib/Dropdown';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 import Modal from 'react-bootstrap/lib/Modal';
@@ -10,7 +9,6 @@ import NavItem from 'react-bootstrap/lib/NavItem';
 
 import 'styles/_bootstrap-custom.scss';
 import 'styles/_icheck-custom.scss';
-import 'styles/_react-datepicker-custom.scss';
 
 import Button from './components/Button';
 import Popover from './components/Popover';
@@ -43,6 +41,7 @@ import Checkbox from './components/Checkbox';
 import CheckboxGroup from './components/CheckboxGroup';
 import ConfirmModal from './components/ConfirmModal';
 import CountBadge from './components/CountBadge';
+import DatePicker from './components/DatePicker';
 import fastStatelessWrapper from './components/fastStatelessWrapper';
 import FilePicker from './components/FilePicker';
 import FormGroup from './components/FormGroup';

--- a/www/examples/DatePickerExample.jsx
+++ b/www/examples/DatePickerExample.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import moment from 'moment';
 import Example from '../components/Example';
-import { DatePicker } from '../../src';
+import { DatePicker, Checkbox } from '../../src';
+import moment from 'moment';
 
-class DatePickerExample extends React.Component {
+class DatePickerExample extends React.PureComponent {
   constructor() {
     super();
-    this.state = { startDate: moment() };
+    this.state = { startDate: moment(), disableInlineEditChecked: false, isClearableChecked: false };
     this.setSelectedDate = this.setSelectedDate.bind(this);
   }
 
@@ -14,15 +14,27 @@ class DatePickerExample extends React.Component {
     this.setState({ startDate: newValue });
   }
 
+  handleDisableInlineEditCheckboxChange = event => this.setState({ disableInlineEditChecked: event.target.checked });
+
   render() {
     return (
-      <DatePicker
-        className="form-control"
-        dateFormat="DD MMM YYYY"
-        selected={this.state.startDate}
-        onChange={this.setSelectedDate}
-        placeholderText="Date e.g. 03 Sep 2016"
-      />
+      <div>
+        <Checkbox
+          label="Disable inline editing"
+          checked={false}
+          inline
+          onChange={this.handleDisableInlineEditCheckboxChange}
+        />
+        <DatePicker
+          className="form-control"
+          dateFormat="DD MMM YYYY"
+          selected={this.state.startDate}
+          onChange={this.setSelectedDate}
+          placeholderText="Select Date"
+          disableInlineEditing={this.state.disableInlineEditChecked}
+          isClearable={true}
+        />
+      </div>
     );
   }
 }
@@ -41,14 +53,26 @@ const exampleProps = {
     </div>
   ),
   exampleCodeSnippet: `
-  <DatePicker
-    className="form-control"
-    dateFormat="DD MMM YYYY"
-    selected={this.state.startDate}
-    onChange={this.setSelectedDate}
-    placeholderText="Date e.g. 03 Sep 2016"
-  />`,
-  propTypeSectionArray: [],
+    <DatePicker
+      className="form-control"
+      dateFormat="DD MMM YYYY"
+      selected={this.state.startDate}
+      onChange={this.setSelectedDate}
+      placeholderText="Date e.g. 03 Sep 2016"
+    />`,
+  propTypeSectionArray: [
+    {
+      label: '',
+      propTypes: [
+        {
+          propType: 'disableInlineEditing',
+          type: 'bool',
+          note: 'A flag to determine whether date picker inline editing is available or not.',
+          defaultValue: 'false',
+        },
+      ],
+    },
+  ],
 };
 
 export default () => (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Extend react-datepicker component to enable/disable inline editing
NB: I also extend the test and karma.conf so I can run the test on WSL.. :)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):
