### PR TITLE
feat: add divider prop to breadcrumb component

### DIFF
--- a/src/components/Breadcrumb/Node/index.jsx
+++ b/src/components/Breadcrumb/Node/index.jsx
@@ -1,26 +1,21 @@
+import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import './styles.scss';
 
 const BreadcrumbNode = ({ isLast, node, onClick }) => {
-  const baseClass = 'breadcrumbnode-component';
-  if (isLast) {
-    return (
-      <span data-testid="breadcrumb-node-wrapper" className={baseClass}>
-        {node.label}
-      </span>
-    );
-  }
+  const className = classnames('aui--breadcrumb-node', { 'aui--breadcrumb-node-link': !isLast });
 
-  const onClickNode = () => onClick(node.id);
+  const onClickNode = () => {
+    if (!isLast) onClick(node.id);
+  };
+
   return (
-    <span data-testid="breadcrumb-node-wrapper" className={`${baseClass} ${baseClass}-link`} onClick={onClickNode}>
+    <div data-testid="breadcrumb-node-wrapper" className={className} onClick={onClickNode}>
       {node.label}
-    </span>
+    </div>
   );
 };
-
-BreadcrumbNode.displayName = 'BreadcrumbNodeComponent';
 
 BreadcrumbNode.propTypes = {
   isLast: PropTypes.bool.isRequired,

--- a/src/components/Breadcrumb/Node/index.spec.jsx
+++ b/src/components/Breadcrumb/Node/index.spec.jsx
@@ -17,9 +17,7 @@ describe('<BreadcrumbNode />', () => {
     const props = { isLast: false, onClick, node };
     const { getByTestId } = render(<BreadcrumbNode {...props} />);
 
-    expect(getByTestId('breadcrumb-node-wrapper')).toHaveClass(
-      'breadcrumbnode-component breadcrumbnode-component-link'
-    );
+    expect(getByTestId('breadcrumb-node-wrapper')).toHaveClass('aui--breadcrumb-node aui--breadcrumb-node-link');
     expect(getByTestId('breadcrumb-node-wrapper')).toHaveTextContent('Canada');
   });
 
@@ -27,7 +25,7 @@ describe('<BreadcrumbNode />', () => {
     const props = { isLast: true, onClick, node };
     const { getByTestId } = render(<BreadcrumbNode {...props} />);
 
-    expect(getByTestId('breadcrumb-node-wrapper')).toHaveClass('breadcrumbnode-component');
+    expect(getByTestId('breadcrumb-node-wrapper')).toHaveClass('aui--breadcrumb-node');
     expect(getByTestId('breadcrumb-node-wrapper')).toHaveTextContent('Canada');
     fireEvent.click(getByTestId('breadcrumb-node-wrapper'));
     expect(onClick).toHaveBeenCalledTimes(0);
@@ -37,9 +35,7 @@ describe('<BreadcrumbNode />', () => {
     const props = { isLast: false, onClick: onClick, node };
     const { getByTestId } = render(<BreadcrumbNode {...props} />);
 
-    expect(getByTestId('breadcrumb-node-wrapper')).toHaveClass(
-      'breadcrumbnode-component breadcrumbnode-component-link'
-    );
+    expect(getByTestId('breadcrumb-node-wrapper')).toHaveClass('aui--breadcrumb-node aui--breadcrumb-node-link');
     expect(getByTestId('breadcrumb-node-wrapper')).toHaveTextContent(node.label);
 
     fireEvent.click(getByTestId('breadcrumb-node-wrapper'));

--- a/src/components/Breadcrumb/Node/styles.scss
+++ b/src/components/Breadcrumb/Node/styles.scss
@@ -1,6 +1,6 @@
 @import '~styles/color';
 
-.breadcrumbnode-component {
+.aui--breadcrumb-node {
   &-link {
     cursor: pointer;
 

--- a/src/components/Breadcrumb/index.jsx
+++ b/src/components/Breadcrumb/index.jsx
@@ -5,9 +5,9 @@ import PropTypes from 'prop-types';
 import BreadcrumbNode from './Node';
 import './styles.scss';
 
-const Breadcrumb = ({ rootNode, nodes, onClick, disabled }) => {
-  const baseClass = 'breadcrumb-component';
-  const className = classnames([baseClass, { [`${baseClass}--disabled`]: disabled }]);
+const Breadcrumb = ({ rootNode, divider, nodes, onClick, disabled }) => {
+  const baseClass = 'aui--breadcrumb';
+  const className = classnames(baseClass, { [`${baseClass}--disabled`]: disabled });
   const onClickFunc = newActiveId => !disabled && onClick(newActiveId);
 
   if (nodes.length === 0) {
@@ -18,28 +18,28 @@ const Breadcrumb = ({ rootNode, nodes, onClick, disabled }) => {
     <div data-testid="breadcrumb-wrapper" className={className}>
       <BreadcrumbNode isLast={false} node={rootNode} onClick={onClickFunc} />
       {_.map(nodes, (node, index) => (
-        <span data-testid="breadcrumb-node" className={`${baseClass}-node`} key={node.id}>
-          <span data-testid="breadcrumb-node-divider" className={`${baseClass}-node-divider`}>
-            {' '}
-            &gt;{' '}
-          </span>
+        <React.Fragment key={node.id}>
+          <div data-testid="breadcrumb-node-divider" className={`${baseClass}-node-divider`}>
+            {divider}
+          </div>
           <BreadcrumbNode isLast={index === nodes.length - 1} node={node} onClick={onClickFunc} />
-        </span>
+        </React.Fragment>
       ))}
     </div>
   );
 };
 
-Breadcrumb.displayName = 'BreadcrumbComponent';
-
 Breadcrumb.propTypes = {
   rootNode: BreadcrumbNode.propTypes.node,
+  divider: PropTypes.node,
   nodes: PropTypes.arrayOf(BreadcrumbNode.propTypes.node),
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
 };
+
 Breadcrumb.defaultProps = {
   rootNode: { id: 'all', label: 'All' },
+  divider: '>',
   nodes: [],
   onClick: newActiveId => {
     throw new Error(`Breadcrumb needs an onClick handler to take ${newActiveId}`);

--- a/src/components/Breadcrumb/index.spec.jsx
+++ b/src/components/Breadcrumb/index.spec.jsx
@@ -14,31 +14,28 @@ describe('<Breadcrumb />', () => {
   it('should render empty with the component className when no nodes', () => {
     const { getByTestId, queryAllByTestId } = render(<Breadcrumb />);
 
-    expect(getByTestId('breadcrumb-wrapper')).toHaveClass('breadcrumb-component');
-    expect(getByTestId('breadcrumb-wrapper')).not.toHaveClass('disabled');
+    expect(getByTestId('breadcrumb-wrapper')).toHaveClass('aui--breadcrumb');
+    expect(getByTestId('breadcrumb-wrapper')).not.toHaveClass('aui--breadcrumb--disabled');
     expect(queryAllByTestId('breadcrumb-node-wrapper')).toHaveLength(0);
   });
 
   it('should render nodes', () => {
-    const { getByTestId, queryAllByTestId } = render(<Breadcrumb nodes={nodes} />);
+    const { getByTestId, queryAllByTestId } = render(<Breadcrumb nodes={nodes} divider="/" />);
 
-    expect(getByTestId('breadcrumb-wrapper')).toHaveClass('breadcrumb-component');
-    expect(getByTestId('breadcrumb-wrapper')).not.toHaveClass('disabled');
+    expect(getByTestId('breadcrumb-wrapper')).toHaveClass('aui--breadcrumb');
+    expect(getByTestId('breadcrumb-wrapper')).not.toHaveClass('aui--breadcrumb--disabled');
     expect(queryAllByTestId('breadcrumb-node-wrapper')).toHaveLength(4);
     expect(queryAllByTestId('breadcrumb-node-wrapper')[0]).toHaveTextContent('All');
 
-    expect(queryAllByTestId('breadcrumb-node')).toHaveLength(nodes.length);
-    queryAllByTestId('breadcrumb-node').forEach(node => expect(node).toHaveClass('breadcrumb-component-node'));
-
     expect(queryAllByTestId('breadcrumb-node-divider')).toHaveLength(nodes.length);
     queryAllByTestId('breadcrumb-node-divider').forEach(node =>
-      expect(node).toHaveTextContent(' > ', { normalizeSpaces: false })
+      expect(node).toHaveTextContent('/', { normalizeSpaces: false })
     );
 
     queryAllByTestId('breadcrumb-node-wrapper').forEach((node, index) => {
-      expect(node).toHaveClass('breadcrumbnode-component');
-      if (index === nodes.length) expect(node).not.toHaveClass('breadcrumbnode-component-link');
-      if (index !== nodes.length) expect(node).toHaveClass('breadcrumbnode-component-link');
+      expect(node).toHaveClass('aui--breadcrumb-node');
+      if (index === nodes.length) expect(node).not.toHaveClass('aui--breadcrumb-node-link');
+      if (index !== nodes.length) expect(node).toHaveClass('aui--breadcrumb-node-link');
     });
   });
 
@@ -68,7 +65,7 @@ describe('<Breadcrumb />', () => {
 
     it('should have disabled class', () => {
       const { getByTestId } = render(<Breadcrumb {...props} />);
-      expect(getByTestId('breadcrumb-wrapper')).toHaveClass('breadcrumb-component--disabled');
+      expect(getByTestId('breadcrumb-wrapper')).toHaveClass('aui--breadcrumb--disabled');
     });
 
     it('should not have any breadcrumb node', () => {

--- a/src/components/Breadcrumb/styles.scss
+++ b/src/components/Breadcrumb/styles.scss
@@ -1,25 +1,22 @@
 @import '~styles/color';
 @import '~styles/font-size';
 
-.breadcrumb-component {
+.aui--breadcrumb {
   $breadcrumb-height: 10px;
+
   color: $color-link;
   cursor: default;
   font-size: $font-size-body;
   height: $breadcrumb-height;
   line-height: $breadcrumb-height;
+  display: flex;
 
-  &-link {
-    cursor: pointer;
-
-    &:hover,
-    &:active {
-      color: $color-link-hover;
-      text-decoration: underline;
-    }
+  .aui--breadcrumb-node-divider {
+    margin-left: 2px;
+    margin-right: 2px;
   }
 
-  &.breadcrumb-component--disabled {
+  &.aui--breadcrumb--disabled {
     color: $color-text-disabled;
     pointer-events: none;
   }

--- a/src/components/TreePicker/Nav/styles.scss
+++ b/src/components/TreePicker/Nav/styles.scss
@@ -9,7 +9,7 @@
     margin-top: 10px;
   }
 
-  > .breadcrumb-component {
+  > .aui--breadcrumb {
     padding-left: 2px;
   }
 }

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -485,7 +485,7 @@
   "src/components/Breadcrumb/index.jsx": [
     {
       "description": "",
-      "displayName": "BreadcrumbComponent",
+      "displayName": "Breadcrumb",
       "methods": [],
       "props": {
         "rootNode": {
@@ -497,6 +497,17 @@
           "description": "",
           "defaultValue": {
             "value": "{ id: 'all', label: 'All' }",
+            "computed": false
+          }
+        },
+        "divider": {
+          "type": {
+            "name": "node"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "'>'",
             "computed": false
           }
         },
@@ -542,7 +553,7 @@
   "src/components/Breadcrumb/Node/index.jsx": [
     {
       "description": "",
-      "displayName": "BreadcrumbNodeComponent",
+      "displayName": "BreadcrumbNode",
       "methods": [],
       "props": {
         "isLast": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Add `divider` prop to Breadcrumb component
- Shuffle the internal structure of the Breadcrumb component

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Allow user to manipulate the divider symbol. Currently it is locked to `>`, now we can change it to anything if needed.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->
- This PR may require updates on styles in other libraries.

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
