### PR TITLE
feat: add accent to node props for treepicker

### DIFF
--- a/src/components/TreePicker/Node/index.jsx
+++ b/src/components/TreePicker/Node/index.jsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import React from 'react';
 import Button from 'react-bootstrap/lib/Button';
 import GridCell from '../../Grid/Cell';
@@ -54,8 +55,13 @@ class TreePickerNodeComponent extends React.PureComponent {
 
     const labelCellProps = isExpandable && !this.state.isLoading ? { onClick: this.setLoadingAndExpandNode } : {};
 
+    const classNames = classnames(baseClass, {
+      'child-node': isChildNode,
+      [`is-${node.accent}`]: node.accent,
+    });
+
     return (
-      <div className={isChildNode ? `${baseClass} child-node` : `${baseClass}`}>
+      <div className={classNames}>
         <GridRow dts={`${_.kebabCase(itemType)}-${node.id}`}>
           {selected ? (
             <GridCell classSuffixes={['button']} dts="button-remove">

--- a/src/components/TreePicker/Node/index.spec.jsx
+++ b/src/components/TreePicker/Node/index.spec.jsx
@@ -111,6 +111,19 @@ describe('TreePickerNodeComponent', () => {
     expect(labelElement.text()).to.equal('Test value: Australian Capital Territory');
   });
 
+  it('should have correct accent color', () => {
+    expect(
+      shallow(
+        <TreePickerNode itemType={itemType} node={{ ...actNode, accent: 'error' }} nodeRenderer={nodeRenderer} />
+      ).props().className
+    ).match(/is-error/);
+    expect(
+      shallow(
+        <TreePickerNode itemType={itemType} node={{ ...actNode, accent: 'warning' }} nodeRenderer={nodeRenderer} />
+      ).props().className
+    ).match(/is-warning/);
+  });
+
   it('should render unselectable nodes with an include button', () => {
     const component = shallow(<TreePickerNode itemType={itemType} node={actNode} />);
 

--- a/src/components/TreePicker/Node/styles.scss
+++ b/src/components/TreePicker/Node/styles.scss
@@ -17,6 +17,22 @@
     width: $icon-size;
   }
 
+  &.is-error {
+    background-color: $color-negative-light;
+  }
+
+  &.is-warning {
+    background-color: $color-warning-light;
+  }
+
+  &.is-info {
+    background-color: $color-info-light;
+  }
+
+  &.is-success {
+    background-color: $color-positive-light;
+  }
+
   &-metadata {
     color: $color-text-light;
 

--- a/src/prop-types/TreePickerPropTypes.js
+++ b/src/prop-types/TreePickerPropTypes.js
@@ -17,6 +17,7 @@ export default {
       ancestors: PropTypes.arrayOf(PropTypes.shape(baseNodeProps).isRequired),
       type: PropTypes.string.isRequired,
       value: PropTypes.number,
+      accent: PropTypes.oneOf(['warning', 'success', 'info', 'error']),
     })
   ),
   breadCrumbNode: PropTypes.shape(baseNodeProps),

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -51,17 +51,21 @@ $color-primary: $color-blue;
 $color-primary-selected: $color-blue-dark;
 
 $color-positive: $color-green;
+$color-positive-light: #eaf8ea;
 $color-positive-selected: $color-green-dark;
 
 $color-negative: $color-red;
+$color-negative-light: #fbedec;
 $color-negative-selected: $color-red-dark;
 
 $color-pending: $color-orange;
 $color-pending-selected: $color-orange-dark;
 $color-warning: $color-orange;
+$color-warning-light: #fef6ea;
 $color-warning-selected: $color-orange-dark;
 
 $color-info: $color-cyan;
+$color-info-light: #e0f0ff;
 $color-info-selected: $color-cyan-dark;
 
 $color-disabled: $color-gray-lighter;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

- add `accent` to support `warning` or `error`
- add lighten versions of the current colors 

Fixes #980 

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
