### PR TITLE
[ASC-89] fix: treepicker empty component

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm run test [-- --no-coverage]
 
 # Run tests and rebuild on file changes.
 
-npm run test:watch [--file=<path>] [--coverage]
+npm run test:watch [-- <path>] [--coverage]
 
 # Optimize SVG before you commit
 npm run svgo

--- a/src/components/TreePicker/Grid/index.jsx
+++ b/src/components/TreePicker/Grid/index.jsx
@@ -27,6 +27,8 @@ const TreePickerGridComponent = ({
   displayGroupHeader,
 }) => {
   const nodesByGroupLabel = _.groupBy(nodes, groupFormatter);
+  const emptySvgIcon = hideIcon ? null : emptySvgSymbol;
+
   return (
     <Grid>
       {isLoading ? (
@@ -65,9 +67,7 @@ const TreePickerGridComponent = ({
           </div>
         ))
       )}
-      {nodes && !isLoading ? (
-        <Empty collection={nodes} hideIcon={hideIcon} icon={emptySvgSymbol} text={emptyText} />
-      ) : null}
+      {nodes && !isLoading ? <Empty collection={nodes} icon={emptySvgIcon} text={emptyText} /> : null}
     </Grid>
   );
 };

--- a/src/components/TreePicker/Grid/index.spec.jsx
+++ b/src/components/TreePicker/Grid/index.spec.jsx
@@ -10,7 +10,7 @@ const getByClass = queryByAttribute.bind(null, 'class');
 
 describe('<TreePickerGrid />', () => {
   const { itemType, qldNode, saNode, nodeRenderer, valueFormatter } = TreePickerMocks;
-  const svgSymbol = <div className="testing-empty-svg-symbol" />;
+  const svgSymbol = <div className="testing-empty-svg-symbol" data-testid="testing-svg-symbol" />;
 
   it('should render with props', () => {
     const props = {
@@ -152,5 +152,31 @@ describe('<TreePickerGrid />', () => {
 
     const { queryAllByTestId } = render(<TreePickerGrid {...props} isLoading />);
     expect(queryAllByTestId('spinner-wrapper')).toHaveLength(1);
+  });
+
+  it('should hide the emptySvgSymbol of the tree picker grid as expected', () => {
+    const props = {
+      emptySvgSymbol: svgSymbol,
+      emptyText: 'Empty!',
+      nodes: [],
+      expandNode: jest.fn(),
+      includeNode: jest.fn(),
+      itemType,
+      nodeRenderer,
+      removeNode: jest.fn(),
+      selected: false,
+      valueFormatter,
+      displayGroupHeader: true,
+      isLoading: false,
+    };
+
+    const { getByTestId, queryAllByTestId, rerender } = render(<TreePickerGrid {...props} />);
+    expect(queryAllByTestId('empty-wrapper')).toHaveLength(1);
+    expect(queryAllByTestId('testing-svg-symbol')).toHaveLength(1);
+    expect(getByTestId('empty-wrapper')).toContainElement(getByTestId('testing-svg-symbol'));
+
+    rerender(<TreePickerGrid {...props} hideIcon />);
+
+    expect(queryAllByTestId('testing-svg-symbol')).toHaveLength(0);
   });
 });

--- a/src/components/TreePicker/index.jsx
+++ b/src/components/TreePicker/index.jsx
@@ -159,11 +159,11 @@ TreePickerSimplePureComponent.propTypes = {
    */
   disableInclude: PropTypes.bool,
   /**
-   * 	Displays this svg symbol when there will be no item on both left or right Grid
+   * 	The svg symbol used when there will be no item on both left or right Grid
    */
   emptySvgSymbol: PropTypes.node,
   /**
-   * 	Displays this svg symbol when there will be no item on right Grid(Selected list)
+   * 	The svg symbol used when there will be no item on right Grid (Selected list)
    */
   emptySelectedListSvgSymbol: PropTypes.node,
   /**
@@ -183,7 +183,7 @@ TreePickerSimplePureComponent.propTypes = {
    */
   groupFormatter: PropTypes.func,
   /**
-   * 	Hides icon when displays empty symbol
+   * 	Hides the empty icon on right Grid (Selected list). Given emptySvgSymbol and hideIcon together, the empty symbol will be only displayed on the left grid.
    */
   hideIcon: PropTypes.bool,
   /**

--- a/src/components/TreePicker/index.spec.jsx
+++ b/src/components/TreePicker/index.spec.jsx
@@ -53,6 +53,20 @@ describe('<TreePicker />', () => {
     expect(rightSplitPane).toContainElement(queryAllByTestId('flexible-spacer-wrapper')[1]);
   });
 
+  it('should render empty text as expected', () => {
+    const newProps = _.assign({}, props, { subtree: [] });
+
+    const { getByText, queryAllByText, rerender } = render(<TreePickerSimplePure {...newProps} />);
+
+    expect(queryAllByText('Begin searching.')).toHaveLength(1);
+    expect(getByText('Begin searching.')).toHaveClass('empty-component-text');
+
+    rerender(<TreePickerSimplePure {...newProps} searchValue="keyword" />);
+    expect(queryAllByText('Begin searching.')).toHaveLength(0);
+    expect(queryAllByText('No items to select.')).toHaveLength(1);
+    expect(getByText('No items to select.')).toHaveClass('empty-component-text');
+  });
+
   it('should have disabled class included when disabled set to true', () => {
     const { getByTestId } = render(<TreePickerSimplePure disabled {...props} />);
     expect(getByTestId('treepicker-wrapper')).toHaveClass('treepickersimplepure-component disabled');

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -5056,14 +5056,14 @@
             "name": "node"
           },
           "required": false,
-          "description": "Displays this svg symbol when there will be no item on both left or right Grid"
+          "description": "The svg symbol used when there will be no item on both left or right Grid"
         },
         "emptySelectedListSvgSymbol": {
           "type": {
             "name": "node"
           },
           "required": false,
-          "description": "Displays this svg symbol when there will be no item on right Grid(Selected list)"
+          "description": "The svg symbol used when there will be no item on right Grid (Selected list)"
         },
         "emptyText": {
           "type": {
@@ -5098,7 +5098,7 @@
             "name": "bool"
           },
           "required": false,
-          "description": "Hides icon when displays empty symbol"
+          "description": "Hides the empty icon on right Grid (Selected list). Given emptySvgSymbol and hideIcon together, the empty symbol will be only displayed on the left grid."
         },
         "includeNode": {
           "type": {

--- a/www/examples/TreePicker.mdx
+++ b/www/examples/TreePicker.mdx
@@ -69,6 +69,13 @@ const Example = () => {
         hideIcon
         selectedNodes={getSelectedNodes()}
         subtree={getSubtree()}
+        emptySvgSymbol={
+          <SvgSymbol
+            classSuffixes={['gray-darker', '70']}
+            href="./assets/svg-symbols.svg#checklist-incomplete"
+            isCircle
+          />
+        }
         emptySelectedListText={
           <div>
             <b>Choose items of interest</b>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
- `<Empty />` doesn't have the `hideIcon` prop, so use the internal attribute `emptySvgIcon` to address this bug.

- Add test coverage to reach 100%.

- fix README to test a single file.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
