### PR TITLE
refactor: use node for icons instead of svg symbol href

### DIFF
--- a/src/components/Empty/index.jsx
+++ b/src/components/Empty/index.jsx
@@ -1,18 +1,13 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import SvgSymbol from '../SvgSymbol';
 import './styles.scss';
 
-const Empty = ({ collection, svgSymbol, text, hideIcon }) => {
-  const classSuffixes = _.isEmpty(svgSymbol.classSuffixes)
-    ? Empty.defaultProps.svgSymbol.classSuffixes
-    : svgSymbol.classSuffixes;
-
+const Empty = ({ collection, text, icon }) => {
   if (_.isEmpty(collection)) {
     return (
       <div className="empty-component">
-        {hideIcon ? null : <SvgSymbol href={svgSymbol.href} classSuffixes={classSuffixes} />}
+        {icon}
         <div className="empty-component-text">{text}</div>
       </div>
     );
@@ -25,17 +20,12 @@ Empty.displayName = 'EmptyComponent';
 
 Empty.propTypes = {
   collection: PropTypes.oneOfType([PropTypes.node, PropTypes.array, PropTypes.object]),
-  svgSymbol: PropTypes.shape(SvgSymbol.propTypes),
   text: PropTypes.node, // can be string or, if you want rich formatting, a node
-  hideIcon: PropTypes.bool,
+  icon: PropTypes.node,
 };
 
 Empty.defaultProps = {
-  svgSymbol: {
-    classSuffixes: ['gray-darker', '70', 'circle'],
-  },
   text: 'Nothing to show.',
-  hideIcon: false,
 };
 
 export default Empty;

--- a/src/components/Empty/index.spec.jsx
+++ b/src/components/Empty/index.spec.jsx
@@ -9,10 +9,6 @@ describe('Empty', () => {
     const component = shallow(<Empty />);
     expect(component.prop('className')).to.equal('empty-component');
 
-    const svgSymbolEl = component.find(SvgSymbol);
-    expect(svgSymbolEl.prop('href')).to.equal('');
-    expect(svgSymbolEl.prop('classSuffixes')).to.deep.equal(['gray-darker', '70', 'circle']);
-
     const textElement = component.find('.empty-component-text');
     expect(textElement.text()).to.equal('Nothing to show.');
   });
@@ -30,8 +26,8 @@ describe('Empty', () => {
   });
 
   it('should render with custom SVG symbol', () => {
-    const svgSymbol = { href: '//wherever.svg#id', classSuffixes: ['class'] };
-    const props = { svgSymbol, text: 'Where is everybody?' };
+    const svgSymbol = <SvgSymbol href="//wherever.svg#id" classSuffixes={['class']} />;
+    const props = { icon: svgSymbol, text: 'Where is everybody?' };
     const component = shallow(<Empty {...props} />);
     expect(component.prop('className')).to.equal('empty-component');
 
@@ -41,23 +37,5 @@ describe('Empty', () => {
 
     const textElement = component.find('.empty-component-text');
     expect(textElement.text()).to.equal('Where is everybody?');
-  });
-
-  it('should render with custom SVG symbol, using default classSuffixes', () => {
-    const svgSymbol = { href: '//wherever.svg#id' };
-    const component = shallow(<Empty {...{ svgSymbol }} />);
-    expect(component.prop('className')).to.equal('empty-component');
-
-    const svgSymbolEl = component.find(SvgSymbol);
-    expect(svgSymbolEl.prop('href')).to.equal('//wherever.svg#id');
-    expect(svgSymbolEl.prop('classSuffixes')).to.deep.equal(['gray-darker', '70', 'circle']);
-  });
-
-  it('should not render with SVG symbol, when hideIcon is set to true', () => {
-    const svgSymbol = { href: '//wherever.svg#id' };
-    const component = shallow(<Empty {...{ svgSymbol, hideIcon: true }} />);
-    expect(component.prop('className')).to.equal('empty-component');
-    const svgSymbolEl = component.find(SvgSymbol);
-    expect(svgSymbolEl).to.have.length(0);
   });
 });

--- a/src/components/InformationBox/index.jsx
+++ b/src/components/InformationBox/index.jsx
@@ -1,17 +1,11 @@
 import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-import SvgSymbol from '../SvgSymbol';
 import './styles.scss';
 
 const InformationBox = ({ children, icon, title, className, dts }) => (
   <div className={classnames('information-box', className)} data-test-selector={dts}>
-    {icon ? (
-      <div className="information-box-icon">
-        {' '}
-        <SvgSymbol classSuffixes={['70']} href={icon} />
-      </div>
-    ) : null}
+    {icon ? <div className="information-box-icon"> {icon}</div> : null}
     <div className="information-box-text">
       {title ? <label className="information-box-title">{title}</label> : null}
       <div className="information-box-node">{children}</div>
@@ -23,7 +17,7 @@ InformationBox.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   title: PropTypes.node,
-  icon: PropTypes.string,
+  icon: PropTypes.node,
   dts: PropTypes.string,
 };
 

--- a/src/components/InformationBox/index.spec.jsx
+++ b/src/components/InformationBox/index.spec.jsx
@@ -4,9 +4,11 @@ import React from 'react';
 import InformationBox from '.';
 
 describe('InformationBoxComponent', () => {
+  const icon = <SvgSymbol href="assets/img#done" />;
+
   it('should render with props', () => {
     const component = shallow(
-      <InformationBox title="render title here" icon="assets/img#done">
+      <InformationBox title="render title here" icon={icon}>
         <div>I am child</div>
       </InformationBox>
     );
@@ -21,7 +23,7 @@ describe('InformationBoxComponent', () => {
 
   it('should render without a title when title props is not provided', () => {
     const component = shallow(
-      <InformationBox icon="assets/img#done">
+      <InformationBox icon={icon}>
         <div>I am child</div>
       </InformationBox>
     );
@@ -46,7 +48,7 @@ describe('InformationBoxComponent', () => {
   });
 
   it('should render without children nodes when children props is not provided', () => {
-    const component = shallow(<InformationBox title="render title here" icon="assets/img#done" />);
+    const component = shallow(<InformationBox title="render title here" icon={icon} />);
 
     expect(component.find('.information-box-title')).to.have.length(1);
     expect(component.find('.information-box-icon')).to.have.length(1);

--- a/src/components/ListPicker/index.jsx
+++ b/src/components/ListPicker/index.jsx
@@ -9,7 +9,6 @@ import FlexibleSpacer from '../FlexibleSpacer';
 import Grid from '../Grid';
 import GridRow from '../Grid/Row';
 import GridCell from '../Grid/Cell';
-import SvgSymbol from '../SvgSymbol';
 import './styles.scss';
 
 const isSubset = (array, subArray) =>
@@ -201,7 +200,7 @@ ListPickerComponent.propTypes = {
   allowMultiSelection: PropTypes.bool,
   emptyIcon: PropTypes.string,
   emptyMessage: PropTypes.string,
-  emptySvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+  emptySvgSymbol: PropTypes.node,
   initialSelection: PropTypes.arrayOf(itemProps),
   itemHeaders: PropTypes.shape({
     label: PropTypes.string,

--- a/src/components/ListPicker/index.spec.jsx
+++ b/src/components/ListPicker/index.spec.jsx
@@ -1,4 +1,4 @@
-import { ListPickerPure, SplitPane, Grid, GridCell, GridRow } from 'adslot-ui';
+import { ListPickerPure, SplitPane, Grid, GridCell, GridRow, SvgSymbol } from 'adslot-ui';
 import React from 'react';
 import Button from 'react-bootstrap/lib/Button';
 import Modal from 'react-bootstrap/lib/Modal';
@@ -57,7 +57,7 @@ describe('ListPickerComponent', () => {
     const initialSelection = getInitialSelection();
     const props = {
       emptyMessage: 'No users.',
-      emptySvgSymbol: { href: '/some.svg#id' },
+      emptySvgSymbol: <SvgSymbol href="/some.svg#id" />,
       initialSelection,
       items: users,
       itemHeaders: userHeaders,
@@ -89,9 +89,7 @@ describe('ListPickerComponent', () => {
     expect(listPickerPureElement.prop('selectedItems')).to.not.equal(initialSelection);
     expect(listPickerPureElement.prop('selectedItems')).to.deep.equal(initialSelection);
     expect(listPickerPureElement.prop('deselectItem')).to.be.a('function');
-    expect(listPickerPureElement.prop('emptySvgSymbol')).to.deep.equal({
-      href: '/some.svg#id',
-    });
+    expect(listPickerPureElement.prop('emptySvgSymbol')).to.be.an('object');
     expect(listPickerPureElement.prop('emptyMessage')).to.equal('No users.');
     expect(listPickerPureElement.prop('labelFormatter')).to.be.a('function');
     expect(listPickerPureElement.prop('itemHeaders')).to.deep.equal(userHeaders);
@@ -302,7 +300,7 @@ describe('ListPickerComponent', () => {
     beforeEach(() => {
       props = {
         emptyMessage: 'No users.',
-        emptySvgSymbol: { href: '/some.svg#id' },
+        emptySvgSymbol: <SvgSymbol href="/some.svg#id" />,
         initialSelection,
         items: users,
         itemHeaders: userHeaders,

--- a/src/components/ListPickerPure/index.jsx
+++ b/src/components/ListPickerPure/index.jsx
@@ -7,7 +7,6 @@ import Empty from '../Empty';
 import Grid from '../Grid';
 import GridRow from '../Grid/Row';
 import GridCell from '../Grid/Cell';
-import SvgSymbol from '../SvgSymbol';
 import './styles.scss';
 
 class ListPickerPureComponent extends React.PureComponent {
@@ -121,7 +120,7 @@ ListPickerPureComponent.propTypes = {
   deselectItem: PropTypes.func,
   emptyIcon: PropTypes.string,
   emptyMessage: PropTypes.string,
-  emptySvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+  emptySvgSymbol: PropTypes.node,
   labelFormatter: PropTypes.func,
   addonFormatter: PropTypes.func,
   itemHeaders: PropTypes.shape({

--- a/src/components/PagedGrid/index.jsx
+++ b/src/components/PagedGrid/index.jsx
@@ -6,7 +6,6 @@ import Empty from '../Empty';
 import Grid from '../Grid';
 import GridRow from '../Grid/Row';
 import GridCell from '../Grid/Cell';
-import SvgSymbol from '../SvgSymbol';
 import './styles.scss';
 
 class PagedGridComponent extends React.PureComponent {
@@ -84,7 +83,7 @@ PagedGridComponent.propTypes = {
   columns: PropTypes.arrayOf(columnProps).isRequired,
   emptyIcon: PropTypes.string,
   emptyMessage: PropTypes.string,
-  emptySvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+  emptySvgSymbol: PropTypes.node,
   items: PropTypes.arrayOf(itemProps).isRequired,
   perPage: PropTypes.number.isRequired,
   verticalCellBorder: PropTypes.bool,

--- a/src/components/Panel/index.jsx
+++ b/src/components/Panel/index.jsx
@@ -1,7 +1,6 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import SvgSymbol from '../SvgSymbol';
 import './styles.scss';
 
 class PanelComponent extends React.PureComponent {
@@ -9,10 +8,7 @@ class PanelComponent extends React.PureComponent {
     id: PropTypes.string.isRequired,
     className: PropTypes.string,
     dts: PropTypes.string,
-    /**
-     * shapeOf <a href="/svg-symbol">SVG Symbol</a> prop types.
-     */
-    icon: PropTypes.shape(SvgSymbol.propTypes),
+    icon: PropTypes.node,
     title: PropTypes.node.isRequired,
     isCollapsed: PropTypes.bool,
     onClick: PropTypes.func,
@@ -28,7 +24,7 @@ class PanelComponent extends React.PureComponent {
     return (
       <div className={classesCombined} data-test-selector={dts}>
         <div className="panel-component-header clearfix" onClick={this.onHeaderClick}>
-          {icon ? <SvgSymbol href={icon.href} /> : null}
+          {icon}
           {title}
         </div>
         <div className="panel-component-content">{children}</div>

--- a/src/components/Panel/index.spec.jsx
+++ b/src/components/Panel/index.spec.jsx
@@ -22,14 +22,17 @@ describe('PanelComponent', () => {
   });
 
   it('should render with props', () => {
-    const component = shallow(<Panel {...panel2}>{panel2.content}</Panel>);
+    const icon = <SvgSymbol href="/assets/svg-symbols.svg#list" />;
+    const component = shallow(
+      <Panel {...panel2} icon={icon}>
+        {panel2.content}
+      </Panel>
+    );
     expect(component.prop('className')).to.equal('panel-component collapsed');
     expect(component.prop('data-test-selector')).to.equal('panel-two');
 
     const headerElement = component.find('.panel-component-header');
-    const icon = headerElement.find(SvgSymbol);
-    expect(icon).to.have.length(1);
-    expect(icon.prop('href')).to.equal('/assets/svg-symbols.svg#list');
+    expect(headerElement.find(SvgSymbol)).to.have.length(1);
 
     const contentElement = component.find('.panel-component-content');
     expect(contentElement).to.have.length(1);

--- a/src/components/Panel/mocks.js
+++ b/src/components/Panel/mocks.js
@@ -10,7 +10,6 @@ const panel1 = {
 
 const panel2 = {
   id: '2',
-  icon: { href: '/assets/svg-symbols.svg#list' },
   title: 'Panel 2',
   isCollapsed: true,
   onClick: _.noop,

--- a/src/components/Tag/index.jsx
+++ b/src/components/Tag/index.jsx
@@ -1,4 +1,3 @@
-import { SvgSymbol } from 'adslot-ui';
 import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -6,19 +5,19 @@ import './styles.scss';
 
 const defaultComponentClass = 'tag-component';
 
-export const ActionButton = ({ onAction, id, actionIconSvgHref }) => (
+export const ActionButton = ({ onAction, id, actionIcon }) => (
   <span className="action-button" onClick={() => onAction(id)}>
-    {actionIconSvgHref ? <SvgSymbol href={actionIconSvgHref} /> : <span className="action-icon">&#x2715;</span>}
+    {actionIcon || <span className="action-icon">&#x2715;</span>}
   </span>
 );
 
 ActionButton.propTypes = {
   id: PropTypes.string.isRequired,
   onAction: PropTypes.func.isRequired,
-  actionIconSvgHref: PropTypes.string,
+  actionIcon: PropTypes.node,
 };
 
-const Tag = ({ children, inverse, id, onAction, accent, baseClass, actionIconSvgHref, dts: customDts }) => {
+const Tag = ({ children, inverse, id, onAction, accent, baseClass, actionIcon, dts: customDts }) => {
   const classes = classnames([
     defaultComponentClass,
     {
@@ -33,7 +32,7 @@ const Tag = ({ children, inverse, id, onAction, accent, baseClass, actionIconSvg
   return (
     <span className={classes} data-test-selector={dts}>
       {children}
-      {onAction ? <ActionButton {...{ onAction, id, actionIconSvgHref }} /> : null}
+      {onAction ? <ActionButton {...{ onAction, id, actionIcon }} /> : null}
     </span>
   );
 };
@@ -47,7 +46,7 @@ Tag.propTypes = {
   baseClass: PropTypes.string,
   inverse: PropTypes.bool,
   onAction: PropTypes.func,
-  actionIconSvgHref: PropTypes.string,
+  actionIcon: PropTypes.node,
   dts: PropTypes.string,
 };
 

--- a/src/components/Tag/index.spec.jsx
+++ b/src/components/Tag/index.spec.jsx
@@ -52,7 +52,8 @@ describe('Tag', () => {
 
   it('should render action buttons', () => {
     const onAction = sinon.spy();
-    const component = shallow(<ActionButton onAction={onAction} actionIconSvgHref="foo" id="Bar" />);
+    const actionIcon = <SvgSymbol href="foo" />;
+    const component = shallow(<ActionButton onAction={onAction} actionIcon={actionIcon} id="Bar" />);
 
     expect(component.prop('className')).to.equal('action-button');
     component.simulate('click');

--- a/src/components/TreePicker/Grid/index.jsx
+++ b/src/components/TreePicker/Grid/index.jsx
@@ -5,7 +5,6 @@ import TreePickerNode from '../Node';
 import Empty from '../../Empty';
 import Grid from '../../Grid';
 import GridRow from '../../Grid/Row';
-import SvgSymbol from '../../SvgSymbol';
 import Spinner from '../../Spinner';
 import TreePickerPropTypes from '../../../prop-types/TreePickerPropTypes';
 import './styles.scss';
@@ -73,7 +72,7 @@ TreePickerGridComponent.displayName = 'TreePickerGridComponent';
 
 TreePickerGridComponent.propTypes = {
   disabled: PropTypes.bool,
-  emptySvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+  emptySvgSymbol: PropTypes.node,
   emptyText: PropTypes.node.isRequired,
   expandNode: PropTypes.func,
   groupFormatter: PropTypes.func,

--- a/src/components/TreePicker/Grid/index.spec.jsx
+++ b/src/components/TreePicker/Grid/index.spec.jsx
@@ -7,7 +7,8 @@ import TreePickerNode from '../Node';
 import TreePickerMocks from '../mocks';
 
 describe('TreePickerGridComponent', () => {
-  const { itemType, qldNode, saNode, svgSymbol, nodeRenderer, valueFormatter } = TreePickerMocks;
+  const { itemType, qldNode, saNode, nodeRenderer, valueFormatter } = TreePickerMocks;
+  const svgSymbol = <div />;
 
   it('should render with props', () => {
     const props = {

--- a/src/components/TreePicker/Nav/index.jsx
+++ b/src/components/TreePicker/Nav/index.jsx
@@ -3,7 +3,6 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import Search from '../../Search';
 import Breadcrumb from '../../Breadcrumb';
-import SvgSymbol from '../../SvgSymbol';
 import TreePickerPropTypes from '../../../prop-types/TreePickerPropTypes';
 import './styles.scss';
 
@@ -25,10 +24,8 @@ const TreePickerNavComponent = ({
   svgSymbolSearch,
 }) => {
   const icons = {};
-  if (svgSymbolSearch)
-    icons.search = <SvgSymbol href={svgSymbolSearch.href} classSuffixes={svgSymbolSearch.classSuffixes} />;
-  if (svgSymbolCancel)
-    icons.close = <SvgSymbol href={svgSymbolCancel.href} classSuffixes={svgSymbolCancel.classSuffixes} />;
+  if (svgSymbolSearch) icons.search = svgSymbolSearch;
+  if (svgSymbolCancel) icons.close = svgSymbolCancel;
 
   const breadcrumbProps = {
     disabled,
@@ -73,8 +70,8 @@ TreePickerNavComponent.propTypes = {
   searchPlaceholder: PropTypes.string,
   searchValue: PropTypes.string,
   showSearch: PropTypes.bool,
-  svgSymbolCancel: PropTypes.shape(SvgSymbol.propTypes),
-  svgSymbolSearch: PropTypes.shape(SvgSymbol.propTypes),
+  svgSymbolCancel: PropTypes.node,
+  svgSymbolSearch: PropTypes.node,
 };
 
 TreePickerNavComponent.defaultProps = {

--- a/src/components/TreePicker/Nav/index.spec.jsx
+++ b/src/components/TreePicker/Nav/index.spec.jsx
@@ -37,6 +37,7 @@ describe('TreePickerNavComponent', () => {
     const searchElement = component.find(Search);
     expect(searchElement).to.have.length(1);
     expect(searchElement.prop('onSearch')).to.be.a('function');
+
     expect(_.isEmpty(searchElement.prop('icons'))).to.equal(true);
 
     const breadcrumbElement = component.find(Breadcrumb);
@@ -60,14 +61,8 @@ describe('TreePickerNavComponent', () => {
   });
 
   it('should render icons with given svgSymbol and pass them to Search', () => {
-    const svgSymbolCancel = {
-      href: '/assets/svg-symbols.svg#cancel',
-    };
-    const svgSymbolSearch = {
-      href: '/assets/svg-symbols.svg#search',
-    };
     const component = shallow(
-      <TreePickerNavComponent {...mockProps()} svgSymbolSearch={svgSymbolSearch} svgSymbolCancel={svgSymbolCancel} />
+      <TreePickerNavComponent {...mockProps()} svgSymbolSearch={<div />} svgSymbolCancel={<div />} />
     );
     const searchElement = component.find(Search);
     expect(searchElement.prop('icons')).to.have.keys(['search', 'close']);

--- a/src/components/TreePicker/index.jsx
+++ b/src/components/TreePicker/index.jsx
@@ -5,7 +5,6 @@ import SplitPane from '../SplitPane';
 import TreePickerGrid from './Grid';
 import TreePickerNav from './Nav';
 import FlexibleSpacer from '../FlexibleSpacer';
-import SvgSymbol from '../SvgSymbol';
 import TreePickerPropTypes from '../../prop-types/TreePickerPropTypes';
 import './styles.scss';
 
@@ -160,11 +159,11 @@ TreePickerSimplePureComponent.propTypes = {
   /**
    * 	Displays this svg symbol when there will be no item on both left or right Grid
    */
-  emptySvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+  emptySvgSymbol: PropTypes.node,
   /**
    * 	Displays this svg symbol when there will be no item on right Grid(Selected list)
    */
-  emptySelectedListSvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+  emptySelectedListSvgSymbol: PropTypes.node,
   /**
    * 	Displays this text when there will be no item on left Grid. Prefer type 'string', but rich text can be used here
    */
@@ -196,7 +195,7 @@ TreePickerSimplePureComponent.propTypes = {
   /**
    * 	Same as emptySymbol
    */
-  initialStateSymbol: PropTypes.shape(SvgSymbol.propTypes),
+  initialStateSymbol: PropTypes.node,
   /**
    * 	Uses for specific className
    */
@@ -234,8 +233,8 @@ TreePickerSimplePureComponent.propTypes = {
    *  A list of available unselected nodes. This prop is not required, but an empty array is not allowed. At least one element is required in the array.
    */
   subtree: PropTypes.arrayOf(TreePickerPropTypes.node.isRequired),
-  svgSymbolCancel: PropTypes.shape(SvgSymbol.propTypes),
-  svgSymbolSearch: PropTypes.shape(SvgSymbol.propTypes),
+  svgSymbolCancel: PropTypes.node,
+  svgSymbolSearch: PropTypes.node,
   /**
    * 	e.g: Default Group
    */

--- a/src/components/TreePicker/index.spec.jsx
+++ b/src/components/TreePicker/index.spec.jsx
@@ -11,14 +11,15 @@ const checkElement = expectedProps => (element, propsList) =>
   _.forEach(propsList, propName => expect(element.prop(propName)).to.equal(expectedProps[propName]));
 
 describe('TreePickerSimplePureComponent', () => {
-  const { actNode, initialSelection, itemType, ntNode, qldNode, saNode, svgSymbol } = TreePickerMocks;
+  const { actNode, initialSelection, itemType, ntNode, qldNode, saNode } = TreePickerMocks;
+  const svgSymbol = <div />;
 
   const props = {
     breadcrumbNodes: [saNode],
     breadcrumbOnClick: _.noop,
     emptySvgSymbol: svgSymbol,
     initialStateNode: 'Begin searching.',
-    initialStateSymbol: TreePickerMocks.svgSymbol,
+    initialStateSymbol: svgSymbol,
     expandNode: _.noop,
     includeNode: _.noop,
     itemType,
@@ -114,7 +115,7 @@ describe('TreePickerSimplePureComponent', () => {
       searchValue: 'Victoria',
       initialSelection: [],
       emptySelectedListText: 'Nothing to show',
-      emptySelectedListSvgSymbol: TreePickerMocks.svgSymbol,
+      emptySelectedListSvgSymbol: svgSymbol,
     });
 
     const component = shallow(<TreePickerSimplePure {...emptyStateProps} />);

--- a/src/components/TreePicker/mocks.js
+++ b/src/components/TreePicker/mocks.js
@@ -5,27 +5,6 @@ const baseItem = {
   value: 10000,
 };
 
-const svgSymbol = { href: '/assets/svg-symbols#search' };
-
-const rootTypes = [
-  {
-    label: 'Geography',
-    id: 'a',
-    svgSymbol,
-    emptySvgSymbol: { href: '/some.svg#id' },
-    isRequired: true,
-  },
-  { label: 'Audiences', id: 'b', svgSymbol, isRequired: false },
-  { label: 'Segments', id: 'c', svgSymbol, isRequired: true },
-  {
-    label: 'Hidden Segments',
-    id: 'd',
-    svgSymbol,
-    isRequired: false,
-    hidden: true,
-  },
-];
-
 const auPath = { id: 'au', label: 'AU', path: [] };
 const actPath = { id: 'au-act', label: 'ACT', path: [auPath] };
 
@@ -105,7 +84,6 @@ const itemType = 'example item type';
 const TreePickerMocks = immutable({
   actNode,
   ntNode,
-  rootTypes,
   baseItem,
   cbrNode,
   cbrNodeAlreadySelected,
@@ -115,7 +93,6 @@ const TreePickerMocks = immutable({
   nodeRenderer,
   qldNode,
   saNode,
-  svgSymbol,
   valueFormatter,
 });
 

--- a/src/components/UserListPicker/index.jsx
+++ b/src/components/UserListPicker/index.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ListPicker from '../ListPicker';
 import Avatar from '../Avatar';
-import SvgSymbol from '../SvgSymbol';
 import './styles.scss';
 
 const UserListPickerComponent = ({
@@ -66,10 +65,7 @@ UserListPickerComponent.propTypes = {
   avatarColor: PropTypes.func,
   emptyIcon: PropTypes.string,
   emptyMessage: PropTypes.string,
-  /**
-   * 	Shape of <a href="/svg-symbol">SVG Symbol</a> prop types.
-   */
-  emptySvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+  emptySvgSymbol: PropTypes.node,
   /**
    *  Array of { avatar: PropTypes.string, givenName: PropTypes.string, surname: PropTypes.string, id: PropTypes.number }
    */

--- a/src/components/UserListPicker/index.spec.jsx
+++ b/src/components/UserListPicker/index.spec.jsx
@@ -22,9 +22,10 @@ describe('UserListPickerComponent', () => {
   });
 
   it('should render with props', () => {
+    const svgSymbol = <div />;
     const props = {
       allowEmptySelection: true,
-      emptySvgSymbol: { href: '/some.svg#id' },
+      emptySvgSymbol: svgSymbol,
       initialSelection: getInitialSelection(),
       userHeaders,
       users,
@@ -34,9 +35,7 @@ describe('UserListPickerComponent', () => {
     const component = shallow(<UserListPicker {...props} />);
     expect(component.type()).to.equal(ListPicker);
 
-    expect(component.prop('emptySvgSymbol')).to.deep.equal({
-      href: '/some.svg#id',
-    });
+    expect(component.prop('emptySvgSymbol')).to.equal(svgSymbol);
     expect(component.prop('initialSelection')).to.deep.equal(getInitialSelection());
     expect(component.prop('itemHeaders')).to.deep.equal(userHeaders);
     expect(component.prop('itemType')).to.equal('user');

--- a/src/prop-types/TreePickerPropTypes.js
+++ b/src/prop-types/TreePickerPropTypes.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import SvgSymbol from '../components/SvgSymbol';
 import idPropType from './idPropType';
 
 const baseNodeProps = {
@@ -23,8 +22,8 @@ export default {
   breadCrumbNode: PropTypes.shape(baseNodeProps),
   rootType: PropTypes.shape(
     mergeNodeProps({
-      emptySvgSymbol: PropTypes.shape(SvgSymbol.propTypes),
-      svgSymbol: PropTypes.shape(SvgSymbol.propTypes),
+      emptySvgSymbol: PropTypes.node,
+      svgSymbol: PropTypes.node,
       hidden: PropTypes.bool,
       isRequired: PropTypes.bool.isRequired,
     })

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -1206,19 +1206,6 @@
           "required": false,
           "description": ""
         },
-        "svgSymbol": {
-          "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
-          },
-          "required": false,
-          "description": "",
-          "defaultValue": {
-            "value": "{\n  classSuffixes: ['gray-darker', '70', 'circle'],\n}",
-            "computed": false
-          }
-        },
         "text": {
           "type": {
             "name": "node"
@@ -1230,16 +1217,12 @@
             "computed": false
           }
         },
-        "hideIcon": {
+        "icon": {
           "type": {
-            "name": "bool"
+            "name": "node"
           },
           "required": false,
-          "description": "",
-          "defaultValue": {
-            "value": "false",
-            "computed": false
-          }
+          "description": ""
         }
       }
     }
@@ -1801,7 +1784,7 @@
         },
         "icon": {
           "type": {
-            "name": "string"
+            "name": "node"
           },
           "required": false,
           "description": ""
@@ -1918,9 +1901,7 @@
         },
         "emptySvgSymbol": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": ""
@@ -2208,9 +2189,7 @@
         },
         "emptySvgSymbol": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": ""
@@ -2444,9 +2423,7 @@
         },
         "emptySvgSymbol": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": ""
@@ -2516,12 +2493,10 @@
         },
         "icon": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
-          "description": "shapeOf <a href=\"/svg-symbol\">SVG Symbol</a> prop types."
+          "description": ""
         },
         "title": {
           "type": {
@@ -3916,9 +3891,9 @@
           "required": true,
           "description": ""
         },
-        "actionIconSvgHref": {
+        "actionIcon": {
           "type": {
-            "name": "string"
+            "name": "node"
           },
           "required": false,
           "description": ""
@@ -3980,9 +3955,9 @@
           "required": false,
           "description": ""
         },
-        "actionIconSvgHref": {
+        "actionIcon": {
           "type": {
-            "name": "string"
+            "name": "node"
           },
           "required": false,
           "description": ""
@@ -4237,9 +4212,7 @@
         },
         "emptySvgSymbol": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": ""
@@ -4489,18 +4462,14 @@
         },
         "svgSymbolCancel": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": ""
         },
         "svgSymbolSearch": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": ""
@@ -4727,18 +4696,14 @@
         },
         "emptySvgSymbol": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": "Displays this svg symbol when there will be no item on both left or right Grid"
         },
         "emptySelectedListSvgSymbol": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": "Displays this svg symbol when there will be no item on right Grid(Selected list)"
@@ -4794,9 +4759,7 @@
         },
         "initialStateSymbol": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": "Same as emptySymbol"
@@ -4920,18 +4883,14 @@
         },
         "svgSymbolCancel": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": ""
         },
         "svgSymbolSearch": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
           "description": ""
@@ -5016,12 +4975,10 @@
         },
         "emptySvgSymbol": {
           "type": {
-            "name": "shape",
-            "value": "SvgSymbol.propTypes",
-            "computed": true
+            "name": "node"
           },
           "required": false,
-          "description": "Shape of <a href=\"/svg-symbol\">SVG Symbol</a> prop types."
+          "description": ""
         },
         "initialSelection": {
           "type": {

--- a/www/examples/Empty.mdx
+++ b/www/examples/Empty.mdx
@@ -11,9 +11,13 @@ class EmptyExample extends React.PureComponent {
         <Empty
           collection={[]}
           text="No items selected"
-          svgSymbol={{
-            href: './assets/svg-symbols.svg#checklist-incomplete',
-          }}
+          icon={
+            <SvgSymbol
+              classSuffixes={['gray-darker', '70']}
+              href="./assets/svg-symbols.svg#checklist-incomplete"
+              isCircle
+            />
+          }
         />
       </div>
     );

--- a/www/examples/InformationBox.mdx
+++ b/www/examples/InformationBox.mdx
@@ -4,7 +4,10 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 ## Information Box
 
 ```jsx live=true
-<InformationBox title="This is an information" icon="./assets/svg-symbols.svg#cancel">
+<InformationBox
+  title="This is an information"
+  icon={<SvgSymbol classSuffixes={['70']} href="./assets/svg-symbols.svg#cancel" />}
+>
   Content body.
 </InformationBox>
 ```

--- a/www/examples/Tag.mdx
+++ b/www/examples/Tag.mdx
@@ -9,19 +9,19 @@ const initialState = [
     text: 'Display',
     accent: 'positive',
     id: '0ac7d4ce-af36-4fd9-b142-6377f8ad5f17',
-    actionIconSvghref: './assets/svg-symbols.svg#cancel',
+    actionIconSvgHref: './assets/svg-symbols.svg#cancel',
   },
   {
     text: 'Mobile',
     accent: 'pending',
     id: '5a884b04-223b-49d9-91d4-7abf10ea608f',
-    actionIconSvghref: './assets/svg-symbols.svg#cancel',
+    actionIconSvgHref: './assets/svg-symbols.svg#cancel',
   },
   {
     text: 'Run of Network',
     accent: 'negative',
     id: '87ecaf18-bf7f-472e-86e6-c91dd2700b78',
-    actionIconSvghref: './assets/svg-symbols.svg#cancel',
+    actionIconSvgHref: './assets/svg-symbols.svg#cancel',
   },
 ];
 
@@ -54,7 +54,7 @@ const Example = () => {
           baseClass={tag.baseClass}
           onAction={deleteTag}
           inverse
-          actionIconSvgHref={tag.actionIconSvgHref}
+          actionIcon={<SvgSymbol href={tag.actionIconSvgHref} />}
         >
           {tag.text}
         </Tag>

--- a/www/examples/UserListPicker.mdx
+++ b/www/examples/UserListPicker.mdx
@@ -5,9 +5,7 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 
 ```jsx live=true
 const avatarColor = () => 'cyan';
-const emptySvgSymbol = {
-  href: './assets/svg-symbols.svg#checklist-incomplete',
-};
+const emptySvgSymbol = <SvgSymbol href="./assets/svg-symbols.svg#checklist-incomplete" />;
 const teamMember1 = {
   avatar: '//lorempixel.com/35/35/people/7',
   givenName: 'John',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
This is part of the process to deprecate SvgSymbol in the future. For those components that are using svg symbol href for icons are all changed to use react node for icons which allow users to pass in their own icons.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
