### PR TITLE
fix: fix carousel incorrect prop

### DIFF
--- a/src/components/Carousel/index.jsx
+++ b/src/components/Carousel/index.jsx
@@ -23,7 +23,7 @@ CarouselComponent.propTypes = {
   children: PropTypes.node,
   autoplay: PropTypes.bool,
   variableWidth: PropTypes.bool,
-  autoplayInterval: PropTypes.number,
+  autoplaySpeed: PropTypes.number,
   slidesToShow: PropTypes.number,
   dots: PropTypes.bool,
 };
@@ -31,7 +31,7 @@ CarouselComponent.propTypes = {
 CarouselComponent.defaultProps = {
   autoplay: true,
   variableWidth: true,
-  autoplayInterval: 10000,
+  autoplaySpeed: 10000,
   slidesToShow: 2,
   dots: true,
 };

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -919,7 +919,7 @@
             "computed": false
           }
         },
-        "autoplayInterval": {
+        "autoplaySpeed": {
           "type": {
             "name": "number"
           },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix Carousel incorrect prop

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
According to the API https://react-slick.neostack.com/docs/example/auto-play, there is no `autoplayInterval`, but only `autoplaySpeed`, which is the prop that we need.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
