### PR TITLE
feat: add showSearchButton prop to Search

### DIFF
--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -6,6 +6,7 @@
   color: $color-gray-dark;
   opacity: .65;
   box-shadow: none;
+  cursor: not-allowed;
 }
 
 @mixin reset-shadow-and-transform {
@@ -78,9 +79,7 @@
     border-color: $color-button-primary-border;
     color: $color-white;
 
-    &.btn-inverse
-
-    &:focus {
+    &.btn-inverse &:focus {
       background-color: $color-button-primary-background;
       border-color: $color-button-primary-border;
       color: $color-white;
@@ -118,6 +117,7 @@
     background-color: $color-button-warning-background;
     border-color: $color-button-warning-border;
     color: $color-white;
+    cursor: not-allowed;
 
     &:focus {
       background-color: $color-button-warning-background;

--- a/src/components/Search/index.jsx
+++ b/src/components/Search/index.jsx
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import Button from '../Button';
 import Spinner from '../Spinner';
 import './styles.scss';
 
@@ -21,6 +22,7 @@ const Search = React.forwardRef(
       placeholder,
       searchOnEnter,
       value,
+      showSearchButton,
     },
     ref
   ) => {
@@ -101,15 +103,22 @@ const Search = React.forwardRef(
           onBlur={onBlur}
         />
         {isLoading && !searchOnEnter && <span className="aui--search-component-spinner">{loaderIcon}</span>}
-        {searchOnEnter && !isValueEmpty && (
-          <span className="aui--search-component-icon with-button" onClick={onInputClear}>
-            {closeIcon}
-          </span>
-        )}
-        {searchOnEnter ? (
-          <button data-testid="search-button" className="aui--search-component-button" onClick={onSearchButtonClick}>
-            {isLoading ? <span>{loaderIcon}</span> : <span>{searchIcon}</span>}
-          </button>
+
+        {searchOnEnter && showSearchButton ? (
+          <>
+            {!isValueEmpty && (
+              <span className="aui--search-component-icon with-button" onClick={onInputClear}>
+                {closeIcon}
+              </span>
+            )}
+            <Button
+              data-testid="search-button"
+              className="aui--button aui--search-component-button"
+              onClick={onSearchButtonClick}
+            >
+              {isLoading ? <span>{loaderIcon}</span> : <span>{searchIcon}</span>}
+            </Button>
+          </>
         ) : (
           <span
             data-testid="search-icon-wrapper"
@@ -160,6 +169,10 @@ Search.propTypes = {
    */
   searchOnEnter: PropTypes.bool,
   value: PropTypes.string,
+  /**
+   * 	Determines whether displaying the search button or not
+   */
+  showSearchButton: PropTypes.bool,
 };
 
 Search.defaultProps = {
@@ -170,6 +183,7 @@ Search.defaultProps = {
   placeholder: '',
   value: '',
   icons: {},
+  showSearchButton: true,
 };
 
 export default Search;

--- a/src/components/Search/index.spec.jsx
+++ b/src/components/Search/index.spec.jsx
@@ -33,7 +33,7 @@ describe('<Search />', () => {
     expect(getByTestId('search-icon')).toHaveClass('search-icon');
   });
 
-  it('should render search button if searchOnEnter is true', () => {
+  it('should render a search button if searchOnEnter and showSearchButton are true', () => {
     const { queryAllByTestId, getByTestId } = render(<Search onSearch={props.onSearch} searchOnEnter />);
     expect(queryAllByTestId('search-button')).toHaveLength(1);
     expect(queryAllByTestId('search-icon')).toHaveLength(1);
@@ -41,7 +41,7 @@ describe('<Search />', () => {
     expect(getByTestId('search-icon')).toHaveClass('search-icon');
   });
 
-  it('should render search button if searchOnEnter and isLoading are true', () => {
+  it('should render a spinner if searchOnEnter and isLoading are true', () => {
     const { queryAllByTestId, getByTestId } = render(<Search onSearch={props.onSearch} searchOnEnter isLoading />);
     expect(queryAllByTestId('search-button')).toHaveLength(1);
     expect(queryAllByTestId('search-icon')).toHaveLength(0);

--- a/src/components/Search/styles.scss
+++ b/src/components/Search/styles.scss
@@ -24,7 +24,7 @@
       border-color: $color-border;
       outline: 0;
 
-      &~.aui--search-component-button {
+      & ~ .aui--search-component-button {
         border-color: $color-border;
       }
     }
@@ -64,12 +64,14 @@
 
   .aui--search-component-button {
     margin-left: -2px;
+    margin-right: 0;
     border: $border-lighter;
     display: flex;
     justify-content: center;
     align-items: center;
     padding: 2px 7px;
     border-radius: 0 $border-radius $border-radius 0;
+    box-shadow: none;
 
     &:hover {
       background-color: $color-gray-white;

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -3841,6 +3841,17 @@
             "value": "''",
             "computed": false
           }
+        },
+        "showSearchButton": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Determines whether displaying the search button or not",
+          "defaultValue": {
+            "value": "true",
+            "computed": false
+          }
         }
       }
     }

--- a/www/examples/Search.mdx
+++ b/www/examples/Search.mdx
@@ -51,6 +51,15 @@ const Example = () => {
         searchOnEnter
       />
       <br />
+      Search on Enter key pressed without a button
+      <Search
+        placeholder="Search on ENTER"
+        isLoading={searchOnEnterKeyLoading}
+        onSearch={searchOnEnterKey}
+        searchOnEnter
+        showSearchButton={false}
+      />
+      <br />
       Expandable Search Bar
       {searchInput ? (
         <Search


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

Decouple prop 'searchOnEnter' with the enter button, and add a new boolean prop 'showSearchButton' for the button specifically.

*New styles can be used in the marketplace.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):

![Screen Shot 2020-10-11 at 10 21 34 pm](https://user-images.githubusercontent.com/42738416/95677288-2f72e100-0c10-11eb-8e70-70f68d8b4055.png)

![Screen Shot 2020-10-11 at 10 21 23 pm](https://user-images.githubusercontent.com/42738416/95677291-339efe80-0c10-11eb-8eaa-6a4b391f16be.png)

