### PR TITLE
[ASC-107] feat: add target to button

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -9,7 +9,7 @@ import { expandDts } from '../../lib/utils';
 import './styles.scss';
 
 const Button = props => {
-  const { bsSize, bsStyle, children, className, disabled, dts, href, inverse, isLoading, size } = props;
+  const { bsSize, bsStyle, children, className, disabled, dts, href, inverse, isLoading, size, target } = props;
   const baseClass = 'aui--button';
   const classes = classNames(
     baseClass,
@@ -31,7 +31,13 @@ const Button = props => {
 
   const renderChildren = () =>
     href ? (
-      <a data-testid="button-anchor" className="aui--button-anchor" href={href}>
+      <a
+        data-testid="button-anchor"
+        className="aui--button-anchor"
+        href={href}
+        target={target}
+        rel="noopener noreferrer"
+      >
         {children}
       </a>
     ) : (
@@ -66,6 +72,11 @@ const adslotButtonPropTypes = {
   className: PropTypes.string,
   dts: PropTypes.string,
   href: PropTypes.string,
+  /**
+   * The target attribute specifies where to open the linked document when there is a defined 'href',
+   * PropTypes.oneOf(['_blank', '_self', '_parent', '_top'])
+   */
+  target: PropTypes.oneOf(['_blank', '_self', '_parent', '_top']),
   inverse: PropTypes.bool,
   isLoading: PropTypes.bool,
   /**
@@ -81,6 +92,7 @@ Button.defaultProps = {
   isLoading: false,
   size: 'small',
   bsStyle: 'default',
+  target: '_self',
 };
 
 export default Button;

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -683,6 +683,35 @@
           "required": false,
           "description": ""
         },
+        "target": {
+          "type": {
+            "name": "enum",
+            "value": [
+              {
+                "value": "'_blank'",
+                "computed": false
+              },
+              {
+                "value": "'_self'",
+                "computed": false
+              },
+              {
+                "value": "'_parent'",
+                "computed": false
+              },
+              {
+                "value": "'_top'",
+                "computed": false
+              }
+            ]
+          },
+          "required": false,
+          "description": "The target attribute specifies where to open the linked document when there is a defined 'href',\nPropTypes.oneOf(['_blank', '_self', '_parent', '_top'])",
+          "defaultValue": {
+            "value": "'_self'",
+            "computed": false
+          }
+        },
         "inverse": {
           "type": {
             "name": "bool"

--- a/www/examples/Button.mdx
+++ b/www/examples/Button.mdx
@@ -27,6 +27,9 @@ import DesignNotes from '../containers/DesignNotes.jsx';
   <Button size="large" href="https://adslot.com">
     Visit Adslot.com
   </Button>
+  <Button size="large" href="https://ui.adslot.com" target="_blank">
+    New Tab
+  </Button>
 </div>
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

Add a new prop 'target' to `<Button />` which provides a way to open a new page in a blank tab, for example



## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
