### PR TITLE
fix: handle checkboxgroup children type

### DIFF
--- a/src/components/CheckboxGroup/index.jsx
+++ b/src/components/CheckboxGroup/index.jsx
@@ -16,6 +16,8 @@ const CheckboxGroup = ({ id, className, dts, children, value, name, inline, onCh
 
   const renderChildren = () =>
     React.Children.map(children, child => {
+      if (!child) return null;
+
       if (child.type === Checkbox) {
         const childProps = {
           ...child.props,
@@ -34,11 +36,11 @@ const CheckboxGroup = ({ id, className, dts, children, value, name, inline, onCh
     });
   const classNames = classnames(['checkbox-group-component', className]);
 
-  return (
+  return children ? (
     <div data-testid="checkbox-group-wrapper" id={id} className={classNames} {...expandDts(dts)}>
       {renderChildren()}
     </div>
-  );
+  ) : null;
 };
 
 CheckboxGroup.propTypes = {

--- a/src/components/CheckboxGroup/index.spec.jsx
+++ b/src/components/CheckboxGroup/index.spec.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { render, cleanup, fireEvent } from '@testing-library/react';
-
 import Checkbox from '../Checkbox';
-
 import CheckboxGroup from '.';
 
 afterEach(cleanup);
@@ -59,5 +57,23 @@ describe('<CheckboxGroup />', () => {
       </CheckboxGroup>
     );
     expect(console.error).toHaveBeenCalledWith("ERROR: CheckboxGroup's children should be an array of Checkbox");
+  });
+
+  it('should return null if there is no children', () => {
+    const { queryAllByTestId } = render(<CheckboxGroup name="movies" value={['test']} onChange={jest.fn()} />);
+    expect(queryAllByTestId('checkbox-group-wrapper')).toHaveLength(0);
+  });
+
+  it('should return null if there is a boolean child', () => {
+    console.error = jest.fn();
+    const { queryAllByTestId } = render(
+      <CheckboxGroup name="movies" value={['test']} onChange={jest.fn()}>
+        {false && <Checkbox label="The Terminator" value="terminator" />}
+        <Checkbox label="Predator" value="predator" />
+      </CheckboxGroup>
+    );
+
+    expect(queryAllByTestId('checkbox-group-wrapper')).toHaveLength(1);
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

`<CheckboxGroup />` is supposed to handle some use cases like:

- `<CheckboxGroup />`  =>  `null`
- `<CheckboxGroup>{false && <Checkbox id={1}/>}<Checkbox id={2} /></CheckboxGroup>` => `<CheckboxGroup><Checkbox id={2} /></CheckboxGroup>`

Fix for the above 2 cases

 

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
