### PR TITLE
feat: add light gray color to CountBadge

### DIFF
--- a/src/components/CountBadge/styles.scss
+++ b/src/components/CountBadge/styles.scss
@@ -28,6 +28,10 @@
     background-color: $color-negative;
   }
 
+  &.status-light {
+    background-color: $color-gray;
+  }
+
   &.count-badge-font-size-small {
     font-size: $font-size-super-tiny;
   }

--- a/www/examples/CountBadgeExample.jsx
+++ b/www/examples/CountBadgeExample.jsx
@@ -24,7 +24,7 @@ const exampleProps = {
         },
         {
           propType: 'status',
-          type: "oneOf: 'default', 'info', 'warning', 'danger'",
+          type: "oneOf: 'default', 'info', 'warning', 'danger', 'light'",
           defaultValue: 'default',
           note: '"default" and no value given have the same effect',
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add light gray to countBadge component. It can be used when count is zero.

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
<img width="583" alt="Screen Shot 2020-01-20 at 4 49 58 pm" src="https://user-images.githubusercontent.com/8103605/72701885-f0de5780-3ba4-11ea-9c06-3f290bb00153.png">
