### PR TITLE
refactor: improve alert input component

### DIFF
--- a/src/components/AlertInput/index.jsx
+++ b/src/components/AlertInput/index.jsx
@@ -3,18 +3,37 @@ import { Popover } from 'adslot-ui';
 import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { popoverPlacements } from '../Popover/constants';
 import './styles.scss';
 
-export const baseClass = 'alert-input-component';
+export const baseClass = 'aui--alert-input';
 
 export default class AlertInput extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isFocused: false,
-      isPopoverVisible: false,
-    };
-  }
+  static propTypes = {
+    className: PropTypes.string,
+    dts: PropTypes.string,
+    disabled: PropTypes.bool,
+    prefixAddon: PropTypes.node,
+    suffixAddon: PropTypes.node,
+    alertStatus: PropTypes.oneOf(['success', 'info', 'warning', 'error']),
+    popoverPlacement: PropTypes.oneOf(popoverPlacements),
+    alertMessage: PropTypes.string,
+    onValueChange: PropTypes.func,
+    onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
+  };
+
+  static defaultProps = {
+    alertStatus: 'success',
+    popoverPlacement: 'bottom',
+  };
+
+  state = {
+    isFocused: false,
+    isPopoverVisible: false,
+  };
+
+  componentRef = React.createRef();
 
   handleMouseEnter = () => {
     if (this.props.alertMessage) {
@@ -51,15 +70,9 @@ export default class AlertInput extends React.PureComponent {
 
   render() {
     const {
-      className: customClass,
       dts,
-      defaultValue,
       popoverPlacement,
       disabled,
-      value,
-      type,
-      min,
-      placeholder,
       prefixAddon,
       suffixAddon,
       alertStatus,
@@ -67,86 +80,59 @@ export default class AlertInput extends React.PureComponent {
       onValueChange,
     } = this.props;
 
-    const className = classnames(`${baseClass}-wrapper`, customClass, {
+    const className = classnames(baseClass, this.props.className, {
       [alertStatus]: alertStatus,
-      'is-focused': this.state.isFocused,
+      [`${baseClass}--focused`]: this.state.isFocused,
+      [`${baseClass}--disabled`]: disabled,
     });
-
-    const popoverClassName = classnames(`${baseClass}-popover`, {
-      [alertStatus]: alertStatus,
-    });
-
     const theme = alertStatus === 'warning' ? 'warn' : alertStatus;
+    const shouldPopoverOpen = this.state.isPopoverVisible && !_.isEmpty(alertMessage);
+
+    const inputProps = _.omit(this.props, [
+      'dts',
+      'prefixAddon',
+      'suffixAddon',
+      'alertStatus',
+      'alertMessage',
+      'onValueChange',
+      'popoverPlacement',
+    ]);
 
     return (
-      <div className={baseClass}>
-        <Popover
-          isOpen={this.state.isPopoverVisible && !_.isEmpty(alertMessage)}
-          triggers={['disabled']}
-          popoverContent={<strong>{alertMessage}</strong>}
-          placement={popoverPlacement}
-          popoverClassNames={popoverClassName}
-          theme={theme}
+      <React.Fragment>
+        <div
+          ref={this.componentRef}
+          className={className}
+          data-test-selector={dts}
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
         >
-          <div
-            className={classnames(className, { [`${baseClass}--disabled`]: disabled })}
-            data-test-selector={dts}
-            onMouseEnter={this.handleMouseEnter}
-            onMouseLeave={this.handleMouseLeave}
-          >
-            {prefixAddon ? <span className={`${baseClass}-wrapper-addon`}>{prefixAddon}</span> : null}
-            <span className={`${baseClass}-wrapper-flex-wrapper`}>
-              <input
-                className={`${baseClass}-wrapper-input`}
-                type={type}
-                defaultValue={defaultValue}
-                value={value}
-                min={min}
-                placeholder={placeholder}
-                onChange={onValueChange}
-                disabled={disabled}
-                onFocus={this.handleInputFocus}
-                onBlur={this.handleInputBlur}
-              />
-            </span>
-            {suffixAddon ? <span className={`${baseClass}-wrapper-addon`}>{suffixAddon}</span> : null}
-          </div>
-        </Popover>
-      </div>
+          {prefixAddon ? <span className={`${baseClass}__addon`}>{prefixAddon}</span> : null}
+
+          <input
+            {...{
+              ...inputProps,
+              className: `${baseClass}__input`,
+              onChange: onValueChange,
+              onFocus: this.handleInputFocus,
+              onBlur: this.handleInputBlur,
+            }}
+          />
+
+          {suffixAddon ? <span className={`${baseClass}__addon`}>{suffixAddon}</span> : null}
+        </div>
+
+        {shouldPopoverOpen && (
+          <Popover.WithRef
+            isOpen
+            refElement={this.componentRef.current}
+            placement={popoverPlacement}
+            popoverClassNames={`${baseClass}__popover`}
+            theme={theme}
+            popoverContent={alertMessage}
+          />
+        )}
+      </React.Fragment>
     );
   }
 }
-
-AlertInput.propTypes = {
-  className: PropTypes.string,
-  dts: PropTypes.string,
-  defaultValue: PropTypes.string,
-  disabled: PropTypes.bool,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  type: PropTypes.oneOf(['text', 'number']),
-  min: PropTypes.number,
-  placeholder: PropTypes.string,
-  prefixAddon: PropTypes.node,
-  suffixAddon: PropTypes.node,
-  alertStatus: PropTypes.oneOf(['success', 'info', 'warning', 'error']),
-  popoverPlacement: PropTypes.oneOf([
-    'left',
-    'top',
-    'top-start',
-    'top-end',
-    'bottom-start',
-    'bottom',
-    'bottom-end',
-    'right',
-  ]),
-  alertMessage: PropTypes.string,
-  onValueChange: PropTypes.func,
-  onBlur: PropTypes.func,
-  onFocus: PropTypes.func,
-};
-
-AlertInput.defaultProps = {
-  type: 'text',
-  disabled: false,
-  popoverPlacement: 'bottom',
-};

--- a/src/components/AlertInput/index.spec.jsx
+++ b/src/components/AlertInput/index.spec.jsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
 import AlertInput from '.';
+import Popover from '../Popover';
 
 describe('AlertInput', () => {
   const initialState = {
@@ -41,7 +42,7 @@ describe('AlertInput', () => {
   describe('handleInputFocus()', () => {
     it('should set `isFocused` to true, and `isPopoverVisible` if there is an alert message', () => {
       const component = shallow(<AlertInput alertMessage="Hello" />);
-      const inputElement = component.find('.alert-input-component-wrapper-input');
+      const inputElement = component.find('.aui--alert-input__input');
       const focusEvent = {
         target: {
           select: sinon.spy(),
@@ -57,7 +58,7 @@ describe('AlertInput', () => {
 
     it('should set `isFocused` to true, but not `isPopoverVisible` if no alert message', () => {
       const component = shallow(<AlertInput />);
-      const inputElement = component.find('.alert-input-component-wrapper-input');
+      const inputElement = component.find('.aui--alert-input__input');
       const focusEvent = {
         target: {
           select: sinon.spy(),
@@ -79,7 +80,7 @@ describe('AlertInput', () => {
         },
       };
       const component = shallow(<AlertInput onFocus={onFocusSpy} />);
-      const inputElement = component.find('.alert-input-component-wrapper-input');
+      const inputElement = component.find('.aui--alert-input__input');
 
       inputElement.simulate('focus', focusEvent);
 
@@ -95,7 +96,7 @@ describe('AlertInput', () => {
   describe('handleInputBlur ()', () => {
     it('should set `isFocused` and `isPopoverVisible` to false', () => {
       const component = shallow(<AlertInput />);
-      const inputElement = component.find('.alert-input-component-wrapper-input');
+      const inputElement = component.find('.aui--alert-input__input');
       const focusEvent = {
         target: {
           select: _.noop,
@@ -109,7 +110,7 @@ describe('AlertInput', () => {
     it('should call `onBlur` if exists', () => {
       const onBlurSpy = sinon.spy();
       const component = shallow(<AlertInput onBlur={onBlurSpy} />);
-      const inputElement = component.find('.alert-input-component-wrapper-input');
+      const inputElement = component.find('.aui--alert-input__input');
       inputElement.simulate('blur');
       expect(onBlurSpy.callCount).to.equal(1);
     });
@@ -126,13 +127,13 @@ describe('AlertInput', () => {
         onBlur: _.noop,
       };
       const wrapper = shallow(<AlertInput {...props} />);
-      expect(wrapper.hasClass('alert-input-component')).to.equal(true);
-      const componentWrapper = wrapper.find('.alert-input-component-wrapper');
+      expect(wrapper.find('.aui--alert-input')).to.have.length(1);
+      const componentWrapper = wrapper.find('.aui--alert-input');
       expect(componentWrapper.prop('onMouseEnter')).to.be.a('function');
       expect(componentWrapper.prop('onMouseLeave')).to.be.a('function');
       expect(componentWrapper.children()).to.have.length(1);
 
-      const inputElement = wrapper.find('.alert-input-component-wrapper-input');
+      const inputElement = wrapper.find('.aui--alert-input__input');
       expect(inputElement.prop('type')).to.equal('number');
       expect(inputElement.prop('min')).to.equal(0);
       expect(inputElement.prop('placeholder')).to.equal('Type a number');
@@ -143,10 +144,11 @@ describe('AlertInput', () => {
     });
 
     it('should also render with default props', () => {
-      const wrapper = shallow(<AlertInput />);
+      const wrapper = shallow(<AlertInput alertMessage="test" />);
+      wrapper.setState({ isPopoverVisible: true });
 
-      expect(wrapper.find('input').prop('type')).to.equal('text');
-      expect(wrapper.find('Popover').prop('placement')).to.equal('bottom');
+      expect(wrapper.find('.aui--alert-input').hasClass('success')).to.equal(true);
+      expect(wrapper.find(Popover.WithRef).prop('placement')).to.equal('bottom');
     });
 
     it('should render with addons', () => {
@@ -155,7 +157,7 @@ describe('AlertInput', () => {
         suffixAddon: '.00',
       };
       const wrapper = shallow(<AlertInput {...props} />);
-      const componentWrapper = wrapper.find('.alert-input-component-wrapper');
+      const componentWrapper = wrapper.find('.aui--alert-input');
       expect(componentWrapper.children()).to.have.length(3);
 
       const prefixElement = componentWrapper.childAt(0);
@@ -174,7 +176,7 @@ describe('AlertInput', () => {
       };
       const wrapper = shallow(<AlertInput {...props} />);
 
-      const componentWrapper = wrapper.find('.alert-input-component-wrapper');
+      const componentWrapper = wrapper.find('.aui--alert-input');
       expect(componentWrapper.children()).to.have.length(3);
 
       const prefixElement = componentWrapper.childAt(0);
@@ -183,7 +185,7 @@ describe('AlertInput', () => {
       const suffixElement = componentWrapper.childAt(2);
       expect(suffixElement.text()).to.equal('.00');
 
-      expect(wrapper.find('.alert-input-component--disabled')).to.have.lengthOf(1);
+      expect(wrapper.find('.aui--alert-input--disabled')).to.have.lengthOf(1);
     });
 
     it('should render with alert status', () => {
@@ -191,29 +193,34 @@ describe('AlertInput', () => {
         alertStatus: 'error',
       };
       const wrapper = shallow(<AlertInput {...props} />);
-      const componentWrapper = wrapper.find('.alert-input-component-wrapper');
-      expect(componentWrapper.prop('className')).to.equal('alert-input-component-wrapper error');
+      const componentWrapper = wrapper.find('.aui--alert-input');
+      expect(componentWrapper.prop('className')).to.equal('aui--alert-input error');
     });
 
     it('should set correct theme for popover', () => {
       const props = {
         alertStatus: 'error',
+        alertMessage: 'something is wrong',
       };
       const wrapper = shallow(<AlertInput {...props} />);
+      wrapper.setState({ isPopoverVisible: true });
 
-      expect(wrapper.find('Popover').prop('theme')).to.equal('error');
+      expect(wrapper.find(Popover.WithRef).prop('theme')).to.equal('error');
 
       wrapper.setProps({ alertStatus: 'warning' });
-      expect(wrapper.find('Popover').prop('theme')).to.equal('warn');
+      expect(wrapper.find(Popover.WithRef).prop('theme')).to.equal('warn');
     });
 
     it('should set correct popoverPlacement position for popover', () => {
       const props = {
         popoverPlacement: 'left',
+        alertMessage: 'something is wrong',
       };
-
       const wrapper = shallow(<AlertInput {...props} />);
-      expect(wrapper.find('Popover').prop('placement')).to.equal('left');
+      wrapper.setState({ isPopoverVisible: true });
+
+      expect(wrapper.find(Popover.WithRef).prop('placement')).to.equal('left');
     });
   });
 });
+/* eslint-enable lodash/prefer-lodash-method */

--- a/src/components/AlertInput/styles.scss
+++ b/src/components/AlertInput/styles.scss
@@ -1,91 +1,82 @@
-@import '~styles/border';
-@import '~styles/color';
-@import '~styles/font-size';
+@import '~styles/variable';
 
-.alert-input-component {
-  &-wrapper {
-    align-items: center;
+.aui--alert-input {
+  display: flex;
+  align-items: center;
+  background-color: $color-well;
+  border: $border-lighter;
+  border-radius: $border-radius;
+  padding: 4px 5px;
+  position: relative;
+
+  &.aui--alert-input--focused {
+    border-color: $color-border;
+  }
+
+  .aui--alert-input__input {
+    flex-grow: 1;
     background-color: $color-well;
-    border: $border-lighter;
-    border-radius: $border-radius;
-    display: flex;
-    padding: 4px 5px;
-    position: relative;
+    border: 0;
+    width: 100%;
+    padding: 0;
 
-    &-flex-wrapper {
-      width: 100%;
-    }
-
-    &.is-focused {
-      border-color: $color-border;
-    }
-
-    &.success {
-      border-color: $color-positive;
-    }
-
-    &.info {
-      border-color: $color-info;
-    }
-
-    &.warning {
-      border-color: $color-warning;
-    }
-
-    &.error {
-      border-color: $color-negative;
-    }
-
-    &-input {
-      background-color: $color-well;
-      border: 0;
-      flex: 1;
-      width: 100%;
-      padding: 0;
-
-      &:focus {
-        outline: none;
-      }
-    }
-
-    &-addon {
-      color: $color-text-addon;
-
-      &:first-child {
-        margin-right: 2px;
-      }
-
-      &:last-child {
-        margin-left: 2px;
-      }
+    &:focus {
+      outline: none;
     }
   }
 
-  &--disabled {
+  &.success {
+    border-color: $color-positive;
+  }
+
+  &.info {
+    border-color: $color-info;
+  }
+
+  &.warning {
+    border-color: $color-warning;
+  }
+
+  &.error {
+    border-color: $color-negative;
+  }
+
+  .aui--alert-input__addon {
+    color: $color-text-addon;
+
+    &:first-child {
+      margin-right: 2px;
+    }
+
+    &:last-child {
+      margin-left: 2px;
+    }
+  }
+
+  &.aui--alert-input--disabled {
     background-color: $color-gray-lighter;
 
-    .alert-input-component-wrapper {
-      &-input {
-        &:disabled {
-          background-color: $color-gray-lighter;
-        }
+    .aui--alert-input__input {
+      &:disabled {
+        background-color: $color-gray-lighter;
       }
+    }
 
-      &-addon {
-        color: $color-gray;
-      }
+    .aui--alert-input__addon {
+      color: $color-gray;
     }
   }
+}
 
-  &-popover {
-    border-radius: 4px;
-    box-shadow: none;
-    font-size: $font-size-small;
+.aui--alert-input__popover {
+  border-radius: 4px;
+  box-shadow: none;
+  font-size: $font-size-small;
 
-    .popover-content {
-      color: inherit;
-      padding: 5px 10px;
-      width: auto;
-    }
+  .popover-content {
+    color: inherit;
+    padding: 5px 10px;
+    width: auto;
+    font-weight: $font-weight-bold;
   }
 }

--- a/www/examples/AlertInputExample.jsx
+++ b/www/examples/AlertInputExample.jsx
@@ -1,45 +1,86 @@
 import React from 'react';
 import _ from 'lodash';
 import Example from '../components/Example';
-import { AlertInput } from '../../src';
+import { ActionPanel, AlertInput, Button, Checkbox, FlexibleSpacer } from '../../src';
+import { popoverPlacements } from '../../src/components/Popover/constants';
 
-const initialState = {
-  impressions: null,
-  status: null,
-  message: null,
+/**
+ * @param {string} value
+ * @return {{status: string}|{message: string, status: string}}
+ */
+const validateValue = value => {
+  switch (true) {
+    case _.isEmpty(value):
+      return { status: 'success' };
+
+    case !_.isNumber(+value) || _.isNaN(+value):
+      return { status: 'error', message: 'Impressions should be a number.' };
+
+    case value < 1000:
+      return {
+        status: 'warning',
+        message: 'A minimum value of 1000 impressions is expected.',
+      };
+
+    default:
+      return { status: 'success' };
+  }
 };
 
 class AlertInputExample extends React.Component {
-  constructor() {
-    super();
-    this.state = initialState;
-    if (typeof this.state.impressions != 'string') this.state.impressions = '';
-    this.changeValue = this.changeValue.bind(this);
-  }
+  state = {
+    hasPrefix: false,
+    hasSuffix: true,
+    isDisabled: false,
+    impressions: null,
+    status: null,
+    message: null,
+    showModal: false,
+  };
 
-  validateValue(value) {
-    switch (true) {
-      case _.isEmpty(value):
-        return { status: 'success' };
+  toggleShowModal = () => this.setState(prevState => ({ showModal: !prevState.showModal }));
 
-      case !_.isNumber(+value) || _.isNaN(+value):
-        return { status: 'error', message: 'Impressions should be a number.' };
+  renderAlertInputExample = () => (
+    <React.Fragment>
+      <div className="adslot-ui-example__options">
+        <Checkbox
+          inline
+          name="prefix"
+          checked={this.state.hasPrefix}
+          label="Show Prefix"
+          onChange={this.togglePrefix}
+        />
+        <Checkbox
+          inline
+          name="suffix"
+          checked={this.state.hasSuffix}
+          label="Show Suffix"
+          onChange={this.toggleSuffix}
+        />
+        <Checkbox
+          inline
+          name="disabled"
+          checked={this.state.isDisabled}
+          label="Disable"
+          onChange={this.toggleDisabled}
+        />
+      </div>
+      <AlertInput
+        value={this.state.impressions || ''}
+        disabled={this.state.isDisabled}
+        prefixAddon={this.state.hasPrefix ? 'Max' : null}
+        suffixAddon={this.state.hasSuffix ? 'impressions' : null}
+        alertStatus={this.state.status}
+        alertMessage={this.state.message}
+        onValueChange={event => this.changeValue(event.target.value)}
+      />
+    </React.Fragment>
+  );
 
-      case value < 1000:
-        return {
-          status: 'warning',
-          message: 'A minimum value of 1000 impressions is expected.',
-        };
-
-      default:
-        return { status: 'success' };
-    }
-  }
-
-  changeValue(value) {
+  changeValue = value => {
     if (value === this.state.impressions) return;
 
-    const validationResponse = this.validateValue(value);
+    const validationResponse = validateValue(value);
     const validationState = {
       status: null,
       message: null,
@@ -49,17 +90,31 @@ class AlertInputExample extends React.Component {
     }
 
     this.setState(_.assign({ impressions: value }, validationState));
-  }
+  };
+
+  togglePrefix = nextState => this.setState({ hasPrefix: nextState });
+
+  toggleSuffix = nextState => this.setState({ hasSuffix: nextState });
+
+  toggleDisabled = nextState => this.setState({ isDisabled: nextState });
 
   render() {
     return (
-      <AlertInput
-        value={this.state.impressions}
-        suffixAddon="impressions"
-        alertStatus={this.state.status}
-        alertMessage={this.state.message}
-        onValueChange={event => this.changeValue(event.target.value)}
-      />
+      <React.Fragment>
+        {this.renderAlertInputExample()}
+
+        <FlexibleSpacer />
+
+        <div className="adslot-ui-example__options">
+          <Button onClick={this.toggleShowModal}>AlertInput in Modal</Button>
+        </div>
+
+        {this.state.showModal && (
+          <ActionPanel isModal size="small" onClose={this.toggleShowModal} title="AlertInput in Modal">
+            {this.renderAlertInputExample()}
+          </ActionPanel>
+        )}
+      </React.Fragment>
     );
   }
 }
@@ -87,6 +142,11 @@ const exampleProps = {
     {
       propTypes: [
         {
+          propType: '...inputProps',
+          type: 'any',
+          note: 'Any valid react input props, e.g. <AlertInput autofocus disabled type="text" defaultValue="xxx" />',
+        },
+        {
           propType: 'className',
           type: 'string',
         },
@@ -95,30 +155,8 @@ const exampleProps = {
           type: 'string',
         },
         {
-          propType: 'defaultValue',
-          type: 'string',
-        },
-        {
           propType: 'disabled',
           type: 'bool',
-          defaultValue: 'false',
-        },
-        {
-          propType: 'value',
-          type: 'string|number',
-        },
-        {
-          propType: 'type',
-          type: "oneOf: 'text', 'number'",
-          defaultValue: 'text',
-        },
-        {
-          propType: 'min',
-          type: 'number',
-        },
-        {
-          propType: 'placeholder',
-          type: 'string',
         },
         {
           propType: 'prefixAddon',
@@ -142,7 +180,7 @@ const exampleProps = {
         },
         {
           propType: 'popoverPlacement',
-          type: "oneOf: 'left', 'top', 'top-start', 'top-end', 'bottom-start', 'bottom', 'bottom-end', 'right'",
+          type: `oneOf: ${popoverPlacements.map(placement => `'${placement}'`).join(', ')}`,
           defaultValue: 'bottom',
         },
         {

--- a/www/examples/styles.scss
+++ b/www/examples/styles.scss
@@ -25,7 +25,19 @@
 .adslot-ui-example-container {
   &.alert-input-example {
     .adslot-ui-example {
-      width: 140px;
+      display: flex;
+      flex-direction: column;
+      width: 270px;
+
+      .flexible-spacer-component {
+        height: 12px;
+        border: 0;
+      }
+
+      .adslot-ui-example__options {
+        display: flex;
+        margin-bottom: 6px;
+      }
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Simplify `AlertInput` DOM structure
Resolves #957 

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
`AlertInput` has an unusual DOM structure, and therefore makes the CSS complicated. By removing some layers of the DOM, and implement `Popover.WithRef` into the component, we end up with a super simple structure and easy to understand.
```jsx
// before
<div class="alert-input-component">
  <span class="aui--popover-element">
    <div class="alert-input-component-wrapper">
      <span class="alert-input-component-wrapper-addon">Max</span>
      <span class="alert-input-component-wrapper-flex-wrapper">
        <input class="alert-input-component-wrapper-input" type="text" value="">
      </span>
      <span class="alert-input-component-wrapper-addon">impressions</span>
    </div>
  </span>
</div>

// after
<div class="aui--alert-input">
  <span class="aui--alert-input__addon">Max</span>
  <input class="aui--alert-input__input" value="">
  <span class="aui--alert-input__addon">impressions</span>
</div>
```


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

Potentially breaking since the DOM structure changes, therefore some styles are invalid.

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
![after](https://user-images.githubusercontent.com/2588669/71074733-e6602500-21d6-11ea-9be0-e4ca7eaf90c6.gif)
