### PR TITLE
feat: button and status pill component

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -10,16 +10,21 @@ import { expandDts } from '../../lib/utils';
 import './styles.scss';
 
 const adslotButtonPropTypes = {
+  /**
+   * PropTypes.oneOf(['small', 'large'])
+   */
+  size: PropTypes.oneOf(['small', 'large']),
   inverse: PropTypes.bool,
   dts: PropTypes.string,
   isLoading: PropTypes.bool,
 };
 
 const Button = props => {
-  const { inverse, children, dts, className, isLoading, disabled } = props;
+  const { inverse, size, children, dts, className, isLoading, disabled } = props;
   const baseClass = 'aui--button';
   const classes = classNames(baseClass, className, {
     'btn-inverse': inverse && !/btn-inverse/.test(className),
+    'btn-large': size === 'large',
   });
 
   const renderSpinner = () =>
@@ -47,6 +52,7 @@ Button.propTypes = { ...adslotButtonPropTypes, ...BootstrapButton.propTypes };
 Button.defaultProps = {
   inverse: false,
   isLoading: false,
+  size: 'small',
 };
 
 export default Button;

--- a/src/components/Button/index.spec.jsx
+++ b/src/components/Button/index.spec.jsx
@@ -49,6 +49,11 @@ describe('ButtonComponent', () => {
     expect(wrapper.prop('className')).to.equal('aui--button btn-inverse');
   });
 
+  it('should render large button with btn-large class', () => {
+    const wrapper = shallow(<Button size="large">Test</Button>);
+    expect(wrapper.prop('className')).to.equal('aui--button btn-large');
+  });
+
   it('should support data-test-selectors', () => {
     const wrapper = shallow(<Button dts="test-button">Test</Button>);
     expect(wrapper.prop('data-test-selector')).to.equal('test-button');

--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -7,6 +7,11 @@
     visibility: hidden; // preserves width and height of button
   }
 
+  &.btn-large {
+    width: 264px;
+    height: 42px;
+  }
+
   .spinner-container {
     position: absolute;
     right: 0;

--- a/src/components/StatusPill/index.jsx
+++ b/src/components/StatusPill/index.jsx
@@ -28,7 +28,7 @@ StatusPill.propTypes = {
   /**
    * 	Text inside status pill
    */
-  status: PropTypes.string.isRequired,
+  status: PropTypes.node.isRequired,
   /**
    * one of ["primary", "success", "warning", "error", "light"]
    */

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -563,6 +563,27 @@
       "displayName": "Button",
       "methods": [],
       "props": {
+        "size": {
+          "type": {
+            "name": "enum",
+            "value": [
+              {
+                "value": "'small'",
+                "computed": false
+              },
+              {
+                "value": "'large'",
+                "computed": false
+              }
+            ]
+          },
+          "required": false,
+          "description": "PropTypes.oneOf(['small', 'large'])",
+          "defaultValue": {
+            "value": "'small'",
+            "computed": false
+          }
+        },
         "inverse": {
           "type": {
             "name": "bool"
@@ -3648,7 +3669,7 @@
       "props": {
         "status": {
           "type": {
-            "name": "string"
+            "name": "node"
           },
           "required": true,
           "description": "Text inside status pill"

--- a/www/examples/Button.mdx
+++ b/www/examples/Button.mdx
@@ -14,6 +14,9 @@ import DesignNotes from '../containers/DesignNotes.jsx';
   <Button bsStyle="warning" isLoading>
     Loading
   </Button>
+  <br />
+  <h3>Large Button</h3>
+  <Button size="large">Add to My Todo List</Button>
 </div>
 ```
 
@@ -35,5 +38,8 @@ import DesignNotes from '../containers/DesignNotes.jsx';
   action. Use the same colour for the border and text eg. <span className="text-blue text-bold">Blue</span>,{' '}
   <span className="text-green text-bold">Green</span>, <span className="text-red text-bold">Red</span> eg. Cancel
   Campaign, Save, Reject etc.
+  <br />
+  <br />
+  <span className="text-bold">Large button</span> is designed to have a fixed 264px x 42px size.
 </DesignNotes>
 <Props componentName="Button" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
1. Button: Add 'size' prop to button to render large button
1. StatusPill: Change 'status' prop type to node

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->
Resolves #1005 amd #1006 

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
<img width="345" alt="Screen Shot 2020-04-14 at 3 19 49 pm" src="https://user-images.githubusercontent.com/8103605/79188808-6b94d700-7e63-11ea-85bc-0c5ca0427304.png">
