### PR TITLE
fix: fix rich text editor loses focus on clicking edit buttons

### DIFF
--- a/src/components/RichTextEditor/ToolbarButton.jsx
+++ b/src/components/RichTextEditor/ToolbarButton.jsx
@@ -8,8 +8,17 @@ const ToolbarButton = ({ onToggle, label, active }) => {
     active,
   });
 
+  const mouseDownHandler = React.useCallback(
+    event => {
+      event.preventDefault();
+      event.stopPropagation();
+      return onToggle();
+    },
+    [onToggle]
+  );
+
   return (
-    <Button className={className} onMouseDown={onToggle}>
+    <Button className={className} onMouseDown={mouseDownHandler}>
       {label}
     </Button>
   );

--- a/src/components/RichTextEditor/index.jsx
+++ b/src/components/RichTextEditor/index.jsx
@@ -40,8 +40,8 @@ const RichTextEditor = ({ className, value, initialValue, onChange, placeholder 
   };
 
   return (
-    <div data-testid="rich-text-editor-wrapper" className={classNames} onClick={focusEditor}>
-      <div className="aui--editor-container">
+    <div data-testid="rich-text-editor-wrapper" className={classNames}>
+      <div className="aui--editor-container" onClick={focusEditor}>
         <Editor
           editorState={value || editorState}
           handleKeyCommand={handleKeyCommand}

--- a/src/components/RichTextEditor/index.spec.jsx
+++ b/src/components/RichTextEditor/index.spec.jsx
@@ -29,7 +29,7 @@ describe('<RichTextEditor />', () => {
     const { container } = render(<RichTextEditor />);
     expect(queryAllByClass(container, 'public-DraftEditorPlaceholder-root')).toHaveLength(1);
 
-    fireEvent.click(getByClass(container, 'aui--editor-root'));
+    fireEvent.click(getByClass(container, 'aui--editor-container'));
     expect(
       queryAllByClass(container, 'public-DraftEditorPlaceholder-root public-DraftEditorPlaceholder-hasFocus')
     ).toHaveLength(1);
@@ -97,7 +97,7 @@ describe('<RichTextEditor />', () => {
     expect(queryAllByTestId('bootstrap-button-wrapper')).toHaveLength(5);
     expect(queryAllByTestId('bootstrap-button-wrapper')[1]).toContainElement(getByAltText('italics'));
 
-    fireEvent.click(queryAllByTestId('bootstrap-button-wrapper')[1]);
+    fireEvent.mouseDown(queryAllByTestId('bootstrap-button-wrapper')[1]);
 
     expect(onChange).toHaveBeenCalledTimes(1);
   });
@@ -110,7 +110,7 @@ describe('<RichTextEditor />', () => {
     expect(queryAllByTestId('bootstrap-button-wrapper')).toHaveLength(5);
     expect(queryAllByTestId('bootstrap-button-wrapper')[4]).toContainElement(getByAltText('number'));
 
-    fireEvent.click(queryAllByTestId('bootstrap-button-wrapper')[4]);
+    fireEvent.mouseDown(queryAllByTestId('bootstrap-button-wrapper')[4]);
 
     expect(onChange).toHaveBeenCalledTimes(1);
   });

--- a/src/components/RichTextEditor/styles.scss
+++ b/src/components/RichTextEditor/styles.scss
@@ -11,6 +11,7 @@
 
   .aui--editor-container {
     padding: 20px;
+    flex-grow: 1;
 
     // sass-lint:disable class-name-format
     .public-DraftEditorPlaceholder-hasFocus {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Ensure that the editor not losing focus when user clicks on styling buttons

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
