### PR TITLE
fix: use SvgSymbol instead of SvgSymbolCircle in empty

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,7 +42,13 @@ module.exports = function configureKarma(config) {
   config.set({
     mode: 'development',
     basePath: '',
-    browsers: ['ChromeHeadless'],
+    browsers: !_.isEmpty(process.env.KARMA_BROWSERS) ? process.env.KARMA_BROWSERS.split(',') : ['ChromeHeadless'],
+    customLaunchers: {
+      HeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-setuid-sandbox'],
+      },
+    },
     colors: true,
     files: [
       'config/load-tests.js',

--- a/scripts/test
+++ b/scripts/test
@@ -23,7 +23,7 @@ if (file) {
 }
 
 // npm run test[:watch] --file=path [--coverage]
-let cmd = 'karma start';
+let cmd = 'KARMA_BROWSERS="${npm_config_browsers}" karma start';
 if (watch) cmd += ' --autoWatch=true --singleRun=false';
 try {
   execSync(cmd, { stdio: [0, 1, 2] });

--- a/src/components/Empty/index.jsx
+++ b/src/components/Empty/index.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import SvgSymbolCircle from '../SvgSymbol/Circle';
+import SvgSymbol from '../SvgSymbol';
 import './styles.scss';
 
 const Empty = ({ collection, svgSymbol, text, hideIcon }) => {
@@ -12,7 +12,7 @@ const Empty = ({ collection, svgSymbol, text, hideIcon }) => {
   if (_.isEmpty(collection)) {
     return (
       <div className="empty-component">
-        {hideIcon ? null : <SvgSymbolCircle href={svgSymbol.href} classSuffixes={classSuffixes} />}
+        {hideIcon ? null : <SvgSymbol href={svgSymbol.href} classSuffixes={classSuffixes} />}
         <div className="empty-component-text">{text}</div>
       </div>
     );
@@ -25,7 +25,7 @@ Empty.displayName = 'EmptyComponent';
 
 Empty.propTypes = {
   collection: PropTypes.oneOfType([PropTypes.node, PropTypes.array, PropTypes.object]),
-  svgSymbol: PropTypes.shape(SvgSymbolCircle.propTypes),
+  svgSymbol: PropTypes.shape(SvgSymbol.propTypes),
   text: PropTypes.node, // can be string or, if you want rich formatting, a node
   hideIcon: PropTypes.bool,
 };

--- a/src/components/Empty/index.spec.jsx
+++ b/src/components/Empty/index.spec.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable lodash/prefer-lodash-method */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { SvgSymbolCircle } from 'adslot-ui';
+import { SvgSymbol } from 'adslot-ui';
 import Empty from '.';
 
 describe('Empty', () => {
@@ -9,8 +9,8 @@ describe('Empty', () => {
     const component = shallow(<Empty />);
     expect(component.prop('className')).to.equal('empty-component');
 
-    const svgSymbolEl = component.find(SvgSymbolCircle);
-    expect(svgSymbolEl.prop('href')).to.equal(undefined);
+    const svgSymbolEl = component.find(SvgSymbol);
+    expect(svgSymbolEl.prop('href')).to.equal('');
     expect(svgSymbolEl.prop('classSuffixes')).to.deep.equal(['gray-darker', '70', 'circle']);
 
     const textElement = component.find('.empty-component-text');
@@ -35,7 +35,7 @@ describe('Empty', () => {
     const component = shallow(<Empty {...props} />);
     expect(component.prop('className')).to.equal('empty-component');
 
-    const svgSymbolEl = component.find(SvgSymbolCircle);
+    const svgSymbolEl = component.find(SvgSymbol);
     expect(svgSymbolEl.prop('href')).to.equal('//wherever.svg#id');
     expect(svgSymbolEl.prop('classSuffixes')).to.deep.equal(['class']);
 
@@ -48,7 +48,7 @@ describe('Empty', () => {
     const component = shallow(<Empty {...{ svgSymbol }} />);
     expect(component.prop('className')).to.equal('empty-component');
 
-    const svgSymbolEl = component.find(SvgSymbolCircle);
+    const svgSymbolEl = component.find(SvgSymbol);
     expect(svgSymbolEl.prop('href')).to.equal('//wherever.svg#id');
     expect(svgSymbolEl.prop('classSuffixes')).to.deep.equal(['gray-darker', '70', 'circle']);
   });
@@ -57,7 +57,7 @@ describe('Empty', () => {
     const svgSymbol = { href: '//wherever.svg#id' };
     const component = shallow(<Empty {...{ svgSymbol, hideIcon: true }} />);
     expect(component.prop('className')).to.equal('empty-component');
-    const svgSymbolEl = component.find(SvgSymbolCircle);
+    const svgSymbolEl = component.find(SvgSymbol);
     expect(svgSymbolEl).to.have.length(0);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Design has requested the circle be removed from all empty states

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
fixes https://github.com/Adslot/adslot-ui/issues/967

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/819711/72408491-3d95ed00-37b7-11ea-8279-773941e5687b.png)

