### PR TITLE
fix: remove data-testid in production

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -13,7 +13,20 @@ const presets = [
   ],
 ];
 
+const env = {
+  production: {
+    plugins: ['babel-plugin-jsx-remove-data-test-id'],
+  },
+  development: {
+    plugins: ['babel-plugin-jsx-remove-data-test-id'],
+  },
+  test: {
+    plugins: [],
+  },
+};
+
 module.exports = {
   presets,
   plugins,
+  env,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8386,6 +8386,12 @@
         }
       }
     },
+    "babel-plugin-jsx-remove-data-test-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-remove-data-test-id/-/babel-plugin-jsx-remove-data-test-id-3.0.0.tgz",
+      "integrity": "sha512-E4uM/LIUizjy2Z5tVAfa8pSXsYgoKWJ97kzuEMfsIxSLSNDWsAhgFVPkgNuakViX5dkNjw1DKIi0VpWP6djqbw==",
+      "dev": true
+    },
     "babel-plugin-macros": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "babel-jest": "^26.0.1",
     "babel-loader": "^8.0.6",
     "babel-plugin-istanbul": "^5.2.0",
+    "babel-plugin-jsx-remove-data-test-id": "^3.0.0",
     "bootstrap-sass": "^3.4.1",
     "case-sensitive-paths-webpack-plugin": "^2.2.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

ASC-112

`data-testid` may be redundant in the production mode. When devs tried to copy the classname of a component but they probably end up with a value of the `data-testid` with confusion and mistakes.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
