### PR TITLE
[ASC-115] fix: new spinner size

### DIFF
--- a/src/components/Spinner/index.jsx
+++ b/src/components/Spinner/index.jsx
@@ -1,24 +1,24 @@
 import React from 'react';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import './styles.scss';
 
-const Spinner = ({ size, colourStyle }) => (
-  <div data-testid="spinner-wrapper" className="spinner-component">
-    <div data-testid="spinner" className={`spinner spinner-${size} spinner-colour-style-${colourStyle}`} />
+const Spinner = ({ className, size }) => (
+  <div data-testid="spinner-wrapper" className={classnames(['spinner-component', className])}>
+    <div data-testid="spinner" className={classnames(['spinner', `spinner-${size}`])} />
   </div>
 );
 
 Spinner.propTypes = {
+  className: PropTypes.string,
   /**
-   * oneOf: 'large', medium', 'small'
+   * Size of the spinner should be one of: 'large' (40x40px), 'medium' (30x30px), 'small' (16x16px)
    */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  colourStyle: PropTypes.string,
 };
 
 Spinner.defaultProps = {
   size: 'large',
-  colourStyle: 'default',
 };
 
 export default Spinner;

--- a/src/components/Spinner/index.spec.jsx
+++ b/src/components/Spinner/index.spec.jsx
@@ -8,11 +8,20 @@ describe('<Spinner />', () => {
   it('should render with defaults', () => {
     const { getByTestId } = render(<Spinner />);
     expect(getByTestId('spinner-wrapper')).toHaveClass('spinner-component');
-    expect(getByTestId('spinner')).toHaveClass('spinner spinner-large spinner-colour-style-default');
+    expect(getByTestId('spinner')).toHaveClass('spinner');
+    expect(getByTestId('spinner')).toHaveClass('spinner-large');
   });
 
-  it('should render small with primary style', () => {
-    const { getByTestId } = render(<Spinner size="small" colourStyle="primary" />);
-    expect(getByTestId('spinner')).toHaveClass('spinner spinner-small spinner-colour-style-primary');
+  it('should render with custom className', () => {
+    const { getByTestId } = render(<Spinner className="custom-spinner-style" />);
+    expect(getByTestId('spinner-wrapper')).toHaveClass('custom-spinner-style');
+  });
+
+  it('should render different size of spinner', () => {
+    const { getByTestId, rerender } = render(<Spinner size="small" />);
+    expect(getByTestId('spinner')).toHaveClass('spinner-small');
+
+    rerender(<Spinner size="medium" />);
+    expect(getByTestId('spinner')).toHaveClass('spinner-medium');
   });
 });

--- a/src/components/Spinner/styles.scss
+++ b/src/components/Spinner/styles.scss
@@ -11,6 +11,10 @@
     animation: rotation 1.1s infinite linear;
     border-radius: 100%;
     border-style: solid;
+    border-bottom-color: $color-spinner;
+    border-left-color: $color-spinner;
+    border-right-color: $color-spinner;
+    border-top-color: $color-spinner-light;
     display: inline-block;
 
     &-small {
@@ -21,21 +25,14 @@
 
     &-medium {
       border-width: 3px;
-      height: 24px;
-      width: 24px;
+      height: 30px;
+      width: 30px;
     }
 
     &-large {
-      border-width: 6px;
-      height: 60px;
-      width: 60px;
-    }
-
-    &-colour-style-default {
-      border-bottom-color: $color-spinner;
-      border-left-color: $color-spinner;
-      border-right-color: $color-spinner;
-      border-top-color: $color-spinner-light;
+      border-width: 3px;
+      height: 40px;
+      width: 40px;
     }
 
     @keyframes rotation {

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -4367,6 +4367,13 @@
       "displayName": "Spinner",
       "methods": [],
       "props": {
+        "className": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
+        },
         "size": {
           "type": {
             "name": "enum",
@@ -4386,20 +4393,9 @@
             ]
           },
           "required": false,
-          "description": "oneOf: 'large', medium', 'small'",
+          "description": "Size of the spinner should be one of: 'large' (40x40px), 'medium' (30x30px), 'small' (16x16px)",
           "defaultValue": {
             "value": "'large'",
-            "computed": false
-          }
-        },
-        "colourStyle": {
-          "type": {
-            "name": "string"
-          },
-          "required": false,
-          "description": "",
-          "defaultValue": {
-            "value": "'default'",
             "computed": false
           }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
1. Change spinner medium size to 30x30px
2. Change spinner large size to 40x40px
3. Add className prop
4. Deprecate colourStyle prop (user can use className to give any custom styles so colourStyle is not needed)

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
