### PR TITLE
fix: change the tag component spacing

### DIFF
--- a/src/components/Tag/styles.scss
+++ b/src/components/Tag/styles.scss
@@ -6,7 +6,7 @@
 
 .tag-component {
   $tag-height: 24px;
-  $tag-spacing-etalon: 5px;
+  $tag-spacing-etalon: 6px;
   $color-tag-inverse: $color-gray-lightest;
   $color-tag-action-inverse: $color-gray;
   $action-icon-padding: ($tag-height - $svg-icon-size) / 2;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increased the tag component padding and margin from 5px to 6px in order to match the 12px base grid.

https://adslot.atlassian.net/browse/ASC-110
<!--- A few sentences describing the overall goals of the pull request's commit. -->


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
