### PR TITLE
feat: add type to button

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -9,7 +9,7 @@ import { expandDts } from '../../lib/utils';
 import './styles.scss';
 
 const Button = props => {
-  const { bsSize, bsStyle, children, className, disabled, dts, href, inverse, isLoading, size, target } = props;
+  const { bsSize, bsStyle, children, className, disabled, dts, href, inverse, isLoading, size, target, type } = props;
   const baseClass = 'aui--button';
   const classes = classNames(
     baseClass,
@@ -49,6 +49,7 @@ const Button = props => {
       data-testid="button-wrapper"
       disabled={isLoading || disabled}
       className={classes}
+      type={type}
       {...expandDts(dts)}
       {..._.omit(props, _.keys(adslotButtonPropTypes))}
     >
@@ -83,6 +84,10 @@ const adslotButtonPropTypes = {
    * PropTypes.oneOf(['small', 'large'])
    */
   size: PropTypes.oneOf(['small', 'large']),
+  /**
+   * PropTypes.oneOf(['button', 'reset', 'submit'])
+   */
+  type: PropTypes.oneOf(['button', 'reset', 'submit']),
 };
 
 Button.propTypes = { ...adslotButtonPropTypes };
@@ -93,6 +98,7 @@ Button.defaultProps = {
   size: 'small',
   bsStyle: 'default',
   target: '_self',
+  type: 'button',
 };
 
 export default Button;

--- a/src/components/ConfirmModal/__snapshots__/index.spec.jsx.snap
+++ b/src/components/ConfirmModal/__snapshots__/index.spec.jsx.snap
@@ -31,6 +31,7 @@ exports[`<ConfirmModal /> should show modal when \`show\` is true 1`] = `
           class="aui--button btn-primary"
           data-test-selector="confirm-modal-confirm"
           data-testid="confirm-modal-confirm"
+          type="button"
         >
           <div
             class="aui--button-children-container"

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -754,6 +754,31 @@
             "value": "'small'",
             "computed": false
           }
+        },
+        "type": {
+          "type": {
+            "name": "enum",
+            "value": [
+              {
+                "value": "'button'",
+                "computed": false
+              },
+              {
+                "value": "'reset'",
+                "computed": false
+              },
+              {
+                "value": "'submit'",
+                "computed": false
+              }
+            ]
+          },
+          "required": false,
+          "description": "PropTypes.oneOf(['button', 'reset', 'submit'])",
+          "defaultValue": {
+            "value": "'button'",
+            "computed": false
+          }
         }
       }
     }

--- a/www/examples/FilePicker.mdx
+++ b/www/examples/FilePicker.mdx
@@ -13,7 +13,9 @@ class FilePickerExample extends React.PureComponent {
 
 render(
   <div style={{ width: 400 }}>
-    <FilePickerExample />
+    <form>
+      <FilePickerExample />
+    </form>
   </div>
 );
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

When `<Button />` was refactored, the button `type` prop is dropped off. Our  `<Button />` should be the type of `'button'`, while `<button />` has a default type of `'submit'`.


When bringing this `type` back, we can fix up current bugs `<form />` with `<FilePicker />`

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
