### PR TITLE
[ASC-129] docs: add popover example for triggers

### DIFF
--- a/www/examples/Popover.mdx
+++ b/www/examples/Popover.mdx
@@ -74,6 +74,39 @@ render(
 
 <br />
 <br />
+<h4>Use Popover triggers as an alternative to Popover.WithRef.</h4>
+<h4>Code will be leaner with the following way.</h4>
+
+```jsx live=true
+const Example = () => {
+  const [safeMode, setSafeMode] = React.useState(true);
+  const toggleSafeMode = () => setSafeMode(!safeMode);
+
+  return (
+    <React.Fragment>
+      <Button onClick={toggleSafeMode}>{`Turn ${safeMode ? 'off' : 'on'} Safe Mode`}</Button>
+      <Popover
+        isOpen={safeMode}
+        triggers={safeMode ? ['hover'] : ['disabled']}
+        placement="right"
+        theme="dark"
+        popoverContent="Safe mode, not able to launch"
+      >
+        <Button disabled={safeMode}>Launch</Button>
+      </Popover>
+    </React.Fragment>
+  );
+};
+
+render(
+  <div style={{ display: 'flex', width: 300, justifyContent: 'space-between' }}>
+    <Example />
+  </div>
+);
+```
+
+<br />
+<br />
 <h4>Popover autoflips when overflowing container</h4>
 
 ```jsx live=true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

As discussed, we can use `<Popover triggers>` to replace some use cases of `<Popover.WithRef>` and make code leaner. Record the use case as a demo.
![Kapture 2021-07-02 at 10 00 34](https://user-images.githubusercontent.com/42738416/124201842-67161600-db1c-11eb-9f2c-475cd98cd5e7.gif)



## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
