### PR TITLE
[ADS-120] chore: deprecate react bootstrap

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,6 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/__mocks__/fileMock.js',
     '\\.(css|less|scss)$': 'identity-obj-proxy',
-    '^react-bootstrap(.*)$': '<rootDir>/node_modules/react-bootstrap$1',
   },
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6567,30 +6567,6 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        }
-      }
-    },
     "bail": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
@@ -12128,15 +12104,6 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
     },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -15450,12 +15417,6 @@
         }
       }
     },
-    "keycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=",
-      "dev": true
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -18044,16 +18005,6 @@
         "reflect.ownkeys": "^0.2.0"
       }
     },
-    "prop-types-extra": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.0.tgz",
-      "integrity": "sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==",
-      "dev": true,
-      "requires": {
-        "react-is": "^16.3.2",
-        "warning": "^3.0.0"
-      }
-    },
     "property-information": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.2.2.tgz",
@@ -18190,24 +18141,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
-      }
-    },
-    "react-bootstrap": {
-      "version": "0.31.5",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.31.5.tgz",
-      "integrity": "sha512-xgDihgX4QvYHmHzL87faDBMDnGfYyqcrqV0TEbWY+JizePOG1vfb8M3xJN+6MJ3kUYqDtQSZ7v/Q6Y5YDrkMdA==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.0",
-        "invariant": "^2.2.1",
-        "keycode": "^2.1.2",
-        "prop-types": "^15.5.10",
-        "prop-types-extra": "^1.0.1",
-        "react-overlays": "^0.7.4",
-        "uncontrollable": "^4.1.0",
-        "warning": "^3.0.0"
       }
     },
     "react-datepicker": {
@@ -18650,19 +18583,6 @@
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.11.2.tgz",
       "integrity": "sha512-640486eSwU/t5iD6yeTlefma8dI3bxPXD93hM9JGKyYITAd0P1JFkkcDeyHZRqNpY/fv1YW0Fad9BXr44OY8wQ==",
       "dev": true
-    },
-    "react-overlays": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.7.4.tgz",
-      "integrity": "sha512-7vsooMx3siLAuEfTs8FYeP/lAORWWFXTO8PON3KgX0Htq1Oa+po6ioSjGyO0/GO5CVSMNhpWt6V2opeexHgBuQ==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.1",
-        "prop-types": "^15.5.10",
-        "prop-types-extra": "^1.0.1",
-        "warning": "^3.0.0"
-      }
     },
     "react-popper": {
       "version": "2.2.5",
@@ -21633,15 +21553,6 @@
         }
       }
     },
-    "uncontrollable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
-      "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
-      "dev": true,
-      "requires": {
-        "invariant": "^2.1.0"
-      }
-    },
     "unescape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unescape/-/unescape-1.0.1.tgz",
@@ -22048,15 +21959,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "prettier": "^2.3.2",
     "prism-react-renderer": "^1.2.1",
     "prop-types": "^15.7.2",
-    "react-bootstrap": "^0.31.5",
     "react-datepicker": "github:Adslot/react-datepicker#2a1ebb8618e1996c321331ef01d290424272d126",
     "react-dev-utils": "^12.0.0-next.31",
     "react-docgen": "^5.4.0",

--- a/src/components/ConfirmModal/__snapshots__/index.spec.jsx.snap
+++ b/src/components/ConfirmModal/__snapshots__/index.spec.jsx.snap
@@ -2,45 +2,53 @@
 
 exports[`<ConfirmModal /> should show modal when \`show\` is true 1`] = `
 <div
-  class="confirm-modal-component fade in modal"
-  data-testid="confirm-modal-wrapper"
-  role="dialog"
-  style="display: block; padding-right: 0px;"
-  tabindex="-1"
+  class="aui--action-panel is-small action-modal confirm-modal-component"
+  data-testid="action-panel-wrapper"
 >
   <div
-    class="modal-sm modal-dialog"
+    class="aui--action-panel-header has-actions"
+    data-testid="action-panel-header"
   >
     <div
-      class="modal-content"
-      role="document"
+      class="title"
+      data-testid="action-panel-title"
+    />
+    <span
+      class="actions"
     >
-      <div
-        class="modal-body"
-        data-testid="confirm-modal-body"
+      <button
+        class="aui--button btn-default close-button"
+        data-test-selector="header-close-button"
+        data-testid="button-wrapper"
+        type="button"
       >
-        <p>
-          Are you sure?
-        </p>
-      </div>
-      <div
-        class="modal-footer"
-        data-testid="confirm-modal-footer"
-      >
-        <button
-          class="aui--button btn-primary"
-          data-test-selector="confirm-modal-confirm"
-          data-testid="confirm-modal-confirm"
-          type="button"
+        <div
+          class="aui--button-children-container"
         >
-          <div
-            class="aui--button-children-container"
-          >
-            Confirm
-          </div>
-        </button>
-      </div>
-    </div>
+          Cancel
+        </div>
+      </button>
+      <button
+        class="aui--button btn-primary"
+        data-test-selector="confirm-modal-confirm"
+        data-testid="confirm-modal-confirm"
+        type="button"
+      >
+        <div
+          class="aui--button-children-container"
+        >
+          Confirm
+        </div>
+      </button>
+    </span>
+  </div>
+  <div
+    class="aui--action-panel-body"
+    data-testid="action-panel-body"
+  >
+    <p>
+      Are you sure?
+    </p>
   </div>
 </div>
 `;

--- a/src/components/ConfirmModal/index.jsx
+++ b/src/components/ConfirmModal/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Modal from 'react-bootstrap/lib/Modal';
+import ActionPanel from '../ActionPanel';
 import Button from '../Button';
 
 const ConfirmModalComponent = ({
@@ -22,42 +22,29 @@ const ConfirmModalComponent = ({
   };
 
   return (
-    <Modal
-      data-testid="confirm-modal-wrapper"
-      className="confirm-modal-component"
-      show={show}
-      bsSize="small"
-      keyboard={false}
-    >
-      {modalTitle ? (
-        <Modal.Header data-testid="confirm-modal-header">
-          <Modal.Title data-testid="confirm-modal-title">{modalTitle}</Modal.Title>
-        </Modal.Header>
-      ) : null}
-      <Modal.Body data-testid="confirm-modal-body">
-        <p>{modalDescription}</p>
-      </Modal.Body>
-      <Modal.Footer data-testid="confirm-modal-footer">
-        {modalClose ? (
+    show && (
+      <ActionPanel
+        isModal
+        data-testid="confirm-modal-wrapper"
+        className="confirm-modal-component"
+        size="small"
+        title={modalTitle}
+        onClose={cancelAction}
+        closeIcon={buttonCancelLabel}
+        actionButton={
           <Button
-            data-testid="confirm-modal-cancel"
-            inverse
-            onClick={cancelAction}
-            data-test-selector="confirm-modal-cancel"
+            data-testid="confirm-modal-confirm"
+            theme="primary"
+            onClick={applyAction}
+            data-test-selector="confirm-modal-confirm"
           >
-            {buttonCancelLabel}
+            {buttonConfirmLabel}
           </Button>
-        ) : null}
-        <Button
-          data-testid="confirm-modal-confirm"
-          theme="primary"
-          onClick={applyAction}
-          data-test-selector="confirm-modal-confirm"
-        >
-          {buttonConfirmLabel}
-        </Button>
-      </Modal.Footer>
-    </Modal>
+        }
+      >
+        <p>{modalDescription}</p>
+      </ActionPanel>
+    )
   );
 };
 
@@ -98,6 +85,7 @@ ConfirmModalComponent.defaultProps = {
   modalApply: () => {
     throw new Error('AdslotUi ConfirmModal needs a modalApply handler');
   },
+  modalTitle: '',
   modalDescription: 'Are you sure?',
   show: false,
 };

--- a/src/components/ConfirmModal/index.spec.jsx
+++ b/src/components/ConfirmModal/index.spec.jsx
@@ -8,14 +8,14 @@ describe('<ConfirmModal />', () => {
   it('should render with defaults', () => {
     const { getByTestId, queryByTestId } = render(<ConfirmModal show />);
 
-    expect(getByTestId('confirm-modal-wrapper')).toHaveClass('confirm-modal-component');
-    expect(getByTestId('confirm-modal-wrapper')).toHaveClass('modal');
+    expect(getByTestId('action-panel-wrapper')).toHaveClass('confirm-modal-component');
+    expect(getByTestId('action-panel-wrapper')).toHaveClass('action-modal');
+    expect(queryByTestId('action-panel-header')).toBeInTheDocument();
+    expect(queryByTestId('action-panel-body')).toBeInTheDocument();
+    expect(getByTestId('action-panel-body')).toHaveTextContent('Are you sure?');
 
-    expect(queryByTestId('confirm-modal-header')).not.toBeInTheDocument();
-    expect(queryByTestId('confirm-modal-body')).toBeInTheDocument();
-    expect(getByTestId('confirm-modal-body')).toHaveTextContent('Are you sure?');
-
-    expect(queryByTestId('confirm-modal-footer')).toBeInTheDocument();
+    expect(queryByTestId('action-panel-header')).toBeInTheDocument();
+    expect(getByTestId('action-panel-header')).toContainElement(getByTestId('confirm-modal-confirm'));
     expect(getByTestId('confirm-modal-confirm')).toHaveClass('btn-primary');
     expect(getByTestId('confirm-modal-confirm')).toHaveAttribute('data-test-selector', 'confirm-modal-confirm');
     expect(getByTestId('confirm-modal-confirm')).toHaveTextContent('Confirm');
@@ -24,40 +24,34 @@ describe('<ConfirmModal />', () => {
   it('should render with props', () => {
     const props = {
       show: true,
-      buttonCancelLabel: 'Close',
       buttonConfirmLabel: 'OK',
       modalClose: jest.fn(),
       modalDescription: 'If sure, please click confirm.',
       modalTitle: 'Please Confirm',
     };
-    const { getByTestId, queryByTestId } = render(<ConfirmModal {...props} />);
-    expect(getByTestId('confirm-modal-wrapper')).toHaveClass('confirm-modal-component');
-    expect(queryByTestId('confirm-modal-header')).toBeInTheDocument();
-    expect(queryByTestId('confirm-modal-title')).toBeInTheDocument();
-    expect(getByTestId('confirm-modal-title')).toHaveTextContent('Please Confirm');
+    const { getByTestId, queryByTestId, getByText } = render(<ConfirmModal {...props} />);
 
-    expect(queryByTestId('confirm-modal-body')).toBeInTheDocument();
-    expect(getByTestId('confirm-modal-body')).toHaveTextContent('If sure, please click confirm.');
+    expect(getByTestId('action-panel-wrapper')).toHaveClass('confirm-modal-component');
+    expect(queryByTestId('action-panel-header')).toBeInTheDocument();
+    expect(queryByTestId('action-panel-title')).toBeInTheDocument();
+    expect(getByTestId('action-panel-title')).toHaveTextContent('Please Confirm');
 
-    expect(queryByTestId('confirm-modal-footer')).toBeInTheDocument();
+    expect(queryByTestId('action-panel-body')).toBeInTheDocument();
+    expect(getByTestId('action-panel-body')).toHaveTextContent('If sure, please click confirm.');
 
-    expect(getByTestId('confirm-modal-cancel')).toHaveClass('btn-inverse');
-    expect(getByTestId('confirm-modal-cancel')).toHaveAttribute('data-test-selector', 'confirm-modal-cancel');
-    expect(getByTestId('confirm-modal-cancel')).toHaveTextContent('Close');
-
-    expect(getByTestId('confirm-modal-confirm')).toHaveClass('btn-primary');
-    expect(getByTestId('confirm-modal-confirm')).toHaveAttribute('data-test-selector', 'confirm-modal-confirm');
-    expect(getByTestId('confirm-modal-confirm')).toHaveTextContent('OK');
+    expect(queryByTestId('action-panel-header')).toBeInTheDocument();
+    expect(getByTestId('action-panel-header')).toContainElement(getByText('Cancel'));
+    expect(getByTestId('action-panel-header')).toContainElement(getByText('OK'));
   });
 
   it('should show modal when `show` is true', () => {
     const { getByTestId } = render(<ConfirmModal show />);
-    expect(getByTestId('confirm-modal-wrapper')).toMatchSnapshot();
+    expect(getByTestId('action-panel-wrapper')).toMatchSnapshot();
   });
 
   it('should hide modal when `show` is false', () => {
     const { queryByTestId } = render(<ConfirmModal show={false} />);
-    expect(queryByTestId('confirm-modal-wrapper')).not.toBeInTheDocument();
+    expect(queryByTestId('action-panel-wrapper')).not.toBeInTheDocument();
   });
 
   it('should call `modalApply` and `modalClose` when we click Apply', () => {
@@ -82,9 +76,9 @@ describe('<ConfirmModal />', () => {
 
   it('should call `modalClose` when we click Cancel', () => {
     const closeMock = jest.fn();
-    const { getByTestId } = render(<ConfirmModal show modalClose={closeMock} />);
+    const { getByText } = render(<ConfirmModal show modalClose={closeMock} />);
 
-    fireEvent.click(getByTestId('confirm-modal-cancel'));
+    fireEvent.click(getByText('Cancel'));
     expect(closeMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ListPicker/index.jsx
+++ b/src/components/ListPicker/index.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Modal from 'react-bootstrap/lib/Modal';
+import ActionPanel from '../ActionPanel';
 import Button from '../Button';
 import ListPickerPure from '../ListPickerPure';
 import SplitPane from '../SplitPane';
@@ -105,11 +105,38 @@ class ListPickerComponent extends React.PureComponent {
     );
 
     return (
-      <Modal className={modalClassName} show={show} bsSize="large" keyboard={false} data-testid="listpicker-wrapper">
-        <Modal.Header>
-          <Modal.Title>{modalTitle}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
+      show && (
+        <ActionPanel
+          isModal
+          className={modalClassName}
+          title={modalTitle}
+          onClose={this.cancelAction}
+          actionButton={
+            <>
+              {_.isEmpty(linkButtons) ? null : (
+                <div className="pull-left">
+                  {_.map(linkButtons, (linkButton, key) =>
+                    _.isObject(linkButton) && isSubset(_.keys(linkButton), ['label', 'href']) ? (
+                      <Button key={linkButton.label} inverse href={linkButton.href}>
+                        {linkButton.label}
+                      </Button>
+                    ) : (
+                      React.cloneElement(linkButton, { key })
+                    )
+                  )}
+                </div>
+              )}
+              <Button
+                theme="primary"
+                onClick={this.applyAction}
+                disabled={disableApplyButton}
+                data-test-selector="listpicker-apply-button"
+              >
+                Apply
+              </Button>
+            </>
+          }
+        >
           {modalDescription ? <p>{modalDescription}</p> : null}
           {_.isEmpty(itemInfo) ? (
             <div className="listpicker-component-body">{listPickerPureElement}</div>
@@ -138,34 +165,8 @@ class ListPickerComponent extends React.PureComponent {
             </div>
           )}
           {modalFootnote ? <div className="listpicker-component-footnote">{modalFootnote}</div> : null}
-        </Modal.Body>
-        <Modal.Footer>
-          {_.isEmpty(linkButtons) ? null : (
-            <div className="pull-left">
-              {_.map(linkButtons, (linkButton, key) =>
-                _.isObject(linkButton) && isSubset(_.keys(linkButton), ['label', 'href']) ? (
-                  <Button key={linkButton.label} inverse href={linkButton.href}>
-                    {linkButton.label}
-                  </Button>
-                ) : (
-                  React.cloneElement(linkButton, { key })
-                )
-              )}
-            </div>
-          )}
-          <Button inverse onClick={this.cancelAction} data-test-selector="listpicker-cancel-button">
-            Cancel
-          </Button>
-          <Button
-            theme="primary"
-            onClick={this.applyAction}
-            disabled={disableApplyButton}
-            data-test-selector="listpicker-apply-button"
-          >
-            Apply
-          </Button>
-        </Modal.Footer>
-      </Modal>
+        </ActionPanel>
+      )
     );
   }
 }

--- a/src/components/ListPicker/index.spec.jsx
+++ b/src/components/ListPicker/index.spec.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { render, cleanup, fireEvent } from '@testing-library/react';
-import Radio from 'react-bootstrap/lib/Radio';
+import Radio from '../Radio';
 import SvgSymbol from '../SvgSymbol';
 import ListPickerComponent from '.';
-
 import ListPickerMocks from '../ListPicker/mocks';
 
 afterEach(cleanup);
@@ -23,11 +22,8 @@ describe('<ListPicker />', () => {
     const { getByTestId, getByText } = render(
       <ListPickerComponent itemInfo={{ label: 'Label', properties: [] }} show />
     );
-    expect(getByTestId('listpicker-wrapper')).toHaveClass('listpicker-component');
-    expect(getByTestId('listpicker-wrapper').firstChild).toHaveClass('modal-lg modal-dialog');
-
-    expect(getByText('Select Items')).toHaveClass('modal-title');
-    expect(getByText('Select Items').parentElement).toHaveClass('modal-header');
+    expect(getByTestId('action-panel-wrapper')).toHaveClass('listpicker-component');
+    expect(getByText('Select Items')).toHaveClass('title');
 
     const listpickerPure = getByTestId('listpickerpure-wrapper');
     expect(listpickerPure).toContainElement(getByTestId('empty-wrapper'));
@@ -35,13 +31,9 @@ describe('<ListPicker />', () => {
     expect(getByTestId('empty-wrapper')).toContainElement(getByTestId('empty-text'));
     expect(getByTestId('empty-text')).toHaveTextContent('No items to select.');
 
-    expect(getByText('Cancel').parentElement).toHaveClass('btn-inverse');
-    expect(getByText('Cancel').parentElement.tagName).toEqual('BUTTON');
-    expect(getByText('Cancel').parentElement.parentElement).toHaveClass('modal-footer');
-    expect(getByText('Apply').parentElement).toHaveClass('aui--button btn-primary');
-    expect(getByText('Apply').parentElement.tagName).toEqual('BUTTON');
-    expect(getByText('Apply').parentElement.parentElement).toHaveClass('modal-footer');
-    expect(getByText('Apply').parentElement).not.toBeDisabled;
+    expect(getByTestId('action-panel-header')).toHaveClass('has-actions');
+    expect(getByTestId('action-panel-header')).toContainElement(getByText('Cancel'));
+    expect(getByTestId('action-panel-header')).toContainElement(getByText('Apply'));
   });
 
   it('should render with props', () => {
@@ -63,14 +55,8 @@ describe('<ListPicker />', () => {
       <ListPickerComponent {...props} items={items} show />
     );
 
-    expect(getByTestId('listpicker-wrapper')).toHaveClass('listpicker-component');
-    expect(getByTestId('listpicker-wrapper').firstChild).toHaveClass('modal-lg modal-dialog');
-
-    expect(getByText('Select Users')).toHaveClass('modal-title');
-    expect(getByText('Select Users').parentElement).toHaveClass('modal-header');
-
-    expect(getByText('Select users.').tagName).toEqual('P');
-    expect(getByText('Select users.').parentElement).toHaveClass('modal-body');
+    expect(getByTestId('action-panel-wrapper')).toHaveClass('listpicker-component');
+    expect(getByText('Select Users')).toHaveClass('title');
 
     expect(getByText('You can select multiple users.')).toHaveClass('listpicker-component-footnote');
 
@@ -84,11 +70,11 @@ describe('<ListPicker />', () => {
     expect(queryAllByTestId('checkbox-input')[1]).toBeChecked(); // selectedItems
     expect(queryAllByTestId('checkbox-input')[2]).not.toBeChecked();
 
+    expect(getByTestId('action-panel-header')).toHaveClass('has-actions');
+    expect(getByTestId('action-panel-header')).toContainElement(getByText('Cancel'));
+    expect(getByTestId('action-panel-header')).toContainElement(getByText('Create User'));
+
     expect(getByText('Create User')).toHaveAttribute('href', '#');
-    expect(getByText('Create User').parentElement.parentElement).toHaveClass('btn-inverse');
-    expect(getByText('Create User').parentElement.parentElement.parentElement.parentElement).toHaveClass(
-      'modal-footer'
-    );
 
     expect(getByTestId('listpickerpure-wrapper')).toHaveAttribute(
       'data-test-selector',
@@ -130,13 +116,12 @@ describe('<ListPicker />', () => {
       modalTitle: 'Select Users',
     };
     const { getByTestId, queryAllByTestId, getByText } = render(<ListPickerComponent {...props} show />);
-    expect(getByTestId('listpicker-wrapper')).toHaveClass('listpicker-component');
+    expect(getByTestId('action-panel-wrapper')).toHaveClass('listpicker-component');
 
-    expect(getByText('Select Users')).toHaveClass('modal-title');
-    expect(getByText('Select Users').parentElement).toHaveClass('modal-header');
+    expect(getByText('Select Users')).toHaveClass('title');
 
     expect(getByText('Select users.').tagName).toEqual('P');
-    expect(getByText('Select users.').parentElement).toHaveClass('modal-body');
+    expect(getByText('Select users.').parentElement).toHaveClass('aui--action-panel-body');
 
     expect(getByText('You can select multiple users.')).toHaveClass('listpicker-component-footnote');
 
@@ -175,8 +160,8 @@ describe('<ListPicker />', () => {
 
   it('should disable apply button for empty selection if `allowEmptySelection` is false', () => {
     const props = { allowEmptySelection: false, items: users };
-    const { getByText } = render(<ListPickerComponent {...props} show />);
-    expect(getByText('Apply').parentElement.parentElement).toHaveClass('modal-footer');
+    const { getByText, getByTestId } = render(<ListPickerComponent {...props} show />);
+    expect(getByTestId('action-panel-header')).toContainElement(getByText('Apply'));
     expect(getByText('Apply').parentElement).toBeDisabled();
   });
 
@@ -241,12 +226,12 @@ describe('<ListPicker />', () => {
 
   it('should show modal when `show` is true', () => {
     const { queryByTestId } = render(<ListPickerComponent show />);
-    expect(queryByTestId('listpicker-wrapper')).toBeInTheDocument();
+    expect(queryByTestId('action-panel-wrapper')).toBeInTheDocument();
   });
 
   it('should hide modal when `show` is false', () => {
     const { queryByTestId } = render(<ListPickerComponent show={false} />);
-    expect(queryByTestId('listpicker-wrapper')).not.toBeInTheDocument();
+    expect(queryByTestId('action-panel-wrapper')).not.toBeInTheDocument();
   });
 
   it('should only call `modalApply` when we click Apply', () => {
@@ -313,20 +298,20 @@ describe('<ListPicker />', () => {
     });
 
     it('should render as node', () => {
-      props.linkButtons = [<Radio data-testid="testing-radio" />];
+      props.linkButtons = [<Radio />];
       const { getByTestId, queryByTestId } = render(<ListPickerComponent {...props} show />);
-      expect(queryByTestId('testing-radio')).toBeInTheDocument();
-      expect(getByTestId('testing-radio').tagName).toEqual('INPUT');
-      expect(getByTestId('testing-radio')).toHaveAttribute('type', 'radio');
+      expect(queryByTestId('radio-wrapper')).toBeInTheDocument();
+      expect(getByTestId('radio-input').tagName).toEqual('INPUT');
+      expect(getByTestId('radio-input')).toHaveAttribute('type', 'radio');
     });
 
     it('should render as mixed nodes and buttons', () => {
-      props.linkButtons = [{ label: 'Create User', href: '#' }, <Radio data-testid="testing-radio" />];
+      props.linkButtons = [{ label: 'Create User', href: '#' }, <Radio />];
       const { getByTestId, queryByTestId, getByText } = render(<ListPickerComponent {...props} show />);
 
-      expect(queryByTestId('testing-radio')).toBeInTheDocument();
-      expect(getByTestId('testing-radio').tagName).toEqual('INPUT');
-      expect(getByTestId('testing-radio')).toHaveAttribute('type', 'radio');
+      expect(queryByTestId('radio-wrapper')).toBeInTheDocument();
+      expect(getByTestId('radio-input').tagName).toEqual('INPUT');
+      expect(getByTestId('radio-input')).toHaveAttribute('type', 'radio');
 
       expect(getByText('Create User').parentElement.parentElement).toHaveClass('btn-inverse');
       expect(getByText('Create User')).toHaveAttribute('href', '#');

--- a/src/components/UserListPicker/index.spec.jsx
+++ b/src/components/UserListPicker/index.spec.jsx
@@ -11,12 +11,12 @@ describe('<UserListPicker />', () => {
   it('should render with defaults', () => {
     const { getByTestId, queryByTestId, getByText } = render(<UserListPicker show />);
 
-    expect(queryByTestId('listpicker-wrapper')).toBeInTheDocument();
-    expect(getByTestId('listpicker-wrapper')).toHaveClass('userlistpicker-component');
+    expect(queryByTestId('action-panel-wrapper')).toBeInTheDocument();
+    expect(getByTestId('action-panel-wrapper')).toHaveClass('userlistpicker-component');
 
-    expect(getByText('Select Users')).toHaveClass('modal-title');
+    expect(getByText('Select Users')).toHaveClass('title');
     expect(getByText('Select users.').tagName).toEqual('P');
-    expect(getByText('Select users.').parentElement).toHaveClass('modal-body');
+    expect(getByText('Select users.').parentElement).toHaveClass('aui--action-panel-body');
 
     expect(queryByTestId('grid-row-wrapper')).toBeInTheDocument();
     expect(getByTestId('grid-row-wrapper')).toHaveClass('grid-component-row-header');
@@ -41,12 +41,12 @@ describe('<UserListPicker />', () => {
     };
     const { getByTestId, queryByTestId, queryAllByTestId, getByText } = render(<UserListPicker {...props} show />);
 
-    expect(queryByTestId('listpicker-wrapper')).toBeInTheDocument();
-    expect(getByTestId('listpicker-wrapper')).toHaveClass('userlistpicker-component');
+    expect(queryByTestId('action-panel-wrapper')).toBeInTheDocument();
+    expect(getByTestId('action-panel-wrapper')).toHaveClass('userlistpicker-component');
 
-    expect(getByText('Select Team Members')).toHaveClass('modal-title');
+    expect(getByText('Select Team Members')).toHaveClass('title');
     expect(getByText('Select team members that you want.').tagName).toEqual('P');
-    expect(getByText('Select team members that you want.').parentElement).toHaveClass('modal-body');
+    expect(getByText('Select team members that you want.').parentElement).toHaveClass('aui--action-panel-body');
 
     expect(queryAllByTestId('grid-row-wrapper')).toHaveLength(4);
     expect(queryAllByTestId('grid-row-wrapper')[0]).toHaveClass('grid-component-row-header');

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,3 @@
-// Export the consumable components.
-import Dropdown from 'react-bootstrap/lib/Dropdown';
-import MenuItem from 'react-bootstrap/lib/MenuItem';
-import Modal from 'react-bootstrap/lib/Modal';
-import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
-import ProgressBar from 'react-bootstrap/lib/ProgressBar';
-
 import './styles/_bootstrap-custom.scss';
 import './styles/_icheck-custom.scss';
 
@@ -95,7 +88,6 @@ export {
   CheckboxGroup,
   ConfirmModal,
   CountBadge,
-  Dropdown,
   DatePicker,
   Empty,
   fastStatelessWrapper,
@@ -108,18 +100,14 @@ export {
   HelpIconPopover,
   ListPicker,
   ListPickerPure,
-  MenuItem,
-  Modal,
   Nav,
   NavItem,
-  OverlayTrigger,
   PagedGrid,
   PageTitle,
   Pagination,
   Panel,
   Popover,
   PrettyDiff,
-  ProgressBar,
   Radio,
   RadioGroup,
   Search,

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -1313,7 +1313,11 @@
             "name": "string"
           },
           "required": false,
-          "description": "title of the modal"
+          "description": "title of the modal",
+          "defaultValue": {
+            "value": "''",
+            "computed": false
+          }
         },
         "show": {
           "type": {

--- a/www/examples/Tab.mdx
+++ b/www/examples/Tab.mdx
@@ -53,8 +53,7 @@ render(Example);
 
 <DesignNotes>
   Tabs are most commonly used with areas that require the user to switch between views. Each tab label is supported by
-  an icon. This is not a react-bootstrap component. However it implements the same API for switching tabs. Only the
-  props listed are supported.
+  an icon. Only the props listed are supported.
 </DesignNotes>
 
 ### Tab


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

- Deprecate `react-bootstrap` with replacing `<Modal />` with `<ActionPanel isModal />`.
- Refactor `<ListPicker />` component
- Also refactor `<ConfirmModal />` and `<UserListPicker />`
- All above changes are supposed to align with the old UI, styles and how to use it.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
