### PR TITLE
refactor: add isSaving prop to image cropper

### DIFF
--- a/src/components/ImageCropper/index.jsx
+++ b/src/components/ImageCropper/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useImperativeHandle, forwardRef } from 'react';
+import React, { useImperativeHandle, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import Cropper from 'cropperjs';
 import 'cropperjs/dist/cropper.css';
@@ -17,10 +17,9 @@ const defaultOptions = {
   toggleDragModeOnDblclick: false,
 };
 
-const ImageCropper = forwardRef(({ title, src, alt, onCancel, onCrop, width, height, aspectRatio }, ref) => {
+const ImageCropper = forwardRef(({ title, src, alt, onCancel, onCrop, width, height, aspectRatio, isSaving }, ref) => {
   const cropperRef = React.useRef();
   const imageRef = React.useRef();
-  const [isSaving, setIsSaving] = useState(false);
 
   React.useEffect(() => {
     if (!cropperRef.current) return;
@@ -34,7 +33,6 @@ const ImageCropper = forwardRef(({ title, src, alt, onCancel, onCrop, width, hei
     });
 
     return () => {
-      setIsSaving(false);
       cropperRef.current.destroy();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -45,16 +43,7 @@ const ImageCropper = forwardRef(({ title, src, alt, onCancel, onCrop, width, hei
   }));
 
   const uploadButton = (
-    <Button
-      bsStyle="primary"
-      onClick={async () => {
-        setIsSaving(true);
-        await onCrop(cropperRef.current.getData());
-        setIsSaving(false);
-      }}
-      isLoading={isSaving}
-      inverse
-    >
+    <Button bsStyle="primary" onClick={() => onCrop(cropperRef.current.getData())} isLoading={isSaving} inverse>
       Upload
     </Button>
   );
@@ -77,10 +66,12 @@ ImageCropper.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   aspectRatio: PropTypes.number,
+  isSaving: PropTypes.bool,
 };
 
 ImageCropper.defaultProps = {
   title: 'Image Upload',
+  isSaving: false,
 };
 
 ImageCropper.displayName = 'ImageCropper';

--- a/src/components/ImageCropper/index.spec.jsx
+++ b/src/components/ImageCropper/index.spec.jsx
@@ -49,11 +49,25 @@ describe('ImageCropperComponent', () => {
   });
 
   it('should destroy cropperRef if component will unmount', () => {
-    const setStateSpy = sandbox.spy();
-    sandbox.stub(React, 'useState').callsFake(init => [init, setStateSpy]);
-    const component = mount(<ImageCropper src="example.svg" onCrop={_.noop} onCancel={_.noop} />);
+    const spyCropperDestroy = sandbox.spy();
+    const TestComponent = ({ aspectRatio }) => {
+      const cropperRef = React.useRef();
+      React.useEffect(() => {
+        cropperRef.current.getCropper().current.destroy = spyCropperDestroy;
+      }, []);
+      return (
+        <ImageCropper
+          ref={cropperRef}
+          src="../../../www/assets/adslot-avatar.png"
+          onCrop={_.noop}
+          onCancel={_.noop}
+          aspectRatio={aspectRatio}
+        />
+      );
+    };
+    const component = mount(<TestComponent />);
     component.unmount();
-    expect(setStateSpy.calledOnceWith(false)).to.equal(true);
+    expect(spyCropperDestroy.calledOnce).to.equal(true);
   });
 
   it('should set correct aspect ratio on cropper', () => {

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -1926,6 +1926,17 @@
           },
           "required": false,
           "description": ""
+        },
+        "isSaving": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Add `isSaving` prop to ImageCropper component to let user to control whether it's saving. We used to handle `isSaving` internally by awaiting the `onCrop` function which will be an issue when this component is unmount before the onCrop function finish. So I think it's better to let user control whether it is saving.   

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
