### PR TITLE
Fix docgen failure if a single component cant be parsed

### DIFF
--- a/scripts/generateDocs.js
+++ b/scripts/generateDocs.js
@@ -6,29 +6,26 @@ const reactDocgen = require('react-docgen');
 const glob = require('glob');
 
 const sourcePath = path.join(__dirname, '..');
-const filesToIgnore = [
-  'fastStatelessWrapper',
-  'mocks.jsx',
-  'spec.jsx',
-  'BlockStyleButtons',
-  'InlineStyleButtons',
-];
+const filesToIgnore = ['fastStatelessWrapper', 'mocks.jsx', 'spec.jsx', 'BlockStyleButtons', 'InlineStyleButtons'];
 const outputFilePath = path.join(__dirname, '../www/containers/props.json');
 
 (async () => {
-  const files = _.reject(
-    await promisify(glob)('src/components/**/*.jsx', { cwd: sourcePath }),
-    (filePath) => _.some(filesToIgnore, (ignoreFile) => _.includes(filePath, ignoreFile))
+  const files = _.reject(await promisify(glob)('src/components/**/*.jsx', { cwd: sourcePath }), filePath =>
+    _.some(filesToIgnore, ignoreFile => _.includes(filePath, ignoreFile))
   );
 
   const result = {};
-  files.forEach((filePath) => {
+  files.forEach(filePath => {
     const absolutePath = path.join(sourcePath, filePath);
-
-    result[filePath] = reactDocgen.parse(
-      fs.readFileSync(absolutePath),
-      reactDocgen.resolver.findAllComponentDefinitions
-    );
+    try {
+      result[filePath] = reactDocgen.parse(
+        fs.readFileSync(absolutePath),
+        reactDocgen.resolver.findAllComponentDefinitions
+      );
+    } catch (err) {
+      // Check: https://github.com/reactjs/react-docgen/issues/336
+      console.warn(`Prop generation skipped for ${filePath} due to react-docgen parsing error`);
+    }
   });
 
   fs.writeFileSync(outputFilePath, JSON.stringify(result, null, '  '));

--- a/src/components/ImageCropper/index.jsx
+++ b/src/components/ImageCropper/index.jsx
@@ -83,4 +83,6 @@ ImageCropper.defaultProps = {
   title: 'Image Upload',
 };
 
+ImageCropper.displayName = 'ImageCropper';
+
 export default ImageCropper;

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -4518,11 +4518,111 @@
       }
     }
   ],
-  "src/components/Toast/index.jsx": [
+  "src/components/Toast/ToastContainer.jsx": [
     {
       "description": "",
-      "displayName": "toastContainerComponent",
-      "methods": []
+      "displayName": "ToastContainerComponent",
+      "methods": [],
+      "props": {
+        "position": {
+          "type": {
+            "name": "enum",
+            "computed": true,
+            "value": "toastPlacements"
+          },
+          "required": false,
+          "description": "PropTypes.oneOf(['top-right', 'top-center', 'top-left', 'bottom-right', 'bottom-center', 'bottom-left'])",
+          "defaultValue": {
+            "value": "'bottom-left'",
+            "computed": false
+          }
+        },
+        "autoClose": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "number"
+              },
+              {
+                "name": "bool"
+              }
+            ]
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "5000",
+            "computed": false
+          }
+        },
+        "hideProgressBar": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "true",
+            "computed": false
+          }
+        },
+        "newestOnTop": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "closeOnClick": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "true",
+            "computed": false
+          }
+        },
+        "rtl": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "draggable": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "true",
+            "computed": false
+          }
+        },
+        "pauseOnHover": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "true",
+            "computed": false
+          }
+        }
+      }
     }
   ],
   "src/components/Totals/index.jsx": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
There is an issue with `react-docgen` where it can't detect some types of components. When that happens it throws and error which is then a promise rejection and can impact the prop doc generation. This fix adds a try catch to handle that with a warning for now as it doesn't seem that the parse will be detecting these components unless there are some magical fixes.

I added a comment to reference the tracked issue and simply log a warning message

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [X] No
