### PR TITLE
fix: btn default css

### DIFF
--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -90,7 +90,8 @@
     }
   }
 
-  &.btn-primary {
+  &.btn-primary,
+  &.btn-default.btn-primary {
     background-color: $color-button-primary-background;
     border-color: $color-button-primary-border;
     color: $color-white;
@@ -103,7 +104,8 @@
     }
   }
 
-  &.btn-success {
+  &.btn-success,
+  &.btn-default.btn-success {
     background-color: $color-button-success-background;
     border-color: $color-button-success-border;
     color: $color-white;
@@ -116,7 +118,8 @@
     }
   }
 
-  &.btn-info {
+  &.btn-info,
+  &.btn-default.btn-info {
     background-color: $color-button-info-background;
     border-color: $color-button-info-border;
     color: $color-white;
@@ -129,7 +132,8 @@
     }
   }
 
-  &.btn-warning {
+  &.btn-warning,
+  &.btn-default.btn-warning {
     background-color: $color-button-warning-background;
     border-color: $color-button-warning-border;
     color: $color-white;
@@ -143,7 +147,8 @@
     }
   }
 
-  &.btn-danger {
+  &.btn-danger,
+  &.btn-default.btn-danger {
     background-color: $color-button-danger-background;
     border-color: $color-button-danger-border;
     color: $color-white;
@@ -157,7 +162,7 @@
   }
 
   &.btn-link,
-  &.btn-link.btn-default {
+  &.btn-default.btn-link {
     background-color: transparent;
     border-color: transparent;
     color: $color-button-link-color;
@@ -169,13 +174,20 @@
       @include reset-shadow-and-transform;
     }
 
+    &:active,
+    &:hover,
+    &:hover:active,
     &:focus {
       background-color: transparent;
       border-color: transparent;
       color: $color-blue-dark;
       box-shadow: none;
-      text-decoration: underline;
+      text-decoration: none;
       outline: none;
+    }
+
+    &:hover:focus {
+      text-decoration: underline;
     }
   }
 

--- a/src/components/HoverDropdownMenu/styles.scss
+++ b/src/components/HoverDropdownMenu/styles.scss
@@ -20,7 +20,7 @@ $dropdown-width: 160px;
         margin: 0;
       }
 
-      .btn {
+      .aui--button {
         padding: 0;
       }
     }

--- a/src/styles/bootstrapOverrides/Button.scss
+++ b/src/styles/bootstrapOverrides/Button.scss
@@ -53,6 +53,7 @@
 
     &.btn-primary {
       @include button-inverse($color-primary);
+      border-color: $color-border-light;
     }
 
     &.btn-success {
@@ -73,6 +74,7 @@
   }
 }
 
+.aui--button,
 .btn {
   box-shadow: 0 1px $color-border-light;
   margin-right: 5px;
@@ -136,7 +138,7 @@
 }
 
 // disable lint on next line as we need to force extra specificity to ensure disabled styles take precedence
-.btn.btn-link {
+.aui--button.btn-link {
   // sass-lint:disable-line force-element-nesting
   cursor: pointer;
   border-color: transparent;
@@ -162,7 +164,8 @@
   }
 }
 
-.btn-borderless {
+.btn-borderless,
+.btn-default.btn-borderless {
   &:not([disabled]) {
     @include aui--button-variant($color-text-light, $color-inverse, $color-white);
     box-shadow: none;
@@ -190,7 +193,7 @@
 }
 
 .btn-xs,
-.btn-group-xs > .btn {
+.btn-group-xs > .aui--button {
   font-size: $font-size-tiny;
 
   &:active {
@@ -205,7 +208,7 @@
 }
 
 .input-group-btn {
-  > .btn {
+  > .aui--button {
     padding-bottom: $padding-base-vertical - 1px;
   }
 }

--- a/www/examples/Button.mdx
+++ b/www/examples/Button.mdx
@@ -7,6 +7,7 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 <div>
   <Button bsStyle="success">Undo</Button>
   <Button bsStyle="primary">Apply</Button>
+  <Button className="btn-primary">Primary</Button>
   <Button className="btn-primary btn-inverse">Inverse</Button>
   <Button bsStyle="info">Help</Button>
   <Button bsStyle="danger" inverse>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

Further fix btn default css

Have been fully tested with `adslot-grid` and `direct-web`. Should be okay after merging.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
