### PR TITLE
fix: button css overwrite issue

### DIFF
--- a/src/components/ActionPanel/styles.scss
+++ b/src/components/ActionPanel/styles.scss
@@ -15,7 +15,7 @@
 
   &.action-modal {
     top: 30px;
-    background-color: $color-white ;
+    background-color: $color-white;
     margin: 30px auto;
     border: 0;
   }
@@ -69,7 +69,7 @@
     }
 
     .close-icon {
-      @include svg-icon('~styles/icons/close.svg')
+      @include svg-icon('~styles/icons/close.svg');
     }
 
     .btn {
@@ -79,10 +79,13 @@
       box-shadow: none;
       border-radius: 2px;
       background-color: $color-white;
-      color: $color-blue;
       display: inline-flex;
       align-items: center;
       justify-content: center;
+
+      &.aui--button {
+        color: $color-blue;
+      }
 
       &:focus:active,
       &:hover:active {
@@ -140,7 +143,6 @@
   opacity: .8;
   animation: fadein .2s;
 }
-
 
 .aui--action-panel-modal-wrapper {
   position: fixed;

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -29,6 +29,10 @@ const Button = props => {
   const classes = classNames(baseClass, className, {
     'btn-inverse': inverse && !/btn-inverse/.test(className),
     'btn-large': size === 'large',
+    'aui--btn-default':
+      (!bsStyle || bsStyle === 'default') &&
+      (!className ||
+        ['btn-default', 'btn-inverse', 'btn-default btn-inverse', 'btn-inverse btn-default'].includes(className)),
   });
 
   const renderSpinner = () =>

--- a/src/components/Button/index.spec.jsx
+++ b/src/components/Button/index.spec.jsx
@@ -17,7 +17,7 @@ describe('ButtonComponent', () => {
 
   it('should support legacy classname btn-inverse for non-breaking change', () => {
     const wrapper = shallow(<Button className="btn-inverse">Test</Button>);
-    expect(wrapper.prop('className')).to.equal('aui--button btn-inverse');
+    expect(wrapper.prop('className')).to.equal('aui--button btn-inverse aui--btn-default');
   });
 
   it('should support className prop', () => {
@@ -41,17 +41,17 @@ describe('ButtonComponent', () => {
         Test
       </Button>
     );
-    expect(wrapper.prop('className')).to.equal('aui--button btn-inverse');
+    expect(wrapper.prop('className')).to.equal('aui--button btn-inverse aui--btn-default');
   });
 
   it('should render inverse button with btn-inverse class', () => {
     const wrapper = shallow(<Button inverse>Test</Button>);
-    expect(wrapper.prop('className')).to.equal('aui--button btn-inverse');
+    expect(wrapper.prop('className')).to.equal('aui--button btn-inverse aui--btn-default');
   });
 
   it('should render large button with btn-large class', () => {
     const wrapper = shallow(<Button size="large">Test</Button>);
-    expect(wrapper.prop('className')).to.equal('aui--button btn-large');
+    expect(wrapper.prop('className')).to.equal('aui--button btn-large aui--btn-default');
   });
 
   it('should support data-test-selectors', () => {
@@ -78,5 +78,10 @@ describe('ButtonComponent', () => {
     );
     const spinnerEl = wrapper.find(Spinner);
     expect(spinnerEl.prop('size')).to.equal('medium');
+  });
+
+  it('should not render classname with "aui--btn-default" when the style has been explicitly defined', () => {
+    const wrapper = shallow(<Button className="btn-primary btn-inverse btn-default">Button</Button>);
+    expect(wrapper.prop('className')).to.not.have.string('aui--btn-default');
   });
 });

--- a/src/styles/bootstrapOverrides/Button.scss
+++ b/src/styles/bootstrapOverrides/Button.scss
@@ -40,8 +40,15 @@
       background-color: $color-background-highlighted;
     }
 
-    &.btn-default {
+    &.aui--btn-default {
       @include button-inverse($color-gray-dark);
+      border-color: $color-gray-light;
+
+      &:hover,
+      &:active,
+      &:hover:active {
+        border-color: $color-gray-light;
+      }
     }
 
     &.btn-primary {
@@ -79,7 +86,7 @@
     transform: translateY(1px);
   }
 
-  &.btn-default {
+  &.aui--btn-default {
     @include aui--button-variant($color-gray-dark, $btn-default-bg, $color-gray-light);
   }
 
@@ -132,6 +139,7 @@
 .btn.btn-link {
   // sass-lint:disable-line force-element-nesting
   cursor: pointer;
+  border-color: transparent;
 
   &,
   &:active {
@@ -148,6 +156,10 @@
   &:active {
     background-color: transparent;
   }
+
+  &:active:hover {
+    border-color: $color-gray-light;
+  }
 }
 
 .btn-borderless {
@@ -156,7 +168,7 @@
     box-shadow: none;
 
     &:hover,
-    &:focus {
+    &:active {
       background-color: $color-white;
       border-color: $color-border-light;
       box-shadow: 0 1px $color-border-light;

--- a/www/examples/Button.mdx
+++ b/www/examples/Button.mdx
@@ -7,14 +7,18 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 <div>
   <Button bsStyle="success">Undo</Button>
   <Button bsStyle="primary">Apply</Button>
+  <Button className="btn-primary btn-inverse">Inverse</Button>
   <Button bsStyle="info">Help</Button>
   <Button bsStyle="danger" inverse>
     Error
   </Button>
   <Button>Default</Button>
+  <Button disabled>Disabled</Button>
   <Button bsStyle="warning" isLoading>
     Loading
   </Button>
+  <Button className="btn btn-borderless">Borderless</Button>
+  <Button className="btn-link">Link</Button>
   <br />
   <h3>Large Button</h3>
   <Button size="large">Add to My Todo List</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
After discussion with @veegandhi, we determine to fix `<Button />` css overwriting problem with `adslot-ui`. In this way, we can avoid breaking changes.

The issue was caused by `btn-default` when the component was not explicitly defined its `bsStyle`, it will give a `btn-default` and if we give the component with `className="btn-primary"`, the `.btn-primary` the selector doesn't overweigh the `btn-default` selector, which means the css wouldn't be overwritten by expected style.

For this problem, changing `btn-default` css styles to `aui--btn-default` and set this classname as per the required situation.

Now, the `<Button />` should behave its way without any breaking changes.

*Buddy test is required for this project only.

## Does this PR introduce a breaking change?

<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [X] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
![Screen Shot 2020-05-14 at 4 07 28 pm](https://user-images.githubusercontent.com/42738416/81898935-0583a700-95fd-11ea-9d72-518c97246924.png)

