### PR TITLE
chore: use npm ci in preversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "svgo": "svgo --recursive --multipass --folder=src --config=svgo-config.yml",
     "posttest": "npm run lint",
     "postversion": "git push -u origin $(git rev-parse --abbrev-ref HEAD) --follow-tags && npm publish && echo '…released.'",
-    "preversion": "echo 'Releasing…' && npm i",
+    "preversion": "echo 'Releasing…' && npm ci",
     "release:major": "npm version major -m 'build: release major version %s'",
     "release:minor": "npm version minor -m 'build: release minor version %s'",
     "release:patch": "npm version patch -m 'build: release patch version %s'",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use `npm ci` instead of `npm i` in `preversion`


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
