### PR TITLE
feat: enable button to support href

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -9,7 +9,7 @@ import { expandDts } from '../../lib/utils';
 import './styles.scss';
 
 const Button = props => {
-  const { bsStyle, bsSize, inverse, size, children, dts, className, isLoading, disabled } = props;
+  const { bsSize, bsStyle, children, className, disabled, dts, href, inverse, isLoading, size } = props;
   const baseClass = 'aui--button';
   const classes = classNames(
     baseClass,
@@ -32,6 +32,15 @@ const Button = props => {
       </div>
     ) : null;
 
+  const renderChildren = () =>
+    href ? (
+      <a data-testid="button-anchor" className="aui--button-anchor" href={href}>
+        {children}
+      </a>
+    ) : (
+      children
+    );
+
   return (
     <button
       data-testid="button-wrapper"
@@ -41,25 +50,31 @@ const Button = props => {
       {..._.omit(props, _.keys(adslotButtonPropTypes))}
     >
       {renderSpinner()}
-      <div className={isLoading ? 'aui--button-children-container' : null}>{children}</div>
+      <div className={classNames('aui--button-children-container', { 'is-loading': isLoading, 'has-anchor': href })}>
+        {renderChildren()}
+      </div>
     </button>
   );
 };
 
 const adslotButtonPropTypes = {
   /**
-   * PropTypes.oneOf(['small', 'large'])
+   * PropTypes.oneOf(['lg', 'large', 'sm', 'small'])
    */
-  size: PropTypes.oneOf(['small', 'large']),
-  inverse: PropTypes.bool,
-  dts: PropTypes.string,
-  isLoading: PropTypes.bool,
+  bsSize: PropTypes.oneOf(['lg', 'large', 'sm', 'small']),
   /**
    * PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link'])
    */
-  bsStyle: PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link']),
-  bsSize: PropTypes.oneOf(['lg', 'large', 'sm', 'small']),
+  bsStyle: PropTypes.oneOf(['default', 'primary', 'success', 'info', 'warning', 'danger', 'link']),
   className: PropTypes.string,
+  dts: PropTypes.string,
+  href: PropTypes.string,
+  inverse: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  /**
+   * PropTypes.oneOf(['small', 'large'])
+   */
+  size: PropTypes.oneOf(['small', 'large']),
 };
 
 Button.propTypes = { ...adslotButtonPropTypes };

--- a/src/components/Button/index.spec.jsx
+++ b/src/components/Button/index.spec.jsx
@@ -11,8 +11,14 @@ describe('<Button />', () => {
   });
 
   it('should support legacy Bootstrap Button props for non-breaking change', () => {
-    const { getByTestId } = render(<Button bsStyle="link">Test</Button>);
+    const { getByTestId } = render(
+      <Button bsStyle="link" href="example.com">
+        Test
+      </Button>
+    );
+
     expect(getByTestId('button-wrapper')).toHaveClass('btn-link');
+    expect(getByTestId('button-anchor')).toHaveAttribute('href', 'example.com');
   });
 
   it('should support legacy classname btn-inverse for non-breaking change', () => {

--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -27,7 +27,7 @@
   vertical-align: middle;
   background-image: none;
   border: 1px solid transparent;
-  padding: 4px 8px;
+  padding: 0;
   font-size: 12px;
   line-height: 1.5;
   border-radius: 2px;
@@ -71,6 +71,13 @@
       color: $color-gray-dark;
       background-color: $color-button-default-hover-background;
       border-color: $color-button-default-hover-border;
+    }
+
+    &:focus {
+      background-color: $color-white;
+      border-color: $color-gray-light;
+      color: $color-gray-dark;
+      outline: none;
     }
   }
 
@@ -163,7 +170,20 @@
   }
 
   &-children-container {
-    visibility: hidden; // preserves width and height of button
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    padding: 4px 8px;
+
+    &.is-loading {
+      visibility: hidden; // preserves width and height of button
+    }
+
+    &.has-anchor {
+      padding: 0;
+    }
   }
 
   &.btn-large {
@@ -193,12 +213,24 @@
     }
   }
 
+  .aui--button-anchor {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    padding: 4px 8px;
+    text-decoration: none;
+    color: inherit;
+  }
+
   .spinner-container {
     position: absolute;
     right: 0;
     left: 0;
     margin-right: auto;
     margin-left: auto;
+    padding: 4px 8px;
 
     // workaround for vertical centering
     .spinner-component {

--- a/src/components/ConfirmModal/__snapshots__/index.spec.jsx.snap
+++ b/src/components/ConfirmModal/__snapshots__/index.spec.jsx.snap
@@ -32,7 +32,9 @@ exports[`<ConfirmModal /> should show modal when \`show\` is true 1`] = `
           data-test-selector="confirm-modal-confirm"
           data-testid="confirm-modal-confirm"
         >
-          <div>
+          <div
+            class="aui--button-children-container"
+          >
             Confirm
           </div>
         </button>

--- a/src/components/ListPicker/index.spec.jsx
+++ b/src/components/ListPicker/index.spec.jsx
@@ -84,9 +84,11 @@ describe('<ListPicker />', () => {
     expect(queryAllByTestId('checkbox-input')[1]).toBeChecked(); // selectedItems
     expect(queryAllByTestId('checkbox-input')[2]).not.toBeChecked();
 
-    expect(getByText('Create User').parentElement).toHaveAttribute('href', '#');
-    expect(getByText('Create User').parentElement).toHaveClass('btn-inverse');
-    expect(getByText('Create User').parentElement.parentElement.parentElement).toHaveClass('modal-footer');
+    expect(getByText('Create User')).toHaveAttribute('href', '#');
+    expect(getByText('Create User').parentElement.parentElement).toHaveClass('btn-inverse');
+    expect(getByText('Create User').parentElement.parentElement.parentElement.parentElement).toHaveClass(
+      'modal-footer'
+    );
 
     expect(getByTestId('listpickerpure-wrapper')).toHaveAttribute(
       'data-test-selector',
@@ -323,8 +325,8 @@ describe('<ListPicker />', () => {
       expect(getByTestId('testing-radio').tagName).toEqual('INPUT');
       expect(getByTestId('testing-radio')).toHaveAttribute('type', 'radio');
 
-      expect(getByText('Create User').parentElement).toHaveClass('btn-inverse');
-      expect(getByText('Create User').parentElement).toHaveAttribute('href', '#');
+      expect(getByText('Create User').parentElement.parentElement).toHaveClass('btn-inverse');
+      expect(getByText('Create User')).toHaveAttribute('href', '#');
     });
   });
 });

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -596,60 +596,39 @@
       "displayName": "Button",
       "methods": [],
       "props": {
-        "size": {
+        "bsSize": {
           "type": {
             "name": "enum",
             "value": [
               {
-                "value": "'small'",
+                "value": "'lg'",
                 "computed": false
               },
               {
                 "value": "'large'",
                 "computed": false
+              },
+              {
+                "value": "'sm'",
+                "computed": false
+              },
+              {
+                "value": "'small'",
+                "computed": false
               }
             ]
           },
           "required": false,
-          "description": "PropTypes.oneOf(['small', 'large'])",
-          "defaultValue": {
-            "value": "'small'",
-            "computed": false
-          }
-        },
-        "inverse": {
-          "type": {
-            "name": "bool"
-          },
-          "required": false,
-          "description": "",
-          "defaultValue": {
-            "value": "false",
-            "computed": false
-          }
-        },
-        "dts": {
-          "type": {
-            "name": "string"
-          },
-          "required": false,
-          "description": ""
-        },
-        "isLoading": {
-          "type": {
-            "name": "bool"
-          },
-          "required": false,
-          "description": "",
-          "defaultValue": {
-            "value": "false",
-            "computed": false
-          }
+          "description": "PropTypes.oneOf(['lg', 'large', 'sm', 'small'])"
         },
         "bsStyle": {
           "type": {
             "name": "enum",
             "value": [
+              {
+                "value": "'default'",
+                "computed": false
+              },
               {
                 "value": "'primary'",
                 "computed": false
@@ -679,37 +658,69 @@
           "required": false,
           "description": "PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link'])"
         },
-        "bsSize": {
-          "type": {
-            "name": "enum",
-            "value": [
-              {
-                "value": "'lg'",
-                "computed": false
-              },
-              {
-                "value": "'large'",
-                "computed": false
-              },
-              {
-                "value": "'sm'",
-                "computed": false
-              },
-              {
-                "value": "'small'",
-                "computed": false
-              }
-            ]
-          },
-          "required": false,
-          "description": ""
-        },
         "className": {
           "type": {
             "name": "string"
           },
           "required": false,
           "description": ""
+        },
+        "dts": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
+        },
+        "href": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
+        },
+        "inverse": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "isLoading": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "size": {
+          "type": {
+            "name": "enum",
+            "value": [
+              {
+                "value": "'small'",
+                "computed": false
+              },
+              {
+                "value": "'large'",
+                "computed": false
+              }
+            ]
+          },
+          "required": false,
+          "description": "PropTypes.oneOf(['small', 'large'])",
+          "defaultValue": {
+            "value": "'small'",
+            "computed": false
+          }
         }
       }
     }

--- a/www/examples/Button.mdx
+++ b/www/examples/Button.mdx
@@ -12,7 +12,7 @@ import DesignNotes from '../containers/DesignNotes.jsx';
   <Button bsStyle="danger" inverse>
     Error
   </Button>
-  <Button>Default</Button>
+  <Button bsStyle="default">Default</Button>
   <Button disabled>Disabled</Button>
   <Button bsStyle="warning" isLoading>
     Loading
@@ -21,7 +21,9 @@ import DesignNotes from '../containers/DesignNotes.jsx';
   <Button className="btn-link">Link</Button>
   <br />
   <h3>Large Button</h3>
-  <Button size="large">Add to My Todo List</Button>
+  <Button size="large" href="https://adslot.com">
+    Visit Adslot.com
+  </Button>
 </div>
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

With `react-bootstrap` `<Button />` component, it can work as an anchor with the prop `href`. In our main project, this `href` is frequently used now. 

Bring this function back to better support.


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [X] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
