### PR TITLE
feat: change primary inverse button border

### DIFF
--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -12,6 +12,10 @@
     height: 42px;
   }
 
+  &.btn-inverse:not([disabled]).btn-primary {
+    border-color: $color-border-light;
+  }
+
   .spinner-container {
     position: absolute;
     right: 0;

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -865,7 +865,6 @@
   "src/components/Carousel/index.jsx": [
     {
       "description": "",
-      "displayName": "CarouselComponent",
       "methods": [],
       "props": {
         "className": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change primary inverse button border to light gray (see screenshot)

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Discussed with Pedros, he would like to have all primary inversed buttons to not have blue border

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
Before
![Screen Shot 2020-08-05 at 12 55 03 am](https://user-images.githubusercontent.com/2588669/89309100-59f76980-d6b6-11ea-82b7-67470b1bca8d.png)

After
![Screen Shot 2020-08-05 at 12 54 49 am](https://user-images.githubusercontent.com/2588669/89309091-57950f80-d6b6-11ea-97da-b12caf104931.png)
