### PR TITLE
fix: character count of the text area

### DIFF
--- a/src/components/Textarea/index.jsx
+++ b/src/components/Textarea/index.jsx
@@ -7,8 +7,11 @@ class Textarea extends React.PureComponent {
   constructor(props) {
     super(props);
 
+    const valueString = _.toString(this.props.value);
+
+    const charCountRemaining = this.props.maxLength - valueString.length;
     this.state = {
-      charCountRemaining: this.props.maxLength,
+      charCountRemaining,
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -46,6 +49,7 @@ Textarea.propTypes = {
   maxLength: PropTypes.number,
   statusClass: PropTypes.string,
   onChange: PropTypes.func,
+  value: PropTypes.string,
 };
 
 Textarea.defaultProps = {

--- a/src/components/Textarea/index.spec.jsx
+++ b/src/components/Textarea/index.spec.jsx
@@ -16,6 +16,12 @@ describe('<Textarea />', () => {
     expect(getByTestId('textarea-span')).toHaveClass('someclass');
   });
 
+  it('should render a countdown span when maxLength is specified with a value', () => {
+    const { getByTestId } = render(<Textarea maxLength={120} statusClass="someclass" value="test" />);
+    expect(getByTestId('textarea-span')).toHaveTextContent('116 characters remaining');
+    expect(getByTestId('textarea-span')).toHaveClass('someclass');
+  });
+
   it('should give additional className to the textarea', () => {
     const { getByTestId } = render(<Textarea maxLength={120} className="someclass" />);
     expect(getByTestId('textarea-area')).toHaveClass('form-control someclass');

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -4973,6 +4973,13 @@
           },
           "required": false,
           "description": ""
+        },
+        "value": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
consider the `textArea` value.length when calculating the remaining characters count

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
fixing the bug https://github.com/Adslot/adslot-ui/issues/1121

`character remaining` count is incorrect when a text area defined with `maxLength` and a `value`

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->
checkout the branch the adslot-ui `text area` example
- edit the code to have `value="some text"`
- check the remaining character count - should consider the `value` length 

## Screenshots (if appropriate):
<img width="519" alt="Screen Shot 2021-03-09 at 4 07 04 pm" src="https://user-images.githubusercontent.com/7802760/110421486-b8277780-80f1-11eb-857d-bb57628a259b.png">

for a number
![Screen Shot 2021-03-10 at 2 47 38 pm](https://user-images.githubusercontent.com/7802760/110574179-c25c7b00-81b0-11eb-9208-18420627a666.png)


for a boolean value
![Screen Shot 2021-03-10 at 2 47 47 pm](https://user-images.githubusercontent.com/7802760/110574208-cf796a00-81b0-11eb-9799-5125bad49200.png)
