### PR TITLE
chore: fix displayName issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23792,6 +23792,32 @@
         }
       }
     },
+    "react-docgen-displayname-handler": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-docgen-displayname-handler/-/react-docgen-displayname-handler-3.0.2.tgz",
+      "integrity": "sha512-6SDJ2h6WuW0Kq6Vw34C3WmRfh1eYNDkaes9hxsmQ4fmX5tiI2lpR28J2cxlu4RpYrqBLrrtke6kWBef7pIL24w==",
+      "dev": true,
+      "requires": {
+        "ast-types": "0.14.2"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.14.2",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+          "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+          "dev": true
+        }
+      }
+    },
     "react-dom": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "react-datepicker": "github:Adslot/react-datepicker#2a1ebb8618e1996c321331ef01d290424272d126",
     "react-dev-utils": "^10.2.1",
     "react-docgen": "^5.0.0",
+    "react-docgen-displayname-handler": "^3.0.2",
     "react-html-parser": "^2.0.2",
     "react-live": "^2.2.2",
     "react-redux": "^7.1.0",

--- a/scripts/generateDocs.js
+++ b/scripts/generateDocs.js
@@ -3,7 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 const reactDocgen = require('react-docgen');
+const displayNameHandler = require('react-docgen-displayname-handler').default;
 const glob = require('glob');
+
+const handlers = reactDocgen.defaultHandlers.concat(displayNameHandler);
 
 const sourcePath = path.join(__dirname, '..');
 const filesToIgnore = ['fastStatelessWrapper', 'mocks.jsx', 'spec.jsx', 'BlockStyleButtons', 'InlineStyleButtons'];
@@ -20,7 +23,8 @@ const outputFilePath = path.join(__dirname, '../www/containers/props.json');
     try {
       result[filePath] = reactDocgen.parse(
         fs.readFileSync(absolutePath),
-        reactDocgen.resolver.findAllComponentDefinitions
+        reactDocgen.resolver.findAllComponentDefinitions,
+        handlers
       );
     } catch (err) {
       // Check: https://github.com/reactjs/react-docgen/issues/336

--- a/src/components/ActionPanel/index.jsx
+++ b/src/components/ActionPanel/index.jsx
@@ -59,8 +59,6 @@ const ActionPanel = React.forwardRef((props, ref) => {
   return isModal ? ReactDOM.createPortal(actionPanel, document.body) : actionPanel;
 });
 
-ActionPanel.displayName = 'ActionPanel';
-
 ActionPanel.propTypes = {
   title: PropTypes.node.isRequired,
   className: PropTypes.string,

--- a/src/components/Alert/index.jsx
+++ b/src/components/Alert/index.jsx
@@ -9,8 +9,6 @@ const Alert = ({ type, children, dts }) => (
   </div>
 );
 
-Alert.displayName = 'AlertComponent';
-
 Alert.propTypes = {
   /**
    * ['success', 'info', 'warning', 'danger']

--- a/src/components/Avatar/index.jsx
+++ b/src/components/Avatar/index.jsx
@@ -18,8 +18,6 @@ const Avatar = ({ color, givenName, tooltip, image, surname }) => (
   </div>
 );
 
-Avatar.displayName = 'AvatarComponent';
-
 Avatar.propTypes = {
   /**
    * PropTypes.oneOf(['blue', 'green', 'red', 'orange', 'cyan'])

--- a/src/components/BorderedWell/index.jsx
+++ b/src/components/BorderedWell/index.jsx
@@ -8,8 +8,6 @@ const BorderedWell = ({ children }) => (
   </div>
 );
 
-BorderedWell.displayName = 'BorderedWellComponent';
-
 BorderedWell.propTypes = {
   children: PropTypes.node,
 };

--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -14,8 +14,6 @@ const CardContent = ({ children, className, stretch, fill, append, dts }) => {
   );
 };
 
-CardContent.displayName = 'CardContentComponent';
-
 CardContent.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
@@ -51,8 +49,6 @@ const Card = ({ children, className, accent, dts }) => {
     </div>
   );
 };
-
-Card.displayName = 'CardComponent';
 
 Card.propTypes = {
   /**

--- a/src/components/ConfirmModal/index.jsx
+++ b/src/components/ConfirmModal/index.jsx
@@ -61,8 +61,6 @@ const ConfirmModalComponent = ({
   );
 };
 
-ConfirmModalComponent.displayName = 'ConfirmModalComponent';
-
 ConfirmModalComponent.propTypes = {
   /**
    * determines the label of cancel button

--- a/src/components/Empty/index.jsx
+++ b/src/components/Empty/index.jsx
@@ -18,8 +18,6 @@ const Empty = ({ collection, text, icon }) => {
   return <div data-testid="empty-wrapper" />;
 };
 
-Empty.displayName = 'EmptyComponent';
-
 Empty.propTypes = {
   collection: PropTypes.oneOfType([PropTypes.node, PropTypes.array, PropTypes.object]),
   text: PropTypes.node, // can be string or, if you want rich formatting, a node

--- a/src/components/FlexibleSpacer/index.jsx
+++ b/src/components/FlexibleSpacer/index.jsx
@@ -3,6 +3,4 @@ import './styles.scss';
 
 const FlexibleSpacer = () => <div data-testid="flexible-spacer-wrapper" className="flexible-spacer-component" />;
 
-FlexibleSpacer.displayName = 'FlexibleSpacerComponent';
-
 export default FlexibleSpacer;

--- a/src/components/FormGroup/index.jsx
+++ b/src/components/FormGroup/index.jsx
@@ -32,8 +32,6 @@ const FormGroupComponent = ({ addon, disabled, helpText, label, onChange, placeh
   );
 };
 
-FormGroupComponent.displayName = 'FormGroupComponent';
-
 FormGroupComponent.propTypes = {
   addon: PropTypes.string,
   disabled: PropTypes.bool,

--- a/src/components/Grid/Cell/index.jsx
+++ b/src/components/Grid/Cell/index.jsx
@@ -24,8 +24,6 @@ const GridCell = ({ children, classSuffixes, onClick, stretch, dts, addonClassNa
   );
 };
 
-GridCell.displayName = 'GridCellComponent';
-
 GridCell.propTypes = {
   /**
    * list of addOn classNames as array of strings

--- a/src/components/Grid/Row/index.jsx
+++ b/src/components/Grid/Row/index.jsx
@@ -18,8 +18,6 @@ const GridRow = ({ horizontalBorder, short, type, verticalCellBorder, children, 
   );
 };
 
-GridRow.displayName = 'GridRowComponent';
-
 GridRow.propTypes = {
   /**
    * the children to be rendered

--- a/src/components/Grid/index.jsx
+++ b/src/components/Grid/index.jsx
@@ -9,7 +9,6 @@ const Grid = ({ children, dts }) => (
   </div>
 );
 
-Grid.displayName = 'GridComponent';
 Grid.propTypes = {
   /**
    * the children to be rendered

--- a/src/components/ImageCropper/index.jsx
+++ b/src/components/ImageCropper/index.jsx
@@ -78,6 +78,4 @@ ImageCropper.defaultProps = {
   isSaving: false,
 };
 
-ImageCropper.displayName = 'ImageCropper';
-
 export default ImageCropper;

--- a/src/components/ListPicker/index.jsx
+++ b/src/components/ListPicker/index.jsx
@@ -177,8 +177,6 @@ class ListPickerComponent extends React.PureComponent {
   }
 }
 
-ListPickerComponent.displayName = 'ListPickerComponent';
-
 const itemProps = PropTypes.shape({
   id: PropTypes.number.isRequired,
 });

--- a/src/components/ListPickerPure/index.jsx
+++ b/src/components/ListPickerPure/index.jsx
@@ -109,8 +109,6 @@ class ListPickerPureComponent extends React.PureComponent {
   }
 }
 
-ListPickerPureComponent.displayName = 'ListPickerPureComponent';
-
 const itemProps = PropTypes.shape({
   id: PropTypes.any.isRequired, // id can be numeric or uuid string
 });

--- a/src/components/PageTitle/index.jsx
+++ b/src/components/PageTitle/index.jsx
@@ -24,8 +24,6 @@ const PageTitle = ({ children, isFooter, title }) => {
   );
 };
 
-PageTitle.displayName = 'PageTitleComponent';
-
 PageTitle.propTypes = {
   children: PropTypes.node,
   isFooter: PropTypes.bool,

--- a/src/components/PrettyDiff/index.jsx
+++ b/src/components/PrettyDiff/index.jsx
@@ -30,8 +30,6 @@ const PrettyDiff = ({ newText, oldText }) => {
   );
 };
 
-PrettyDiff.displayName = 'PrettyDiffComponent';
-
 PrettyDiff.propTypes = {
   newText: PropTypes.string,
   oldText: PropTypes.string,

--- a/src/components/Slicey/Arc/index.jsx
+++ b/src/components/Slicey/Arc/index.jsx
@@ -14,8 +14,6 @@ const Arc = ({ data }) => {
   );
 };
 
-Arc.displayName = 'SliceyArcComponent';
-
 Arc.propTypes = {
   data: PropTypes.shape({
     label: PropTypes.string.isRequired,

--- a/src/components/Slicey/Donut/index.jsx
+++ b/src/components/Slicey/Donut/index.jsx
@@ -3,6 +3,4 @@ import './styles.scss';
 
 const Donut = () => <circle data-testid="slicey-donut-wrapper" className="donut-component" r=".45" cx="0" cy="0" />;
 
-Donut.displayName = 'SliceyDonutComponent';
-
 export default Donut;

--- a/src/components/Slicey/Marker/index.jsx
+++ b/src/components/Slicey/Marker/index.jsx
@@ -14,8 +14,6 @@ const Marker = ({ fraction }) => {
   );
 };
 
-Marker.displayName = 'SliceyMarkerComponent';
-
 Marker.propTypes = {
   fraction: PropTypes.number,
 };

--- a/src/components/Slicey/index.jsx
+++ b/src/components/Slicey/index.jsx
@@ -84,8 +84,6 @@ const Slicey = ({ dataset, diameter, donut, marker }) => {
   );
 };
 
-Slicey.displayName = 'SliceyComponent';
-
 Slicey.propTypes = {
   /**
    * Slicey will represent all values as percentage of the pie based on the sum of all values.

--- a/src/components/SplitPane/index.jsx
+++ b/src/components/SplitPane/index.jsx
@@ -14,8 +14,6 @@ const SplitPaneComponent = ({ children, dts, additionalClassNames }) => {
   );
 };
 
-SplitPaneComponent.displayName = 'SplitPaneComponent';
-
 SplitPaneComponent.propTypes = {
   additionalClassNames: PropTypes.arrayOf(PropTypes.string),
   children: PropTypes.node,

--- a/src/components/Statistic/index.jsx
+++ b/src/components/Statistic/index.jsx
@@ -19,8 +19,6 @@ const Statistic = ({ label, value, inline }) => {
   );
 };
 
-Statistic.displayName = 'StatisticComponent';
-
 Statistic.propTypes = {
   /**
    * 	Horizontal layout as opposed to stacked.

--- a/src/components/SvgSymbol/index.jsx
+++ b/src/components/SvgSymbol/index.jsx
@@ -46,8 +46,6 @@ const SvgSymbol = props => {
   );
 };
 
-SvgSymbol.displayName = 'SvgSymbolComponent';
-
 SvgSymbol.propTypes = {
   classSuffixes: PropTypes.arrayOf(PropTypes.string.isRequired),
   /**

--- a/src/components/Tag/index.jsx
+++ b/src/components/Tag/index.jsx
@@ -41,8 +41,6 @@ const Tag = ({ children, inverse, id, onAction, accent, baseClass, actionIcon, d
   );
 };
 
-Tag.displayName = 'TagComponent';
-
 Tag.propTypes = {
   children: PropTypes.node.isRequired,
   id: PropTypes.string,

--- a/src/components/Tile/index.jsx
+++ b/src/components/Tile/index.jsx
@@ -39,6 +39,4 @@ Tile.propTypes = {
   dts: PropTypes.string,
 };
 
-Tile.displayName = 'TileComponent';
-
 export default Tile;

--- a/src/components/TileGrid/index.jsx
+++ b/src/components/TileGrid/index.jsx
@@ -94,6 +94,4 @@ TileGrid.propTypes = {
   distributed: PropTypes.bool,
 };
 
-TileGrid.displayName = 'TileGridComponent';
-
 export default TileGrid;

--- a/src/components/Totals/index.jsx
+++ b/src/components/Totals/index.jsx
@@ -24,8 +24,6 @@ const Totals = ({ toSum, valueFormatter }) => (
   </Grid>
 );
 
-Totals.displayName = 'TotalsComponent';
-
 Totals.propTypes = {
   /**
    * { label: PropTypes.node, value: PropTypes.number.isRequired, isHidden: PropTypes.bool }

--- a/src/components/TreePicker/Grid/index.jsx
+++ b/src/components/TreePicker/Grid/index.jsx
@@ -72,8 +72,6 @@ const TreePickerGridComponent = ({
   );
 };
 
-TreePickerGridComponent.displayName = 'TreePickerGridComponent';
-
 TreePickerGridComponent.propTypes = {
   disabled: PropTypes.bool,
   emptySvgSymbol: PropTypes.node,

--- a/src/components/TreePicker/Nav/index.jsx
+++ b/src/components/TreePicker/Nav/index.jsx
@@ -57,7 +57,6 @@ const TreePickerNavComponent = ({
   );
 };
 
-TreePickerNavComponent.displayName = 'TreePickerNavComponent';
 TreePickerNavComponent.propTypes = {
   breadcrumbRootNode: TreePickerPropTypes.breadCrumbNode,
   breadcrumbNodes: PropTypes.arrayOf(TreePickerPropTypes.breadCrumbNode),

--- a/src/components/TreePicker/Node/index.jsx
+++ b/src/components/TreePicker/Node/index.jsx
@@ -115,8 +115,6 @@ class TreePickerNodeComponent extends React.PureComponent {
   }
 }
 
-TreePickerNodeComponent.displayName = 'TreePickerNodeComponent';
-
 TreePickerNodeComponent.propTypes = {
   disabled: PropTypes.bool,
   expandNode: PropTypes.func,

--- a/src/components/TreePicker/index.jsx
+++ b/src/components/TreePicker/index.jsx
@@ -127,8 +127,6 @@ const TreePickerSimplePureComponent = ({
   );
 };
 
-TreePickerSimplePureComponent.displayName = 'TreePickerSimplePureComponent';
-
 TreePickerSimplePureComponent.propTypes = {
   /**
    * 	Class Names for SplitPane component

--- a/src/components/UserListPicker/index.jsx
+++ b/src/components/UserListPicker/index.jsx
@@ -48,8 +48,6 @@ const UserListPickerComponent = ({
   );
 };
 
-UserListPickerComponent.displayName = 'ListPickerComponent';
-
 const userType = PropTypes.shape({
   avatar: PropTypes.string,
   givenName: PropTypes.string,

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -103,8 +103,8 @@
   "src/components/ActionPanel/index.jsx": [
     {
       "description": "",
-      "displayName": "ActionPanel",
       "methods": [],
+      "displayName": "ActionPanel",
       "props": {
         "title": {
           "type": {
@@ -198,7 +198,7 @@
   "src/components/Alert/index.jsx": [
     {
       "description": "",
-      "displayName": "AlertComponent",
+      "displayName": "Alert",
       "methods": [],
       "props": {
         "type": {
@@ -403,7 +403,7 @@
   "src/components/Avatar/index.jsx": [
     {
       "description": "",
-      "displayName": "AvatarComponent",
+      "displayName": "Avatar",
       "methods": [],
       "props": {
         "color": {
@@ -469,7 +469,7 @@
   "src/components/BorderedWell/index.jsx": [
     {
       "description": "",
-      "displayName": "BorderedWellComponent",
+      "displayName": "BorderedWell",
       "methods": [],
       "props": {
         "children": {
@@ -778,7 +778,7 @@
   "src/components/Card/index.jsx": [
     {
       "description": "",
-      "displayName": "CardContentComponent",
+      "displayName": "CardContent",
       "methods": [],
       "props": {
         "children": {
@@ -839,7 +839,7 @@
     },
     {
       "description": "",
-      "displayName": "CardComponent",
+      "displayName": "Card",
       "methods": [],
       "props": {
         "children": {
@@ -877,6 +877,7 @@
     {
       "description": "",
       "methods": [],
+      "displayName": "CarouselComponent",
       "props": {
         "className": {
           "type": {
@@ -1297,7 +1298,7 @@
   "src/components/Empty/index.jsx": [
     {
       "description": "",
-      "displayName": "EmptyComponent",
+      "displayName": "Empty",
       "methods": [],
       "props": {
         "collection": {
@@ -1450,7 +1451,7 @@
   "src/components/FlexibleSpacer/index.jsx": [
     {
       "description": "",
-      "displayName": "FlexibleSpacerComponent",
+      "displayName": "FlexibleSpacer",
       "methods": []
     }
   ],
@@ -1523,7 +1524,7 @@
   "src/components/Grid/Cell/index.jsx": [
     {
       "description": "",
-      "displayName": "GridCellComponent",
+      "displayName": "GridCell",
       "methods": [],
       "props": {
         "addonClassNames": {
@@ -1592,7 +1593,7 @@
   "src/components/Grid/index.jsx": [
     {
       "description": "",
-      "displayName": "GridComponent",
+      "displayName": "Grid",
       "methods": [],
       "props": {
         "children": {
@@ -1615,7 +1616,7 @@
   "src/components/Grid/Row/index.jsx": [
     {
       "description": "",
-      "displayName": "GridRowComponent",
+      "displayName": "GridRow",
       "methods": [],
       "props": {
         "children": {
@@ -1874,8 +1875,8 @@
   "src/components/ImageCropper/index.jsx": [
     {
       "description": "",
-      "displayName": "ImageCropper",
       "methods": [],
+      "displayName": "ImageCropper",
       "props": {
         "title": {
           "type": {
@@ -2781,7 +2782,7 @@
   "src/components/PageTitle/index.jsx": [
     {
       "description": "",
-      "displayName": "PageTitleComponent",
+      "displayName": "PageTitle",
       "methods": [],
       "props": {
         "children": {
@@ -3374,7 +3375,7 @@
   "src/components/PrettyDiff/index.jsx": [
     {
       "description": "",
-      "displayName": "PrettyDiffComponent",
+      "displayName": "PrettyDiff",
       "methods": [],
       "props": {
         "newText": {
@@ -3677,6 +3678,7 @@
     {
       "description": "",
       "methods": [],
+      "displayName": "Search",
       "props": {
         "className": {
           "type": {
@@ -3918,7 +3920,7 @@
   "src/components/Slicey/Arc/index.jsx": [
     {
       "description": "",
-      "displayName": "SliceyArcComponent",
+      "displayName": "Arc",
       "methods": [],
       "props": {
         "data": {
@@ -3964,7 +3966,7 @@
   "src/components/Slicey/Donut/index.jsx": [
     {
       "description": "",
-      "displayName": "SliceyDonutComponent",
+      "displayName": "Donut",
       "methods": []
     }
   ],
@@ -3976,7 +3978,7 @@
     },
     {
       "description": "",
-      "displayName": "SliceyComponent",
+      "displayName": "Slicey",
       "methods": [],
       "props": {
         "dataset": {
@@ -4030,7 +4032,7 @@
   "src/components/Slicey/Marker/index.jsx": [
     {
       "description": "",
-      "displayName": "SliceyMarkerComponent",
+      "displayName": "Marker",
       "methods": [],
       "props": {
         "fraction": {
@@ -4132,7 +4134,7 @@
   "src/components/Statistic/index.jsx": [
     {
       "description": "",
-      "displayName": "StatisticComponent",
+      "displayName": "Statistic",
       "methods": [],
       "props": {
         "inline": {
@@ -4233,7 +4235,7 @@
   "src/components/SvgSymbol/index.jsx": [
     {
       "description": "",
-      "displayName": "SvgSymbolComponent",
+      "displayName": "SvgSymbol",
       "methods": [],
       "props": {
         "classSuffixes": {
@@ -4546,7 +4548,7 @@
     },
     {
       "description": "",
-      "displayName": "TagComponent",
+      "displayName": "Tag",
       "methods": [],
       "props": {
         "children": {
@@ -4703,7 +4705,7 @@
   "src/components/Tile/index.jsx": [
     {
       "description": "",
-      "displayName": "TileComponent",
+      "displayName": "Tile",
       "methods": [],
       "props": {
         "className": {
@@ -4747,7 +4749,7 @@
   "src/components/TileGrid/index.jsx": [
     {
       "description": "",
-      "displayName": "TileGridComponent",
+      "displayName": "TileGrid",
       "methods": [],
       "props": {
         "title": {
@@ -4957,7 +4959,7 @@
   "src/components/Totals/index.jsx": [
     {
       "description": "",
-      "displayName": "TotalsComponent",
+      "displayName": "Totals",
       "methods": [],
       "props": {
         "toSum": {
@@ -5739,7 +5741,7 @@
   "src/components/UserListPicker/index.jsx": [
     {
       "description": "",
-      "displayName": "ListPickerComponent",
+      "displayName": "UserListPickerComponent",
       "methods": [],
       "props": {
         "allowEmptySelection": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
In the past, we had to manage the `displayName` manually for doc generation. Sometimes, `displayName` will disappear accidentally if we change part of the code.

For this issue, introduce a new plugin `react-docgen-displayname-handler`, and it can help us with this one. This library is recently updated and has a decent downloads

![Screen Shot 2020-10-03 at 8 36 23 am](https://user-images.githubusercontent.com/42738416/94974964-882ce480-0553-11eb-8ae8-72fe5992332d.png)

Also, removed redundant `displayName` in each file.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
