### PR TITLE
fix: checkboxgroup value for numeric ids

### DIFF
--- a/src/components/CheckboxGroup/index.jsx
+++ b/src/components/CheckboxGroup/index.jsx
@@ -51,7 +51,7 @@ CheckboxGroup.propTypes = {
   /**
    * string array of checked values
    */
-  value: PropTypes.arrayOf(PropTypes.string).isRequired,
+  value: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
   /**
    * checkBoxGroup children: oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]
    */

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -1200,7 +1200,15 @@
           "type": {
             "name": "arrayOf",
             "value": {
-              "name": "string"
+              "name": "union",
+              "value": [
+                {
+                  "name": "string"
+                },
+                {
+                  "name": "number"
+                }
+              ]
             }
           },
           "required": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

`<CheckboxGroup />` only supports string[] as its value now, but for some use cases, we need checkbox group to collect numeric ids. To eliminate warnings, add number[] to its type. 


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
