### PR TITLE
refactor: change action panel title type to node

### DIFF
--- a/src/components/ActionPanel/index.jsx
+++ b/src/components/ActionPanel/index.jsx
@@ -25,7 +25,7 @@ const ActionPanel = React.forwardRef((props, ref) => {
       <div className={classNames('aui--action-panel-wrapper', { 'aui--action-panel-modal-wrapper': isModal })}>
         <div className={classNames('aui--action-panel', className, `is-${size}`, { 'action-modal': isModal })}>
           <div className={classNames('aui--action-panel-header', { 'has-actions': actionButton })}>
-            <span className="title">{title}</span>
+            <div className="title">{title}</div>
             <span className="actions">
               <Button
                 onClick={onClose}
@@ -49,7 +49,7 @@ const ActionPanel = React.forwardRef((props, ref) => {
 ActionPanel.displayName = 'ActionPanel';
 
 ActionPanel.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   className: PropTypes.string,
   // large is intended to be used in a modal
   size: PropTypes.oneOf(['small', 'medium', 'large']),

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -108,7 +108,7 @@
       "props": {
         "title": {
           "type": {
-            "name": "string"
+            "name": "node"
           },
           "required": true,
           "description": ""
@@ -1906,13 +1906,6 @@
             "computed": false
           }
         },
-        "emptyIcon": {
-          "type": {
-            "name": "string"
-          },
-          "required": false,
-          "description": ""
-        },
         "emptyMessage": {
           "type": {
             "name": "string"
@@ -2190,13 +2183,6 @@
             "computed": false
           }
         },
-        "emptyIcon": {
-          "type": {
-            "name": "string"
-          },
-          "required": false,
-          "description": ""
-        },
         "emptyMessage": {
           "type": {
             "name": "string"
@@ -2392,13 +2378,6 @@
             }
           },
           "required": true,
-          "description": ""
-        },
-        "emptyIcon": {
-          "type": {
-            "name": "string"
-          },
-          "required": false,
           "description": ""
         },
         "emptyMessage": {
@@ -3223,7 +3202,7 @@
           "required": false,
           "description": ""
         },
-        "initialState": {
+        "initialValue": {
           "type": {
             "name": "instanceOf",
             "value": "EditorState"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In the new design of product detail modal, we have the publisher logo image and some action buttons on title so Action Panel needs to support custom title as react node.                             

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Change `title` prop type to node. 

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
