### PR TITLE
fix: ActionPanel body content can always overflow

### DIFF
--- a/src/components/ActionPanel/styles.scss
+++ b/src/components/ActionPanel/styles.scss
@@ -18,6 +18,11 @@
     background-color: $color-white;
     margin: 30px auto;
     border: 0;
+
+    .aui--action-panel-body {
+      max-height: calc(100vh - var(--action-panel-margin-top) - var(--action-panel-margin-bottom) - var(--action-panel-header-height));
+      overflow: auto;
+    }
   }
 
   &.is-small {
@@ -33,7 +38,7 @@
   }
 
   &-header {
-    height: 48px;
+    height: $action-panel-header-height;
     color: $color-gray-darkest;
     padding: 12px;
     padding-left: 18px;
@@ -139,7 +144,7 @@
   left: 0;
   background-color: $color-gray-dark;
   width: 100%;
-  opacity: .8;
+  opacity: $action-panel-backdrop-opacity;
   animation: fadein .2s;
 }
 
@@ -151,4 +156,5 @@
   align-content: center;
   top: 0;
   left: 0;
+  animation: fadein .2s;
 }

--- a/src/styles/animation.scss
+++ b/src/styles/animation.scss
@@ -1,9 +1,11 @@
+@import '~styles/variable';
+
 @keyframes fadein {
   from {
     opacity: 0;
   }
 
   to {
-    opacity: .9;
+    opacity: $action-panel-backdrop-opacity;
   }
 }

--- a/src/styles/variable.scss
+++ b/src/styles/variable.scss
@@ -79,6 +79,11 @@ $modal-backdrop-bg: $color-gray-darker;
 $modal-backdrop-opacity: .8;
 $modal-content-border-color: transparent;
 
+// == ActionPanel
+$action-panel-backdrop-opacity: .8;
+$action-panel-header-height: 48px;
+$action-panel-margin: 30px;
+
 // == Tables
 $table-bg-accent: $color-gray-white; // for striping;
 $table-bg-hover: $color-gray-white; // for hover;


### PR DESCRIPTION
## Description

- Set ActionPanel max-height and overflow by default so we don't have to add it manually in each custom component's css
  - the ActionPanel as a modal should always have a max-height so that content can overflow on small screens or when there is a lot of content
- also fix a small bug with the fadein animation that caused a bit of a flicker when opening a modal

Fixes ADS-4854

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):
