### PR TITLE
feat: enable <TileGrid> item title to be react node

### DIFF
--- a/src/components/TileGrid/index.jsx
+++ b/src/components/TileGrid/index.jsx
@@ -50,7 +50,7 @@ const TileGrid = ({ title, items, onItemClick, distributed }) => {
 
   return (
     <div className={baseClass}>
-      <strong className={`${baseClass}-title`}>{title}</strong>
+      {title ? <strong className={`${baseClass}-title`}>{title}</strong> : null}
       <ul className={`${baseClass}-list`}>{cardList}</ul>
     </div>
   );
@@ -61,7 +61,7 @@ TileGrid.defaultProps = {
 };
 
 TileGrid.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node,
   /**
    * 	The shape of item object is defined below
    */
@@ -69,7 +69,7 @@ TileGrid.propTypes = {
     PropTypes.shape({
       id: idPropType.isRequired,
       classSuffix: PropTypes.string.isRequired,
-      title: PropTypes.string.isRequired,
+      title: PropTypes.node.isRequired,
       imgLink: PropTypes.string,
       width: PropTypes.number,
       maxWidth: PropTypes.number,

--- a/src/components/TileGrid/index.spec.jsx
+++ b/src/components/TileGrid/index.spec.jsx
@@ -7,7 +7,6 @@ import TileGrid from '.';
 
 describe('TileGrid', () => {
   const props = {
-    title: 'Lorem ipsum',
     items: [{ id: '0', classSuffix: 'alpha', title: 'Alpha' }, { id: '1', classSuffix: 'beta', title: 'Beta' }],
     onItemClick: _.noop,
   };
@@ -17,12 +16,20 @@ describe('TileGrid', () => {
     expect(component.prop('className')).to.equal('tile-grid-component');
 
     const title = component.find('.tile-grid-component-title');
-    expect(title).to.have.length(1);
-    expect(title.text()).to.equal('Lorem ipsum');
+    expect(title).to.have.length(0);
 
     const list = component.find('.tile-grid-component-list');
     expect(list).to.have.length(1);
     expect(list.children()).to.have.length(0);
+  });
+
+  it('renders title if props contain it', () => {
+    const newProps = _.assign(props, { title: 'Lorem ipsum' });
+    const component = shallow(<TileGrid {...newProps} items={[]} />);
+
+    const title = component.find('.tile-grid-component-title');
+    expect(title).to.have.length(1);
+    expect(title.text()).to.equal('Lorem ipsum');
   });
 
   it('renders with items', () => {

--- a/www/containers/Props.jsx
+++ b/www/containers/Props.jsx
@@ -51,7 +51,7 @@ const Props = ({ componentName, customMapper }) => {
                     <code>{HtmlParser(_.get(prop, 'required', ''))}</code>
                   </td>
                   <td>
-                    <code>{HtmlParser(_.get(prop, 'defaultValue.value', ''))}</code>
+                    <code>{_.get(prop, 'defaultValue.value', '')}</code>
                   </td>
                   <td>{HtmlParser(prop.description)}</td>
                 </tr>

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -4254,9 +4254,9 @@
       "props": {
         "title": {
           "type": {
-            "name": "string"
+            "name": "node"
           },
-          "required": true,
+          "required": false,
           "description": ""
         },
         "items": {
@@ -4275,7 +4275,7 @@
                   "required": true
                 },
                 "title": {
-                  "name": "string",
+                  "name": "node",
                   "required": true
                 },
                 "imgLink": {

--- a/www/examples/Switch.mdx
+++ b/www/examples/Switch.mdx
@@ -42,7 +42,7 @@ const Example = () => {
       <div>
         <div style={{ paddingTop: 20 }}>Disabled Checked Switch</div>
         <div style={{ paddingTop: 10 }}>
-          <Switch checked disabled />
+          <Switch checked disabled onChange={_.noop} />
         </div>
       </div>
     </>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

- Enable the key title of the prop `items` to be `React.Node` to receive svg icon as part of it.

- The prop `title` of the `<TileGrid />` component should not be required, as sometimes there is no title for it.

- btw, fixing up warnings and errors of homepage shown in the browser console  

Resolves #1010 
## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [X] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
