### PR TITLE
fix: default button issue

### DIFF
--- a/src/styles/bootstrapOverrides/Button.scss
+++ b/src/styles/bootstrapOverrides/Button.scss
@@ -40,6 +40,10 @@
       background-color: $color-background-highlighted;
     }
 
+    &.btn-default {
+      @include button-inverse($color-gray-dark);
+    }
+
     &.btn-primary {
       @include button-inverse($color-primary);
     }
@@ -76,7 +80,7 @@
   }
 
   &.btn-default {
-    @include aui--button-variant($btn-default-color, $btn-default-bg, $btn-default-border);
+    @include aui--button-variant($color-gray-dark, $btn-default-bg, $color-gray-light);
   }
 
   &.btn-primary {

--- a/www/examples/Button.mdx
+++ b/www/examples/Button.mdx
@@ -11,6 +11,7 @@ import DesignNotes from '../containers/DesignNotes.jsx';
   <Button bsStyle="danger" inverse>
     Error
   </Button>
+  <Button>Default</Button>
   <Button bsStyle="warning" isLoading>
     Loading
   </Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Align the default color with the current color palette used.

As `<Button />` can be given props `bsStyle = "default", inverse={true}`, a tweak here is to remove focus issue of this kind of button.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
