### PR TITLE
feat: nav external control

### DIFF
--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -7,10 +7,9 @@ import './styles.scss';
 
 const Nav = ({ stacked, className, onSelect, activeKey, barPosition, children, dts }) => {
   let navItems = [];
-  const [currentKey, setActiveKey] = React.useState(activeKey);
 
   React.Children.forEach(children, child => {
-    navItems.push(React.cloneElement(child, { onSelect, activeKey: currentKey, setActiveKey }));
+    navItems.push(React.cloneElement(child, { onSelect, activeKey: activeKey }));
   });
 
   return (
@@ -25,9 +24,8 @@ const Nav = ({ stacked, className, onSelect, activeKey, barPosition, children, d
   );
 };
 
-export const NavItem = ({ className, disabled, activeKey, setActiveKey, eventKey, href, onSelect, children }) => {
+export const NavItem = ({ className, disabled, activeKey, eventKey, href, onSelect, children }) => {
   const onItemClick = () => {
-    setActiveKey(eventKey);
     onSelect(eventKey);
   };
 
@@ -85,7 +83,6 @@ NavItem.propTypes = {
   onSelect: PropTypes.func,
   activeKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   children: PropTypes.node,
-  setActiveKey: PropTypes.func,
   /**
    * A key for each item, and can be used in onSelect
    */

--- a/src/components/Navigation/index.spec.jsx
+++ b/src/components/Navigation/index.spec.jsx
@@ -44,16 +44,12 @@ describe('<NavItem />', () => {
   });
 
   it('should trigger `setActiveKey` and `onSelect` when clicking the nav item', () => {
-    const setActiveKey = jest.fn();
     const onSelect = jest.fn();
     const { getByTestId, queryAllByTestId } = render(
-      <NavItem activeKey={0} eventKey={'event-key'} setActiveKey={setActiveKey} onSelect={onSelect} />
+      <NavItem activeKey={0} eventKey={'event-key'} onSelect={onSelect} />
     );
     expect(queryAllByTestId('nav-item-component')).toHaveLength(1);
     fireEvent.click(getByTestId('nav-item-component'));
-
-    expect(setActiveKey).toHaveBeenCalledTimes(1);
-    expect(setActiveKey).toHaveBeenCalledWith('event-key');
 
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith('event-key');
@@ -161,17 +157,9 @@ describe('<Nav />', () => {
     expect(queryAllByTestId('nav-component')).toHaveLength(1);
     expect(queryAllByTestId('nav-item-component')).toHaveLength(3);
 
-    expect(getByText('Dashboard')).toHaveClass('active');
-    expect(getByText('Reports')).not.toHaveClass('active');
-    expect(getByText('Invoicing')).not.toHaveClass('active');
-
     fireEvent.click(getByText('Reports'));
 
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith(1);
-
-    expect(getByText('Dashboard')).not.toHaveClass('active');
-    expect(getByText('Reports')).toHaveClass('active');
-    expect(getByText('Invoicing')).not.toHaveClass('active');
   });
 });

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -2737,13 +2737,6 @@
           "required": false,
           "description": ""
         },
-        "setActiveKey": {
-          "type": {
-            "name": "func"
-          },
-          "required": false,
-          "description": ""
-        },
         "eventKey": {
           "type": {
             "name": "union",

--- a/www/examples/Navigation.mdx
+++ b/www/examples/Navigation.mdx
@@ -4,19 +4,28 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 ## Navigation
 
 ```jsx live=true
-const Example = () => (
-  <Nav activeKey={0} onSelect={_.noop}>
-    <NavItem key={0} eventKey={0}>
-      Dashboard
-    </NavItem>
-    <NavItem key={1} eventKey={1}>
-      Reports
-    </NavItem>
-    <NavItem key={2} eventKey={2} disabled>
-      Invoicing
-    </NavItem>
-  </Nav>
-);
+const Example = () => {
+  const [activeTab, setActiveTab] = React.useState(0);
+
+  return (
+    <React.Fragment>
+      <Nav activeKey={activeTab} onSelect={setActiveTab}>
+        <NavItem key={0} eventKey={0}>
+          Dashboard
+        </NavItem>
+        <NavItem key={1} eventKey={1}>
+          Reports
+        </NavItem>
+        <NavItem key={2} eventKey={2} disabled>
+          Invoicing
+        </NavItem>
+      </Nav>
+      <br />
+      <h4>External Control</h4>
+      <Button onClick={() => setActiveTab(1)}>Switch to Reports</Button>
+    </React.Fragment>
+  );
+};
 
 render(Example);
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
As users should manage the nav tab state themselves, drop off the `setActiveKey` prop of the `<NavItem />`.

Users can switch tab externally if needed. New examples are provided.


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
