### PR TITLE
refactor: move custom class to the end

### DIFF
--- a/src/components/ActionPanel/index.jsx
+++ b/src/components/ActionPanel/index.jsx
@@ -23,7 +23,7 @@ const ActionPanel = React.forwardRef((props, ref) => {
     <div ref={ref}>
       <div className={isModal ? 'aui--action-panel-backdrop' : 'hide'} />
       <div className={classNames('aui--action-panel-wrapper', { 'aui--action-panel-modal-wrapper': isModal })}>
-        <div className={classNames('aui--action-panel', className, `is-${size}`, { 'action-modal': isModal })}>
+        <div className={classNames('aui--action-panel', `is-${size}`, { 'action-modal': isModal }, className)}>
           <div className={classNames('aui--action-panel-header', { 'has-actions': actionButton })}>
             <div className="title">{title}</div>
             <span className="actions">

--- a/src/components/AlertInput/index.jsx
+++ b/src/components/AlertInput/index.jsx
@@ -90,11 +90,15 @@ export default class AlertInput extends React.PureComponent {
       onValueChange,
     } = this.props;
 
-    const className = classnames(baseClass, this.props.className, {
-      [alertStatus]: alertStatus,
-      [`${baseClass}--focused`]: this.state.isFocused,
-      [`${baseClass}--disabled`]: disabled,
-    });
+    const className = classnames(
+      baseClass,
+      {
+        [alertStatus]: alertStatus,
+        [`${baseClass}--focused`]: this.state.isFocused,
+        [`${baseClass}--disabled`]: disabled,
+      },
+      this.props.className
+    );
     const theme = alertStatus === 'warning' ? 'warn' : alertStatus;
     const shouldPopoverOpen = this.state.isPopoverVisible && !_.isEmpty(alertMessage);
 

--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -1,20 +1,14 @@
 import _ from 'lodash';
+import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { expandDts } from '../../lib/utils';
 import './styles.scss';
 
 const CardContent = ({ children, className, stretch, fill, append, dts }) => {
-  const baseClass = 'card-component-content';
-  const contentClassNames = [baseClass];
-
-  if (stretch) contentClassNames.push('stretch');
-  if (fill) contentClassNames.push('fill');
-  if (append) contentClassNames.push('append');
-  if (className) contentClassNames.push(className);
-
+  const contentClassNames = classnames('card-component-content', { stretch, fill, append }, className);
   return (
-    <div className={contentClassNames.join(' ')} {...expandDts(dts)}>
+    <div className={contentClassNames} {...expandDts(dts)}>
       {children}
     </div>
   );
@@ -39,9 +33,7 @@ CardContent.defaultProps = {
 
 const Card = ({ children, className, accent, dts }) => {
   const baseClass = 'card-component';
-  const containerClassNames = [baseClass];
-  if (accent) containerClassNames.push(`accent accent-${accent}`);
-  if (className) containerClassNames.push(className);
+  const containerClassNames = classnames(baseClass, { [`accent accent-${accent}`]: accent }, className);
 
   const nestedChildren = React.Children.map(children, (
     child // eslint-disable-line lodash/prefer-lodash-method
@@ -51,7 +43,7 @@ const Card = ({ children, className, accent, dts }) => {
   ) => (_.get(child, 'props.append') ? child : null));
 
   return (
-    <div className={containerClassNames.join(' ')} {...expandDts(dts)}>
+    <div className={containerClassNames} {...expandDts(dts)}>
       <div className={`${baseClass}-content-container`}>{nestedChildren}</div>
       {appendedChildren}
     </div>

--- a/src/components/Grid/Cell/index.jsx
+++ b/src/components/Grid/Cell/index.jsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { expandDts, classSuffixHelper } from '../../../lib/utils';
@@ -13,8 +14,7 @@ const GridCell = ({ children, classSuffixes, onClick, stretch, dts, addonClassNa
     },
     componentClass,
   });
-  const baseClassNames = `${componentClass}${classesList}`;
-  const className = addonClassNames ? [baseClassNames, ...addonClassNames].join(' ') : baseClassNames;
+  const className = classnames(`${componentClass}${classesList}`, ...addonClassNames);
   const extraProps = onClick ? { onClick } : {};
 
   return (
@@ -51,6 +51,7 @@ GridCell.propTypes = {
 };
 
 GridCell.defaultProps = {
+  addonClassNames: [],
   classSuffixes: [],
   stretch: false,
 };

--- a/src/components/PageTitle/index.jsx
+++ b/src/components/PageTitle/index.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FlexibleSpacer } from 'adslot-ui';
@@ -7,7 +8,7 @@ import './styles.scss';
 const baseClass = 'pagetitle-component';
 
 const PageTitle = ({ children, isFooter, title }) => {
-  const className = isFooter ? `${baseClass} ${baseClass}-is-footer` : baseClass;
+  const className = classnames(baseClass, { [`${baseClass}-is-footer`]: isFooter });
   return (
     <div className={className} id={_.kebabCase(title)}>
       {children ? (

--- a/src/components/Panel/index.jsx
+++ b/src/components/Panel/index.jsx
@@ -19,7 +19,7 @@ class PanelComponent extends React.PureComponent {
 
   render() {
     const { className, children, dts, icon, isCollapsed, title } = this.props;
-    const classesCombined = classnames(['panel-component', className, { collapsed: isCollapsed }]);
+    const classesCombined = classnames(['panel-component', { collapsed: isCollapsed }, className]);
 
     return (
       <div className={classesCombined} data-test-selector={dts}>

--- a/src/components/Tabs/index.jsx
+++ b/src/components/Tabs/index.jsx
@@ -64,7 +64,7 @@ class Tabs extends React.PureComponent {
           {tabs.map(tab => (
             <li
               role="presentation"
-              className={classnames(tab.props.tabClassName, { active: tab.props.show, disabled: tab.props.disabled })}
+              className={classnames({ active: tab.props.show, disabled: tab.props.disabled }, tab.props.tabClassName)}
               key={tab.props.eventKey}
             >
               <a

--- a/src/components/TileGrid/index.jsx
+++ b/src/components/TileGrid/index.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import _ from 'lodash';
+import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import idPropType from '../../prop-types/idPropType';
@@ -11,8 +12,9 @@ const baseClass = 'tile-grid-component';
 
 const TileGrid = ({ title, items, onItemClick, distributed }) => {
   const cardList = _.map(items, item => {
-    const itemClassNames = [`${baseClass}-item`, `${baseClass}-item-${item.classSuffix}`];
-    if (distributed) itemClassNames.push(`${baseClass}-item-distributed`);
+    const itemClassNames = classnames(`${baseClass}-item`, `${baseClass}-item-${item.classSuffix}`, {
+      [`${baseClass}-item-distributed`]: distributed,
+    });
 
     const imgWrapperClassNames = [`${baseClass}-item-img-wrapper`];
 
@@ -35,7 +37,7 @@ const TileGrid = ({ title, items, onItemClick, distributed }) => {
       : { width: item.width || defaultWidth };
 
     return (
-      <li key={item.id} className={itemClassNames.join(' ')} style={itemStyle}>
+      <li key={item.id} className={itemClassNames} style={itemStyle}>
         {item.imgLink ? (
           <div className={imgWrapperClassNames.join(' ')}>
             <img src={item.imgLink} alt="item-link" />

--- a/src/components/TreePicker/Nav/index.jsx
+++ b/src/components/TreePicker/Nav/index.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import _ from 'lodash';
+import classnames from 'classnames';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Search from '../../Search';
 import Breadcrumb from '../../Breadcrumb';
@@ -33,9 +34,10 @@ const TreePickerNavComponent = ({
     onClick: breadcrumbOnClick,
     rootNode: breadcrumbRootNode,
   };
+  const className = classnames('treepickernav-component', { disabled });
 
   return (
-    <div className={`treepickernav-component ${disabled ? 'disabled' : ''}`} data-test-selector="treepicker-nav-search">
+    <div className={className} data-test-selector="treepicker-nav-search">
       {showSearch && (
         <Search
           disabled={disabled}

--- a/src/components/TreePicker/index.jsx
+++ b/src/components/TreePicker/index.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SplitPane from '../SplitPane';
@@ -55,9 +56,10 @@ const TreePickerSimplePureComponent = ({
   let searchTextNode = emptyText || 'No items to select.';
   searchTextNode = initialStateNode && _.isEmpty(searchValue) ? initialStateNode : searchTextNode;
   const emptySymbol = initialStateSymbol && _.isEmpty(searchValue) ? initialStateSymbol : emptySvgSymbol;
+  const className = classnames('treepickersimplepure-component', { disabled });
 
   return (
-    <div className={`treepickersimplepure-component ${disabled ? 'disabled' : ''}`}>
+    <div className={className}>
       <SplitPane
         additionalClassNames={additionalClassNames}
         dts={`treepicker-splitpane-available-${_.kebabCase(itemType)}`}

--- a/src/components/TreePicker/index.spec.jsx
+++ b/src/components/TreePicker/index.spec.jsx
@@ -40,7 +40,7 @@ describe('TreePickerSimplePureComponent', () => {
 
   it('should render with props', () => {
     const component = shallow(<TreePickerSimplePure {...props} />);
-    expect(component.prop('className')).to.equal('treepickersimplepure-component ');
+    expect(component.prop('className')).to.equal('treepickersimplepure-component');
 
     expect(component.find(SplitPane)).to.have.length(2);
     expect(component.children().every(SplitPane)).to.equal(true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Move all custom classes to the end of `className`

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
CSS rules are applied from left to right, so the later styles will override the former. Therefore to give the custom class the most control, we need to put it at the end of class generation.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
