### PR TITLE
feat: add theme to InformationBox

### DIFF
--- a/src/components/Avatar/index.jsx
+++ b/src/components/Avatar/index.jsx
@@ -18,7 +18,10 @@ const Avatar = ({ color, givenName, tooltip, image, surname }) => (
 Avatar.displayName = 'AvatarComponent';
 
 Avatar.propTypes = {
-  color: PropTypes.string,
+  /**
+   * PropTypes.oneOf(['blue', 'green', 'red', 'orange', 'cyan'])
+   */
+  color: PropTypes.oneOf(['blue', 'green', 'red', 'orange', 'cyan']),
   givenName: PropTypes.string,
   tooltip: PropTypes.string,
   image: PropTypes.string,

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -17,10 +17,14 @@ const adslotButtonPropTypes = {
   inverse: PropTypes.bool,
   dts: PropTypes.string,
   isLoading: PropTypes.bool,
+  /**
+   * PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link'])
+   */
+  bsStyle: PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link']),
 };
 
 const Button = props => {
-  const { inverse, size, children, dts, className, isLoading, disabled } = props;
+  const { bsStyle, inverse, size, children, dts, className, isLoading, disabled } = props;
   const baseClass = 'aui--button';
   const classes = classNames(baseClass, className, {
     'btn-inverse': inverse && !/btn-inverse/.test(className),
@@ -36,6 +40,7 @@ const Button = props => {
 
   return (
     <BootstrapButton
+      bsStyle={bsStyle}
       {..._.omit(props, _.keys(adslotButtonPropTypes))}
       disabled={isLoading || disabled}
       className={classes}

--- a/src/components/ButtonGroup/index.jsx
+++ b/src/components/ButtonGroup/index.jsx
@@ -9,7 +9,10 @@ class ButtonGroup extends React.PureComponent {
   static propTypes = {
     dts: PropTypes.string,
     children: PropTypes.node,
-    bsStyle: PropTypes.string,
+    /**
+     * PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link'])
+     */
+    bsStyle: PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link']),
     inverse: PropTypes.bool,
     disabled: PropTypes.bool,
     bsSize: PropTypes.string,

--- a/src/components/InformationBox/index.jsx
+++ b/src/components/InformationBox/index.jsx
@@ -3,12 +3,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import './styles.scss';
 
-const InformationBox = ({ children, icon, title, className, dts }) => (
-  <div className={classnames('information-box', className)} data-test-selector={dts}>
-    {icon ? <div className="information-box-icon"> {icon}</div> : null}
-    <div className="information-box-text">
-      {title ? <label className="information-box-title">{title}</label> : null}
-      <div className="information-box-node">{children}</div>
+const styles = ['primary', 'success', 'warning', 'error', 'light'];
+
+const InformationBox = ({ children, icon, title, className, theme, dts }) => (
+  <div
+    className={classnames('aui--information-box', `aui--information-box-${theme}`, className)}
+    data-test-selector={dts}
+  >
+    {icon ? <div className="aui--information-box-icon"> {icon}</div> : null}
+    <div className="aui--information-box-text">
+      {title ? <label className="aui--information-box-title">{title}</label> : null}
+      <div className="aui--information-box-node">{children}</div>
     </div>
   </div>
 );
@@ -16,9 +21,14 @@ const InformationBox = ({ children, icon, title, className, dts }) => (
 InformationBox.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  theme: PropTypes.oneOf(styles),
   title: PropTypes.node,
   icon: PropTypes.node,
   dts: PropTypes.string,
+};
+
+InformationBox.defaultProps = {
+  theme: 'light',
 };
 
 export default InformationBox;

--- a/src/components/InformationBox/index.spec.jsx
+++ b/src/components/InformationBox/index.spec.jsx
@@ -13,12 +13,14 @@ describe('InformationBoxComponent', () => {
       </InformationBox>
     );
 
-    expect(component.find('.information-box').prop('className')).to.equal('information-box');
-    const titleElement = component.find('.information-box-title');
+    expect(component.find('.aui--information-box').prop('className')).to.equal(
+      'aui--information-box aui--information-box-light'
+    );
+    const titleElement = component.find('.aui--information-box-title');
     expect(titleElement).to.have.length(1);
     expect(titleElement.text()).to.equal('render title here');
-    expect(component.find('.information-box-node')).to.have.length(1);
-    expect(component.find('.information-box-icon')).to.have.length(1);
+    expect(component.find('.aui--information-box-node')).to.have.length(1);
+    expect(component.find('.aui--information-box-icon')).to.have.length(1);
   });
 
   it('should render without a title when title props is not provided', () => {
@@ -28,10 +30,10 @@ describe('InformationBoxComponent', () => {
       </InformationBox>
     );
 
-    const titleElement = component.find('.information-box-title');
+    const titleElement = component.find('.aui--information-box-title');
     expect(titleElement).to.have.length(0);
-    expect(component.find('.information-box-node')).to.have.length(1);
-    expect(component.find('.information-box-icon')).to.have.length(1);
+    expect(component.find('.aui--information-box-node')).to.have.length(1);
+    expect(component.find('.aui--information-box-icon')).to.have.length(1);
     expect(component.find(SvgSymbol)).to.have.length(1);
   });
 
@@ -42,22 +44,32 @@ describe('InformationBoxComponent', () => {
       </InformationBox>
     );
 
-    expect(component.find('.information-box-title')).to.have.length(1);
-    expect(component.find('.information-box-node').children()).to.have.length(1);
-    expect(component.find('.information-box-icon')).to.have.length(0);
+    expect(component.find('.aui--information-box-title')).to.have.length(1);
+    expect(component.find('.aui--information-box-node').children()).to.have.length(1);
+    expect(component.find('.aui--information-box-icon')).to.have.length(0);
   });
 
   it('should render without children nodes when children props is not provided', () => {
     const component = shallow(<InformationBox title="render title here" icon={icon} />);
 
-    expect(component.find('.information-box-title')).to.have.length(1);
-    expect(component.find('.information-box-icon')).to.have.length(1);
-    expect(component.find('.information-box-node').children()).to.have.length(0);
+    expect(component.find('.aui--information-box-title')).to.have.length(1);
+    expect(component.find('.aui--information-box-icon')).to.have.length(1);
+    expect(component.find('.aui--information-box-node').children()).to.have.length(0);
   });
 
   it('should accept custom class names', () => {
     const component = shallow(<InformationBox title="Class name test title" className="cx" />);
 
-    expect(component.find('.information-box').prop('className')).to.equal('information-box cx');
+    expect(component.find('.aui--information-box').prop('className')).to.equal(
+      'aui--information-box aui--information-box-light cx'
+    );
+  });
+
+  it('should accept custom theme', () => {
+    const component = shallow(<InformationBox title="Class name test title" theme="primary" />);
+
+    expect(component.find('.aui--information-box').prop('className')).to.equal(
+      'aui--information-box aui--information-box-primary'
+    );
   });
 });

--- a/src/components/InformationBox/styles.scss
+++ b/src/components/InformationBox/styles.scss
@@ -1,13 +1,32 @@
 @import '~styles/color';
 @import '~styles/variable';
 
-.information-box {
-  background-color: $color-background-highlighted;
+.aui--information-box {
   padding: $spacing-etalon;
   color: $color-text-label;
   display: inline-flex;
   align-items: center;
   width: 100%;
+
+  &.aui--information-box-primary {
+    background-color: $color-infobox-primary;
+  }
+
+  &.aui--information-box-success {
+    background-color: $color-infobox-success;
+  }
+
+  &.aui--information-box-warning {
+    background-color: $color-infobox-warning;
+  }
+
+  &.aui--information-box-error {
+    background-color: $color-infobox-error;
+  }
+
+  &.aui--information-box-light {
+    background-color: $color-infobox-light;
+  }
 
   &-text {
     padding-left: 20px;
@@ -22,8 +41,7 @@
 
   &-icon {
     $information-box-icon-size: 70px;
-
-    background-color: $color-background;
+    background-color: transparent;
     width: $information-box-icon-size;
     height: $information-box-icon-size;
     border-radius: $border-radius-circle;

--- a/src/components/Popover/index.jsx
+++ b/src/components/Popover/index.jsx
@@ -14,6 +14,9 @@ const triggerPropTypes = PropTypes.oneOf(['click', 'hover', 'focus', 'disabled']
 
 class Popover extends React.PureComponent {
   static propTypes = {
+    /**
+     * PropTypes.oneOf(['light', 'dark', 'warn', 'error', 'info', 'success'])
+     */
     theme: PropTypes.oneOf(themes),
     title: PropTypes.node,
     className: PropTypes.string,

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -130,3 +130,10 @@ $color-light-green: #def1de;
 $color-dark-green: #5bb75b;
 $color-light-red: #f8dcdb;
 $color-dark-red: #da4f49;
+
+// Information Box
+$color-infobox-primary: $color-info-light;
+$color-infobox-success: $color-positive-light;
+$color-infobox-warning: $color-warning-light;
+$color-infobox-error: $color-negative-light;
+$color-infobox-light: $color-gray-lightest;

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -408,10 +408,32 @@
       "props": {
         "color": {
           "type": {
-            "name": "string"
+            "name": "enum",
+            "value": [
+              {
+                "value": "'blue'",
+                "computed": false
+              },
+              {
+                "value": "'green'",
+                "computed": false
+              },
+              {
+                "value": "'red'",
+                "computed": false
+              },
+              {
+                "value": "'orange'",
+                "computed": false
+              },
+              {
+                "value": "'cyan'",
+                "computed": false
+              }
+            ]
           },
           "required": false,
-          "description": ""
+          "description": "PropTypes.oneOf(['blue', 'green', 'red', 'orange', 'cyan'])"
         },
         "givenName": {
           "type": {
@@ -612,6 +634,39 @@
             "value": "false",
             "computed": false
           }
+        },
+        "bsStyle": {
+          "type": {
+            "name": "enum",
+            "value": [
+              {
+                "value": "'primary'",
+                "computed": false
+              },
+              {
+                "value": "'success'",
+                "computed": false
+              },
+              {
+                "value": "'info'",
+                "computed": false
+              },
+              {
+                "value": "'warning'",
+                "computed": false
+              },
+              {
+                "value": "'danger'",
+                "computed": false
+              },
+              {
+                "value": "'link'",
+                "computed": false
+              }
+            ]
+          },
+          "required": false,
+          "description": "PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link'])"
         }
       },
       "composes": [
@@ -654,10 +709,36 @@
         },
         "bsStyle": {
           "type": {
-            "name": "string"
+            "name": "enum",
+            "value": [
+              {
+                "value": "'primary'",
+                "computed": false
+              },
+              {
+                "value": "'success'",
+                "computed": false
+              },
+              {
+                "value": "'info'",
+                "computed": false
+              },
+              {
+                "value": "'warning'",
+                "computed": false
+              },
+              {
+                "value": "'danger'",
+                "computed": false
+              },
+              {
+                "value": "'link'",
+                "computed": false
+              }
+            ]
           },
           "required": false,
-          "description": ""
+          "description": "PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link'])"
         },
         "inverse": {
           "type": {
@@ -1796,6 +1877,39 @@
           "required": false,
           "description": ""
         },
+        "theme": {
+          "type": {
+            "name": "enum",
+            "value": [
+              {
+                "value": "'primary'",
+                "computed": false
+              },
+              {
+                "value": "'success'",
+                "computed": false
+              },
+              {
+                "value": "'warning'",
+                "computed": false
+              },
+              {
+                "value": "'error'",
+                "computed": false
+              },
+              {
+                "value": "'light'",
+                "computed": false
+              }
+            ]
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "'light'",
+            "computed": false
+          }
+        },
         "title": {
           "type": {
             "name": "node"
@@ -2606,7 +2720,7 @@
             "value": "themes"
           },
           "required": false,
-          "description": "",
+          "description": "PropTypes.oneOf(['light', 'dark', 'warn', 'error', 'info', 'success'])",
           "defaultValue": {
             "value": "'light'",
             "computed": false

--- a/www/examples/InformationBox.mdx
+++ b/www/examples/InformationBox.mdx
@@ -4,12 +4,21 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 ## Information Box
 
 ```jsx live=true
-<InformationBox
-  title="This is an information"
-  icon={<SvgSymbol classSuffixes={['70']} href="./assets/svg-symbols.svg#cancel" />}
->
-  Content body.
-</InformationBox>
+<div>
+  <InformationBox title="This is an information">Content body.</InformationBox>
+  <InformationBox title="This is a primary information" theme="primary">
+    Content body.
+  </InformationBox>
+  <InformationBox title="This is a success information" theme="success">
+    Content body.
+  </InformationBox>
+  <InformationBox title="This is a warning information" theme="warning">
+    Content body.
+  </InformationBox>
+  <InformationBox title="This is an error information" theme="error">
+    Content body.
+  </InformationBox>
+</div>
 ```
 
 <DesignNotes>

--- a/www/examples/Introduction.mdx
+++ b/www/examples/Introduction.mdx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
   <img src="./assets/banner.jpg" style={{ maxWidth: '100%' }} />
 </div>
 
-<div style={{ display: 'flex', marginTop: 30, justifyContent: 'space-between' }}>
+<div style={{ display: 'grid', gridColumnGap: 10, marginTop: 30, gridTemplateColumns: '1fr 1fr auto' }}>
   <div>
     <InformationBox className="intro-page-box">
       <SvgSymbol href="./assets/svg-symbols.svg#code-guide" classSuffixes={['box-icon']} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

- Add a new prop `theme` to `<InformationBox />` to take one of `['primary', 'success', 'warning', 'error', 'light']` for easy use in other projects, set `light` to be default as it's completely the same as the legacy design.

- Remove the redundant icon halo, add a new sample to the doc.

- Refine prop types using for theme/color and add descriptions for docs.

- One issue here is we are using `#dbf0fd` for `primary` color of the info box, however, this color is inconsistent to the current `adslot-ui` library. So, choose a very similar color `#e0f0ff` from the current color palette as a new alternative.

- new use cases of `<InformationBox />` (checked with Pedros)
![Screen Shot 2020-05-08 at 11 21 00 am](https://user-images.githubusercontent.com/42738416/81360038-1d9b8800-911e-11ea-8e1d-355e8be639c7.png)


Resolves #994

FYI, further talks about color management and enhancement, please refer to #1013 


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
