### PR TITLE
fix: plugin for dist and popover modifiers

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -20,6 +20,9 @@ const env = {
   development: {
     plugins: ['babel-plugin-jsx-remove-data-test-id'],
   },
+  dist: {
+    plugins: ['babel-plugin-jsx-remove-data-test-id'],
+  },
   test: {
     plugins: [],
   },

--- a/__mocks__/popper.js.js
+++ b/__mocks__/popper.js.js
@@ -6,7 +6,7 @@ export default class Popper {
   constructor() {
     return {
       destroy: () => {},
-      scheduleUpdate: () => {},
+      update: () => {},
     };
   }
 }

--- a/src/components/Popover/Popper.jsx
+++ b/src/components/Popover/Popper.jsx
@@ -19,8 +19,6 @@ export const renderArrowStyles = (placement, arrowStyles, container = null) => {
   const verticalPosition =
     _.get(container, 'clientHeight') >= DEFAULT_ARROW_POSITION * 2 ? DEFAULT_ARROW_POSITION : null;
 
-  // console.log(horizontalPosition);
-  // console.log(_.get(container, 'clientWidth'));
   let calculatedArrowStyles = {};
   switch (true) {
     case _.includes(['bottom-start', 'top-start'], placement) && !_.isNull(horizontalPosition):
@@ -64,22 +62,25 @@ const Popper = ({
     if (popperElement && popperRef) popperRef(popperElement);
   }, [popperRef, popperElement]);
 
+  // react-popper not using subsequent settings to overwrite preceding ones
+  const defaultModifiers = [{ name: 'arrow', options: { element: arrowElement } }];
+  if (!_.find(modifiers, { name: 'offset' }))
+    defaultModifiers.push({
+      name: 'offset',
+      options: {
+        offset: [0, 6],
+      },
+    });
+  if (!_.find(modifiers, { name: 'flip' }))
+    defaultModifiers.push({
+      name: 'flip',
+      options: {
+        altBoundary: true,
+      },
+    });
+
   const { styles, attributes, update } = usePopper(refElement, popperElement, {
-    modifiers: [
-      { name: 'arrow', options: { element: arrowElement } },
-      {
-        name: 'offset',
-        options: {
-          offset: [0, 6],
-        },
-      },
-      {
-        name: 'flip',
-        options: {
-          altBoundary: true,
-        },
-      },
-    ].concat(modifiers),
+    modifiers: defaultModifiers.concat(modifiers),
     placement: popperPlacement,
     wrapperStyles,
   });
@@ -102,7 +103,7 @@ const Popper = ({
           </div>
         ) : null}
         <div data-testid="popover-content" className="popover-content">
-          {_.isFunction(popoverContent) ? popoverContent({ scheduleUpdate: update }) : popoverContent}
+          {_.isFunction(popoverContent) ? popoverContent({ update }) : popoverContent}
         </div>
       </div>
       <div

--- a/src/components/Popover/index.spec.jsx
+++ b/src/components/Popover/index.spec.jsx
@@ -174,6 +174,36 @@ describe('<Popover />', () => {
     expect(getByTestId('popover-test-content')).toHaveTextContent('test');
   });
 
+  it('should set up modifiers for a popover', () => {
+    const { getByTestId } = render(
+      <div>
+        <Popover
+          id="popover-example"
+          popoverContent={() => <div data-testid="popover-test-content">test</div>}
+          placement="bottom"
+          modifiers={[
+            {
+              name: 'offset',
+              options: {
+                offset: [0, 8],
+              },
+            },
+            {
+              name: 'flip',
+              options: {
+                altBoundary: false,
+              },
+            },
+          ]}
+          isOpen
+        >
+          Test message
+        </Popover>
+      </div>
+    );
+    expect(getByTestId('popover-test-content')).toHaveTextContent('test');
+  });
+
   describe('triggers', () => {
     it('should register event handlers for multiple triggers', () => {
       const { getByTestId, queryAllByTestId } = render(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Hot fix for `data-testid` is still in dist files

Fix modifiers not able to be overwritten


## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
