### PR TITLE
[ASC-104] refactor: simplify adslot button

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -9,14 +9,14 @@ import { expandDts } from '../../lib/utils';
 import './styles.scss';
 
 const Button = props => {
-  const { bsSize, bsStyle, children, className, disabled, dts, href, inverse, isLoading, size, target, type } = props;
+  const { theme, children, className, disabled, dts, href, inverse, isLoading, size, target, type } = props;
   const baseClass = 'aui--button';
   const classes = classNames(
     baseClass,
     {
-      'btn-inverse': inverse && !/btn-inverse/.test(className),
-      'btn-large': size === 'large' || _.includes(['lg', 'large'], bsSize),
-      [`btn-${bsStyle}`]: !_.isEmpty(bsStyle),
+      'btn-inverse': inverse,
+      'btn-large': size === 'large',
+      [`btn-${theme}`]: !_.isEmpty(theme),
       'has-anchor': href,
     },
     className
@@ -25,7 +25,7 @@ const Button = props => {
   const renderSpinner = () =>
     isLoading ? (
       <div data-testid="button-spinner-wrapper" className="spinner-container">
-        <Spinner size={_.includes(['lg', 'large'], bsSize) ? 'medium' : 'small'} />
+        <Spinner size={size === 'large' ? 'medium' : 'small'} />
       </div>
     ) : null;
 
@@ -63,13 +63,9 @@ const Button = props => {
 
 const adslotButtonPropTypes = {
   /**
-   * PropTypes.oneOf(['lg', 'large', 'sm', 'small'])
-   */
-  bsSize: PropTypes.oneOf(['lg', 'large', 'sm', 'small']),
-  /**
    * PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link'])
    */
-  bsStyle: PropTypes.oneOf(['default', 'primary', 'success', 'info', 'warning', 'danger', 'link']),
+  theme: PropTypes.oneOf(['default', 'primary', 'success', 'info', 'warning', 'danger', 'link']),
   className: PropTypes.string,
   dts: PropTypes.string,
   href: PropTypes.string,
@@ -96,7 +92,7 @@ Button.defaultProps = {
   inverse: false,
   isLoading: false,
   size: 'small',
-  bsStyle: 'default',
+  theme: 'default',
   target: '_self',
   type: 'button',
 };

--- a/src/components/Button/index.spec.jsx
+++ b/src/components/Button/index.spec.jsx
@@ -10,22 +10,6 @@ describe('<Button />', () => {
     expect(queryAllByTestId('button-wrapper')).toHaveLength(1);
   });
 
-  it('should support legacy Bootstrap Button props for non-breaking change', () => {
-    const { getByTestId } = render(
-      <Button bsStyle="link" href="example.com">
-        Test
-      </Button>
-    );
-
-    expect(getByTestId('button-wrapper')).toHaveClass('btn-link');
-    expect(getByTestId('button-anchor')).toHaveAttribute('href', 'example.com');
-  });
-
-  it('should support legacy classname btn-inverse for non-breaking change', () => {
-    const { getByTestId } = render(<Button className="btn-inverse">Test</Button>);
-    expect(getByTestId('button-wrapper')).toHaveClass('aui--button btn-inverse btn-default');
-  });
-
   it('should support className prop', () => {
     const { getByTestId } = render(<Button className="all the-classes">Test</Button>);
     expect(getByTestId('button-wrapper')).toHaveClass('aui--button all the-classes');
@@ -37,16 +21,12 @@ describe('<Button />', () => {
     expect(getByTestId('button-wrapper')).toHaveAttribute('id', 'button-id');
   });
 
-  it('should not duplicate btn-inverse class if both legacy and new are used', () => {
-    const { getByTestId } = render(
-      <Button inverse className="btn-inverse">
-        Test
-      </Button>
-    );
-    expect(getByTestId('button-wrapper')).toHaveClass('aui--button btn-inverse btn-default');
+  it('should not render inverse button with btn-inverse class (have to use inverse props instead)', () => {
+    const { getByTestId } = render(<Button className="btn-inverse">Test</Button>);
+    expect(getByTestId('button-wrapper')).toHaveClass('aui--button btn-default');
   });
 
-  it('should render inverse button with btn-inverse class', () => {
+  it('should render inverse button with inverse props', () => {
     const { getByTestId } = render(<Button inverse>Test</Button>);
     expect(getByTestId('button-wrapper')).toHaveClass('aui--button btn-inverse btn-default');
   });
@@ -71,8 +51,8 @@ describe('<Button />', () => {
     expect(queryAllByTestId('button-spinner-wrapper')).toHaveLength(1);
   });
 
-  it('should only allow bsSize medium or small on Spinner', () => {
-    const { getByTestId } = render(<Button isLoading bsSize="lg" />);
+  it('should only allow size medium or small on Spinner', () => {
+    const { getByTestId } = render(<Button isLoading size="large" />);
     expect(getByTestId('spinner')).toHaveClass('spinner-medium');
   });
 });

--- a/src/components/ButtonGroup/index.jsx
+++ b/src/components/ButtonGroup/index.jsx
@@ -12,20 +12,20 @@ class ButtonGroup extends React.PureComponent {
     /**
      * PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link'])
      */
-    bsStyle: PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link']),
+    theme: PropTypes.oneOf(['primary', 'success', 'info', 'warning', 'danger', 'link']),
     inverse: PropTypes.bool,
     disabled: PropTypes.bool,
-    bsSize: PropTypes.string,
+    size: PropTypes.string,
   };
 
   injectProps(children) {
     return React.Children.map(children, child => {
       if (React.isValidElement(child)) {
         const buttonProps = {
-          ...(this.props.bsStyle ? { bsStyle: this.props.bsStyle } : {}),
+          ...(this.props.theme ? { theme: this.props.theme } : {}),
           ...(!_.isNil(this.props.inverse) ? { inverse: this.props.inverse } : {}),
           ...(!_.isNil(this.props.disabled) ? { disabled: this.props.disabled } : {}),
-          ...(this.props.bsSize ? { bsSize: this.props.bsSize } : {}),
+          ...(this.props.size ? { size: this.props.size } : {}),
         };
 
         const childNodes = React.Children.map(child.props.children, childNode =>

--- a/src/components/ButtonGroup/index.spec.jsx
+++ b/src/components/ButtonGroup/index.spec.jsx
@@ -18,8 +18,8 @@ describe('<ButtonGroup />', () => {
 
   it('should override child Button style', () => {
     const { queryAllByTestId } = render(
-      <ButtonGroup bsStyle="link" inverse>
-        <Button bsStyle="primary">Test1</Button>
+      <ButtonGroup theme="link" inverse>
+        <Button theme="primary">Test1</Button>
         <Button inverse={false}>Test2</Button>
       </ButtonGroup>
     );
@@ -30,7 +30,7 @@ describe('<ButtonGroup />', () => {
   it('should disable child buttons', () => {
     const { queryAllByTestId } = render(
       <ButtonGroup disabled>
-        <Button bsStyle="primary">Test1</Button>
+        <Button theme="primary">Test1</Button>
         <Button inverse={false}>Test2</Button>
       </ButtonGroup>
     );
@@ -40,10 +40,10 @@ describe('<ButtonGroup />', () => {
 
   it('should inject props to Button at any nested level', () => {
     const { getByTestId } = render(
-      <ButtonGroup disabled bsSize="large">
+      <ButtonGroup disabled size="large">
         <div>
           <div>foo</div>
-          <Button bsStyle="primary">Test1</Button>
+          <Button theme="primary">Test1</Button>
         </div>
       </ButtonGroup>
     );

--- a/src/components/ConfirmModal/index.jsx
+++ b/src/components/ConfirmModal/index.jsx
@@ -41,7 +41,7 @@ const ConfirmModalComponent = ({
         {modalClose ? (
           <Button
             data-testid="confirm-modal-cancel"
-            className="btn-inverse"
+            inverse
             onClick={cancelAction}
             data-test-selector="confirm-modal-cancel"
           >
@@ -50,7 +50,7 @@ const ConfirmModalComponent = ({
         ) : null}
         <Button
           data-testid="confirm-modal-confirm"
-          bsStyle="primary"
+          theme="primary"
           onClick={applyAction}
           data-test-selector="confirm-modal-confirm"
         >

--- a/src/components/FilePicker/index.jsx
+++ b/src/components/FilePicker/index.jsx
@@ -103,7 +103,7 @@ class FilePickerComponent extends React.PureComponent {
           ) : null}
           <Button
             data-testid="file-picker-input-button"
-            className="btn-inverse"
+            inverse
             onClick={this.onUploadBtnClick}
             disabled={this.props.disabled || isFileSelected}
           >

--- a/src/components/HoverDropdownMenu/PopoverLinkItem/index.jsx
+++ b/src/components/HoverDropdownMenu/PopoverLinkItem/index.jsx
@@ -12,7 +12,7 @@ class PopoverLinkItemComponent extends React.PureComponent {
     const buttonProps = {
       disabled: !isEnabled,
       onClick,
-      bsStyle: 'link',
+      theme: 'link',
     };
 
     if (target !== '_modal') {

--- a/src/components/ImageCropper/index.jsx
+++ b/src/components/ImageCropper/index.jsx
@@ -43,7 +43,7 @@ const ImageCropper = forwardRef(({ title, src, alt, onCancel, onCrop, width, hei
   }));
 
   const uploadButton = (
-    <Button bsStyle="primary" onClick={() => onCrop(cropperRef.current.getData())} isLoading={isSaving} inverse>
+    <Button theme="primary" onClick={() => onCrop(cropperRef.current.getData())} isLoading={isSaving} inverse>
       Upload
     </Button>
   );

--- a/src/components/ListPicker/index.jsx
+++ b/src/components/ListPicker/index.jsx
@@ -151,7 +151,7 @@ class ListPickerComponent extends React.PureComponent {
             <div className="pull-left">
               {_.map(linkButtons, (linkButton, key) =>
                 _.isObject(linkButton) && isSubset(_.keys(linkButton), ['label', 'href']) ? (
-                  <Button key={linkButton.label} className="btn-inverse" href={linkButton.href}>
+                  <Button key={linkButton.label} inverse href={linkButton.href}>
                     {linkButton.label}
                   </Button>
                 ) : (
@@ -160,11 +160,11 @@ class ListPickerComponent extends React.PureComponent {
               )}
             </div>
           )}
-          <Button className="btn-inverse" onClick={this.cancelAction} data-test-selector="listpicker-cancel-button">
+          <Button inverse onClick={this.cancelAction} data-test-selector="listpicker-cancel-button">
             Cancel
           </Button>
           <Button
-            bsStyle="primary"
+            theme="primary"
             onClick={this.applyAction}
             disabled={disableApplyButton}
             data-test-selector="listpicker-apply-button"

--- a/src/components/Paragraph/index.jsx
+++ b/src/components/Paragraph/index.jsx
@@ -40,7 +40,7 @@ const Paragraph = ({ briefWordCount, content, className, dts, isHtml }) => {
       {paragraphWordCount > briefWordCount && (
         <Button
           data-testid="paragraph-read-more-button"
-          bsStyle="link"
+          theme="link"
           className={`${baseClass}-read-more`}
           onClick={toggleReadMore}
         >

--- a/src/components/TreePicker/Node/index.jsx
+++ b/src/components/TreePicker/Node/index.jsx
@@ -69,7 +69,8 @@ class TreePickerNodeComponent extends React.PureComponent {
           {selected ? (
             <GridCell classSuffixes={['button']} dts="button-remove">
               <Button
-                className="btn-inverse button-xs"
+                className="button-xs"
+                inverse
                 onClick={this.handleRemove}
                 disabled={disabled || node.isSelectable === false}
               >
@@ -97,7 +98,8 @@ class TreePickerNodeComponent extends React.PureComponent {
           {!selected ? (
             <GridCell classSuffixes={['button']} dts="button-add">
               <Button
-                className="btn-inverse button-xs"
+                className="button-xs"
+                inverse
                 onClick={this.handleInclude}
                 disabled={disabled || node.isSelectable === false || this.state.isLoading}
               >

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -596,32 +596,7 @@
       "displayName": "Button",
       "methods": [],
       "props": {
-        "bsSize": {
-          "type": {
-            "name": "enum",
-            "value": [
-              {
-                "value": "'lg'",
-                "computed": false
-              },
-              {
-                "value": "'large'",
-                "computed": false
-              },
-              {
-                "value": "'sm'",
-                "computed": false
-              },
-              {
-                "value": "'small'",
-                "computed": false
-              }
-            ]
-          },
-          "required": false,
-          "description": "PropTypes.oneOf(['lg', 'large', 'sm', 'small'])"
-        },
-        "bsStyle": {
+        "theme": {
           "type": {
             "name": "enum",
             "value": [
@@ -816,7 +791,7 @@
           "required": false,
           "description": ""
         },
-        "bsStyle": {
+        "theme": {
           "type": {
             "name": "enum",
             "value": [
@@ -863,7 +838,7 @@
           "required": false,
           "description": ""
         },
-        "bsSize": {
+        "size": {
           "type": {
             "name": "string"
           },

--- a/www/examples/Breadcrumb.mdx
+++ b/www/examples/Breadcrumb.mdx
@@ -33,7 +33,7 @@ const Example = () => {
 
   if (_.isEmpty(breadcrumbNodes)) {
     return (
-      <Button className="btn-inverse" onClick={resetState}>
+      <Button inverse onClick={resetState}>
         Reset breadcrumb example
       </Button>
     );

--- a/www/examples/Button.mdx
+++ b/www/examples/Button.mdx
@@ -5,20 +5,22 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 
 ```jsx live=true
 <div>
-  <Button bsStyle="success">Undo</Button>
-  <Button bsStyle="primary">Apply</Button>
+  <Button theme="success">Undo</Button>
+  <Button theme="primary">Apply</Button>
   <Button className="btn-primary">Primary</Button>
-  <Button className="btn-primary btn-inverse">Inverse</Button>
-  <Button bsStyle="info">Help</Button>
-  <Button bsStyle="danger" inverse>
+  <Button inverse className="btn-primary">
+    Inverse
+  </Button>
+  <Button theme="info">Help</Button>
+  <Button theme="danger" inverse>
     Error
   </Button>
-  <Button bsStyle="default">Default</Button>
-  <Button bsStyle="default" className="some class">
+  <Button theme="default">Default</Button>
+  <Button bsSthemetyle="default" className="some class">
     Default with Class
   </Button>
   <Button disabled>Disabled</Button>
-  <Button bsStyle="warning" isLoading>
+  <Button theme="warning" isLoading>
     Loading
   </Button>
   <Button className="btn-borderless">Borderless</Button>

--- a/www/examples/ButtonGroup.mdx
+++ b/www/examples/ButtonGroup.mdx
@@ -9,7 +9,7 @@ const Example = () => {
 
   return (
     <React.Fragment>
-      <ButtonGroup bsStyle="success">
+      <ButtonGroup theme="success">
         <Button>Approve</Button>
         <Popover triggers="click" placement="bottom" popoverContent="I am a popover on click!">
           <Button className="svg-icon">
@@ -17,7 +17,7 @@ const Example = () => {
           </Button>
         </Popover>
       </ButtonGroup>
-      <ButtonGroup bsStyle="danger" inverse={true}>
+      <ButtonGroup theme="danger" inverse={true}>
         <Button>Reject</Button>
         <Popover
           triggers="disabled"
@@ -31,13 +31,13 @@ const Example = () => {
           </Button>
         </Popover>
       </ButtonGroup>
-      <ButtonGroup bsStyle="primary">
+      <ButtonGroup theme="primary">
         <Button>Sign off</Button>
         <Button className="svg-icon" onClick={() => alert('>I am a Alert on click!')}>
           <SvgSymbol href="./assets/svg-symbols.svg#caret-down" />
         </Button>
       </ButtonGroup>
-      <ButtonGroup bsStyle="warning" inverse={true} disabled={true}>
+      <ButtonGroup theme="warning" inverse={true} disabled={true}>
         <Button>Disabled</Button>
         <Button className="svg-icon">
           <SvgSymbol href="./assets/svg-symbols.svg#caret-down" />

--- a/www/examples/ConfirmModal.mdx
+++ b/www/examples/ConfirmModal.mdx
@@ -25,7 +25,7 @@ class ConfirmModalExample extends React.PureComponent {
           modalClose={this.toggleConfirmModal}
           show={this.state.showConfirmModal}
         />
-        <Button bsStyle="primary" onClick={this.toggleConfirmModal}>
+        <Button theme="primary" onClick={this.toggleConfirmModal}>
           Sign Off
         </Button>
       </div>

--- a/www/examples/ListPicker.mdx
+++ b/www/examples/ListPicker.mdx
@@ -65,7 +65,7 @@ const Example = () => {
         show={showModal}
       />
       <div style={{ display: 'flex', width: '300px', alignItems: 'center', justifyContent: 'space-between' }}>
-        <Button bsStyle="primary" className="btn-inverse" onClick={toggleListPickerModal}>
+        <Button theme="primary" inverse onClick={toggleListPickerModal}>
           Open List Picker
         </Button>
         <Checkbox checked={showInfoPane} onChange={toggleShowInfoPane} />

--- a/www/examples/Popover.mdx
+++ b/www/examples/Popover.mdx
@@ -7,7 +7,7 @@ import { popoverPlacements, themes } from '../../src/components/Popover/constant
 ```jsx live=true
 <div style={{ width: 150, display: 'flex', justifyContent: 'space-between' }}>
   <Popover placement="right" title="Popover Title" theme="dark" popoverContent="My initial positioning is right">
-    <Button bsStyle="info">Hover Me</Button>
+    <Button theme="info">Hover Me</Button>
   </Popover>
   <Popover
     placement="bottom"
@@ -16,7 +16,7 @@ import { popoverPlacements, themes } from '../../src/components/Popover/constant
     theme="success"
     popoverContent="My initial positioning is bottom"
   >
-    <Button bsStyle="success">Click Me</Button>
+    <Button theme="success">Click Me</Button>
   </Popover>
 </div>
 ```

--- a/www/examples/Tag.mdx
+++ b/www/examples/Tag.mdx
@@ -38,7 +38,7 @@ const Example = () => {
 
   if (_.isEmpty(tags)) {
     return (
-      <Button className="btn-inverse" onClick={resetTags}>
+      <Button inverse onClick={resetTags}>
         Reset tag example
       </Button>
     );

--- a/www/examples/UserListPicker.mdx
+++ b/www/examples/UserListPicker.mdx
@@ -42,7 +42,7 @@ const Example = () => {
         userHeaders={listPickerItemHeaders}
         users={listPickerItems}
       />
-      <Button className="btn-inverse" onClick={toggleModal}>
+      <Button inverse onClick={toggleModal}>
         Assign Team
       </Button>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
- rename bsStyle to theme
- remove bsSize (we already have size) and accepts "small" and "large" (not accepting "lg" and "sm" anymore)
- change the behavior so that inverse should be done via inverse props (and not from className="btn-inverse")

NB: tested on direct-web https://github.com/Adslot/direct-web/pull/12158
## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
