### PR TITLE
fix: emptyIcon prop is not used in ListPicker

### DIFF
--- a/src/components/ListPicker/index.jsx
+++ b/src/components/ListPicker/index.jsx
@@ -79,7 +79,6 @@ class ListPickerComponent extends React.PureComponent {
     const { selectedItems, disableApplyButton } = this.state;
     const {
       allowMultiSelection,
-      emptyIcon,
       emptyMessage,
       emptySvgSymbol,
       labelFormatter,
@@ -99,7 +98,6 @@ class ListPickerComponent extends React.PureComponent {
     const listPickerPureElement = (
       <ListPickerPure
         allowMultiSelection={allowMultiSelection}
-        emptyIcon={emptyIcon}
         emptyMessage={emptyMessage}
         emptySvgSymbol={emptySvgSymbol}
         deselectItem={this.deselectItem}
@@ -198,7 +196,6 @@ const linkButtonsProps = PropTypes.arrayOf(
 ListPickerComponent.propTypes = {
   allowEmptySelection: PropTypes.bool,
   allowMultiSelection: PropTypes.bool,
-  emptyIcon: PropTypes.string,
   emptyMessage: PropTypes.string,
   emptySvgSymbol: PropTypes.node,
   initialSelection: PropTypes.arrayOf(itemProps),

--- a/src/components/ListPicker/index.spec.jsx
+++ b/src/components/ListPicker/index.spec.jsx
@@ -111,8 +111,9 @@ describe('ListPickerComponent', () => {
       properties: [{ label: 'Name', value: 'Jill Smith' }, { label: 'Age', value: '21' }],
     };
     const initialSelection = getInitialSelection();
+    const emptySvgSymbol = <div />;
     const props = {
-      emptyIcon: '/some.png',
+      emptySvgSymbol,
       emptyMessage: 'No users.',
       initialSelection,
       items: users,
@@ -184,7 +185,7 @@ describe('ListPickerComponent', () => {
     expect(listPickerPureElement.prop('selectedItems')).to.not.equal(initialSelection);
     expect(listPickerPureElement.prop('selectedItems')).to.deep.equal(initialSelection);
     expect(listPickerPureElement.prop('deselectItem')).to.be.a('function');
-    expect(listPickerPureElement.prop('emptyIcon')).to.equal('/some.png');
+    expect(listPickerPureElement.prop('emptySvgSymbol')).to.equal(emptySvgSymbol);
     expect(listPickerPureElement.prop('emptyMessage')).to.equal('No users.');
     expect(listPickerPureElement.prop('labelFormatter')).to.be.a('function');
     expect(listPickerPureElement.prop('itemHeaders')).to.deep.equal(userHeaders);

--- a/src/components/ListPickerPure/index.jsx
+++ b/src/components/ListPickerPure/index.jsx
@@ -59,7 +59,6 @@ class ListPickerPureComponent extends React.PureComponent {
   render() {
     const {
       allowMultiSelection,
-      emptyIcon,
       emptyMessage,
       emptySvgSymbol,
       items,
@@ -101,7 +100,7 @@ class ListPickerPureComponent extends React.PureComponent {
                 ) : null}
               </GridRow>
             ))}
-            <Empty collection={items} icon={emptyIcon} svgSymbol={emptySvgSymbol} text={emptyMessage} />
+            <Empty collection={items} icon={emptySvgSymbol} text={emptyMessage} />
           </Grid>
         </div>
       </div>
@@ -118,7 +117,6 @@ const itemProps = PropTypes.shape({
 ListPickerPureComponent.propTypes = {
   allowMultiSelection: PropTypes.bool,
   deselectItem: PropTypes.func,
-  emptyIcon: PropTypes.string,
   emptyMessage: PropTypes.string,
   emptySvgSymbol: PropTypes.node,
   labelFormatter: PropTypes.func,

--- a/src/components/PagedGrid/index.jsx
+++ b/src/components/PagedGrid/index.jsx
@@ -19,7 +19,7 @@ class PagedGridComponent extends React.PureComponent {
 
   render() {
     const { activePage } = this.state;
-    const { columns, emptyIcon, emptyMessage, emptySvgSymbol, items, perPage, verticalCellBorder } = this.props;
+    const { columns, emptyMessage, emptySvgSymbol, items, perPage, verticalCellBorder } = this.props;
     const pageItems = _(items)
       .clone()
       .splice((this.state.activePage - 1) * perPage, perPage);
@@ -48,7 +48,7 @@ class PagedGridComponent extends React.PureComponent {
               ))}
             </GridRow>
           ))}
-          <Empty collection={items} icon={emptyIcon} svgSymbol={emptySvgSymbol} text={emptyMessage} />
+          <Empty collection={items} icon={emptySvgSymbol} text={emptyMessage} />
         </Grid>
         {totalPages > 1 ? (
           <div className="pagedgrid-component-pagination">
@@ -81,7 +81,6 @@ const columnProps = PropTypes.shape({
 
 PagedGridComponent.propTypes = {
   columns: PropTypes.arrayOf(columnProps).isRequired,
-  emptyIcon: PropTypes.string,
   emptyMessage: PropTypes.string,
   emptySvgSymbol: PropTypes.node,
   items: PropTypes.arrayOf(itemProps).isRequired,

--- a/src/components/TreePicker/Grid/index.jsx
+++ b/src/components/TreePicker/Grid/index.jsx
@@ -62,7 +62,7 @@ const TreePickerGridComponent = ({
         ))
       )}
       {nodes && !isLoading ? (
-        <Empty collection={nodes} hideIcon={hideIcon} svgSymbol={emptySvgSymbol} text={emptyText} />
+        <Empty collection={nodes} hideIcon={hideIcon} icon={emptySvgSymbol} text={emptyText} />
       ) : null}
     </Grid>
   );

--- a/src/components/TreePicker/Grid/index.spec.jsx
+++ b/src/components/TreePicker/Grid/index.spec.jsx
@@ -44,7 +44,7 @@ describe('TreePickerGridComponent', () => {
     const emptyElement = gridElement.find(Empty);
     expect(emptyElement).to.have.length(1);
     expect(emptyElement.prop('collection')).to.equal(props.nodes);
-    expect(emptyElement.prop('svgSymbol')).to.equal(props.emptySvgSymbol);
+    expect(emptyElement.prop('icon')).to.equal(props.emptySvgSymbol);
     expect(emptyElement.prop('text')).to.equal(props.emptyText);
   });
 
@@ -96,7 +96,7 @@ describe('TreePickerGridComponent', () => {
       const emptyElement = gridElement.find(Empty);
       expect(emptyElement).to.have.length(1);
       expect(emptyElement.prop('collection')).to.equal(props.nodes);
-      expect(emptyElement.prop('svgSymbol')).to.equal(props.emptySvgSymbol);
+      expect(emptyElement.prop('icon')).to.equal(props.emptySvgSymbol);
       expect(emptyElement.prop('text')).to.equal(props.emptyText);
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is related to #998, found that `emptyIcon` is duplicated with `emptySvgSymbol` and couldn't found any use case for this prop. So I think it's safe to deprecate it.

<!--- A few sentences describing the overall goals of the pull request's commit. -->


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
