### PR TITLE
[ADS-3669] Upgrade node 12.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: required
 language: node_js
 node_js:
-  - '8'
   - '10'
+  - '12'
 addons:
   chrome: stable
 before_install:

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "react-popper": "^1.3.3"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Upgrade NodeJs version from 10.18 to 12.14 lts, Retire Node 8 as the maintenance of this version ends in Jan 2020.

![image](https://user-images.githubusercontent.com/3688957/71793201-f3628c80-308f-11ea-81b6-4f8fed5872f4.png)


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [x] No

Note:
 `Yes`, if the package consumer is using Node 8
 `No`, if the package consumer is using Node 10

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->
N/A

## Screenshots (if appropriate):
N/A