### PR TITLE
fix: add ref to carousel component

### DIFF
--- a/src/components/Carousel/index.jsx
+++ b/src/components/Carousel/index.jsx
@@ -8,15 +8,15 @@ import './styles.scss';
 
 const baseClass = 'aui--carousel-component';
 
-const CarouselComponent = props => {
+const CarouselComponent = React.forwardRef((props, ref) => {
   const { className, children } = props;
 
   return (
-    <Slider {...props} className={classNames(baseClass, className)}>
+    <Slider {...props} ref={ref} className={classNames(baseClass, className)}>
       {children}
     </Slider>
   );
-};
+});
 
 CarouselComponent.propTypes = {
   className: PropTypes.string,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
In order to use methods on react-slick, user has to give ref to Slider component. So we have to forward ref to Slider.
[react-slick doc](https://react-slick.neostack.com/docs)

For example:
```jsx
const example = () =>  {
  const images = [0,1,2];
  const carouselRef = React.useRef();
  const goToSlide = () => carouselRef.current.slickGoTo(images.length -1)
    return (
      <div>
        <button onClick={goToSlide}>Go To Last Slide</button>
        <Slider ref={carouselRef} {...settings} />
        {images.map((image, index) => (
          <div>
            <img src={baseUrl + "/abstract" + index + ".jpg"} />
          </div>
        ))}   
      </div>
    )
}
```

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
