### PR TITLE
feat: change rich text editor button hover styles

### DIFF
--- a/src/components/RichTextEditor/styles.scss
+++ b/src/components/RichTextEditor/styles.scss
@@ -40,13 +40,12 @@
 
       &:hover,
       &.active {
-        background-color: $color-white;
+        background-color: $color-gray-lighter;
         border-color: $color-gray-lighter;
-        box-shadow: 0 1px $color-gray-light;
       }
 
       img {
-        height: 16px;
+        height: 20px;
       }
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Change hover and active state for buttons.
- Enlarge the button icons from 16px to 20px

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
Italic button is the old style
![Screen Shot 2020-08-17 at 12 03 26 pm](https://user-images.githubusercontent.com/2588669/90351062-68645e80-e082-11ea-95f2-3f7fb2e8b55f.png)
