### PR TITLE
v27.8.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "27.8.22",
+  "version": "27.8.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "27.8.22",
+  "version": "27.8.23",
   "description": "Core component library. By Adslot",
   "main": "dist/adslot-ui-main.js",
   "files": [


### PR DESCRIPTION
### Changes

- [85310003b8fca55d8fb6c3254b658588314e8f89] fix: fix package-lock to point to main npm registry
 
- [3580b77721d48fedc63662624285c3d8d98b40bb] ci: update package-lock validation to check for nexus references
 
- [f4eb48852c987ba77f08b181e7bed4b894170d86] build: release patch version 27.8.23
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v27.8.22...v27.8.23