### PR TITLE
[ASC-105] feat: new paragraph component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10412,8 +10412,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -14707,6 +14706,11 @@
         "space-separated-tokens": "^1.0.0"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
@@ -14852,6 +14856,74 @@
           "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
           "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
           "dev": true
+        }
+      }
+    },
+    "html-to-text": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-6.0.0.tgz",
+      "integrity": "sha512-r0KNC5aqCAItsjlgtirW6RW25c92Ee3ybQj8z//4Sl4suE3HIPqM4deGpYCUJULLjtVPEP1+Ma+1ZeX1iMsCiA==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "he": "^1.2.0",
+        "htmlparser2": "^4.1.0",
+        "lodash": "^4.17.20",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.1.0.tgz",
+          "integrity": "sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
+        },
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "domutils": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
+          "integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.3.0"
+          }
+        },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        },
+        "htmlparser2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "domutils": "^2.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
@@ -20207,8 +20279,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "draft-js": "^0.11.5",
     "draft-js-export-html": "^1.4.1",
     "draft-js-import-html": "^1.4.1",
+    "html-to-text": "^6.0.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.15",
     "react": "^16.8.6",

--- a/src/components/Paragraph/index.jsx
+++ b/src/components/Paragraph/index.jsx
@@ -1,0 +1,82 @@
+import _ from 'lodash';
+import React from 'react';
+import { htmlToText } from 'html-to-text';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { expandDts } from '../../lib/utils';
+import Button from '../Button';
+import './styles.scss';
+
+const Paragraph = ({ briefWordCount, content, className, dts, isHtml }) => {
+  const [readMore, setReadMore] = React.useState(false);
+  const baseClass = 'aui--paragraph';
+  const paragraph = isHtml ? htmlToText(content, { wordwrap: false }) : content;
+  const paragraphWordCount = _.get(paragraph, 'length');
+
+  const brief = _.truncate(paragraph, {
+    length: briefWordCount,
+    separator: ' ',
+  });
+
+  const toggleReadMore = () => {
+    setReadMore(!readMore);
+  };
+
+  return (
+    <div data-testid="paragraph-wrapper" className={classnames(baseClass, className)} {...expandDts(dts)}>
+      {!readMore && (
+        <div data-testid="paragraph-brief" className="brief-content">
+          {brief}
+        </div>
+      )}
+
+      <div
+        data-testid="paragraph-expandable-content"
+        className={classnames('expandable-content', { expanded: readMore, collapsed: !readMore })}
+      >
+        {readMore ? paragraph : _.replace(paragraph, brief, '')}
+      </div>
+
+      {paragraphWordCount > briefWordCount && (
+        <Button
+          data-testid="paragraph-read-more-button"
+          bsStyle="link"
+          className={`${baseClass}-read-more`}
+          onClick={toggleReadMore}
+        >
+          {!readMore ? `Read More` : `Read Less`}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+Paragraph.propTypes = {
+  /**
+   * 	The maximum of word count for brief content
+   */
+  briefWordCount: PropTypes.number.isRequired,
+  /**
+   * 	Content inside paragraph
+   */
+  content: PropTypes.string,
+  /**
+   *  	Custom classnames
+   */
+  className: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  /**
+   * 	Generate "data-test-selector" on the paragraph
+   */
+  dts: PropTypes.string,
+  /**
+   *    Define if the content is HTML type or not
+   */
+  isHtml: PropTypes.bool,
+};
+
+Paragraph.defaultProps = {
+  briefWordCount: 255,
+  isHtml: false,
+};
+
+export default Paragraph;

--- a/src/components/Paragraph/index.spec.jsx
+++ b/src/components/Paragraph/index.spec.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import Paragraph from '.';
+
+afterEach(cleanup);
+
+describe('<Paragraph />', () => {
+  const plainText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. \n
+  Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
+
+  const htmlText = `
+    <details>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat.
+      </p>
+      <p>
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.Excepteur
+        sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+    </details>
+  `;
+
+  it('should render with plain content', () => {
+    const { getByTestId, queryAllByTestId } = render(<Paragraph content={plainText} briefWordCount={15} />);
+    expect(queryAllByTestId('paragraph-wrapper')).toHaveLength(1);
+    expect(getByTestId('paragraph-brief')).toHaveTextContent('Lorem ipsum...');
+
+    expect(queryAllByTestId('paragraph-expandable-content')).toHaveLength(1);
+    expect(queryAllByTestId('paragraph-read-more-button')).toHaveLength(1);
+  });
+
+  it('should render with isHtml', () => {
+    const { getByTestId, queryAllByTestId } = render(<Paragraph content={htmlText} briefWordCount={15} isHtml />);
+    expect(queryAllByTestId('paragraph-wrapper')).toHaveLength(1);
+    expect(getByTestId('paragraph-brief')).toHaveTextContent('Lorem ipsum...');
+
+    expect(queryAllByTestId('paragraph-expandable-content')).toHaveLength(1);
+    expect(queryAllByTestId('paragraph-read-more-button')).toHaveLength(1);
+  });
+
+  it('should be able to click read more button to expand paragraph', () => {
+    const { getByTestId, queryAllByTestId } = render(<Paragraph content={htmlText} briefWordCount={15} isHtml />);
+    expect(queryAllByTestId('paragraph-wrapper')).toHaveLength(1);
+
+    expect(queryAllByTestId('paragraph-brief')).toHaveLength(1);
+    expect(queryAllByTestId('paragraph-expandable-content')).toHaveLength(1);
+    expect(getByTestId('paragraph-expandable-content')).toHaveClass('expandable-content collapsed');
+
+    expect(queryAllByTestId('paragraph-read-more-button')).toHaveLength(1);
+    fireEvent.click(getByTestId('paragraph-read-more-button'));
+
+    expect(queryAllByTestId('paragraph-brief')).toHaveLength(0);
+    expect(queryAllByTestId('paragraph-expandable-content')).toHaveLength(1);
+    expect(getByTestId('paragraph-expandable-content')).toHaveClass('expandable-content expanded');
+  });
+});

--- a/src/components/Paragraph/styles.scss
+++ b/src/components/Paragraph/styles.scss
@@ -1,0 +1,39 @@
+@import '~styles/color';
+
+.aui--paragraph {
+  margin: 0;
+  font-size: 14px;
+  white-space: pre-line;
+
+  .expandable-content {
+    overflow: hidden;
+
+    &.expanded {
+      max-height: 800px;
+      opacity: 1;
+      transition: 1s ease;
+    }
+
+    &.collapsed {
+      max-height: 0;
+      opacity: 0;
+      transition: .4s ease;
+    }
+  }
+
+  &-read-more {
+    padding: 4px 0;
+
+    &.aui--button.btn-link {
+      &:focus {
+        color: $color-button-link-color;
+        text-decoration: none;
+      }
+
+      &:hover,
+      :hover:focus {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -77,6 +77,7 @@ import Tile from './components/Tile';
 import Pill from './components/Pill';
 import Pagination from './components/Pagination';
 import Skeleton from './components/Skeleton';
+import Paragraph from './components/Paragraph';
 
 export {
   Accordion,
@@ -153,4 +154,5 @@ export {
   Tile,
   Pill,
   Skeleton,
+  Paragraph,
 };

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -2989,6 +2989,69 @@
       }
     }
   ],
+  "src/components/Paragraph/index.jsx": [
+    {
+      "description": "",
+      "displayName": "Paragraph",
+      "methods": [],
+      "props": {
+        "briefWordCount": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "The maximum of word count for brief content",
+          "defaultValue": {
+            "value": "255",
+            "computed": false
+          }
+        },
+        "content": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Content inside paragraph"
+        },
+        "className": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "string"
+              },
+              {
+                "name": "arrayOf",
+                "value": {
+                  "name": "string"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "description": "Custom classnames"
+        },
+        "dts": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "Generate \"data-test-selector\" on the paragraph"
+        },
+        "isHtml": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Define if the content is HTML type or not",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        }
+      }
+    }
+  ],
   "src/components/Pill/index.jsx": [
     {
       "description": "",

--- a/www/containers/routes.js
+++ b/www/containers/routes.js
@@ -61,6 +61,7 @@ import PillExample from '../examples/Pill.mdx';
 import TileExample from '../examples/Tile.mdx';
 import PaginationExample from '../examples/Pagination.mdx';
 import SkeletonExample from '../examples/Skeleton.mdx';
+import ParagraphExample from '../examples/Paragraph.mdx';
 
 const routes = [
   {
@@ -439,6 +440,12 @@ const routes = [
     path: '/skeleton',
     component: SkeletonExample,
     title: 'Skeleton',
+    group: 'Components',
+  },
+  {
+    path: '/paragraph',
+    component: ParagraphExample,
+    title: 'Paragraph',
     group: 'Components',
   },
 ];

--- a/www/examples/Paragraph.mdx
+++ b/www/examples/Paragraph.mdx
@@ -1,0 +1,38 @@
+import Props from '../containers/Props.jsx';
+import DesignNotes from '../containers/DesignNotes.jsx';
+
+## Paragraph
+
+```jsx live=true
+const Example = () => {
+  const content = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. \n
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
+
+  const richText = `
+    <details>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat.
+      </p>
+      <p>
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.Excepteur
+        sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+    </details>
+  `;
+
+  return (
+    <React.Fragment>
+      <Paragraph briefWordCount={200} content={content} />
+      <br />
+      <Paragraph briefWordCount={200} content={richText} isHtml />
+    </React.Fragment>
+  );
+};
+render(Example);
+```
+
+<Props componentName="Paragraph" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

- New component `<Paragraph />` with a Read More button, and it can be used to display `description` in data
  - It supports `briefWordCount` to determine the threshold to display the brief or full content.
  - It can display plain text and one rich format text - `HTML` when specified.

- As we still explore the requirement of this component, please leave your ideas here to further improve this one.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):

![Kapture 2020-11-20 at 16 11 30](https://user-images.githubusercontent.com/42738416/99761814-22200f00-2b4b-11eb-8fad-021c34280c39.gif)
