### PR TITLE
[ADS-5505] chore: add vscode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/javascript-node
+{
+	"name": "Node.js",
+	"image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:14-buster",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8888],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm run deps",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/README.md
+++ b/README.md
@@ -24,11 +24,26 @@ Technology:
 
 ## Development
 
-- Take a look at our [Contributing](https://ui.adslot.com/contributing) guidelines
+To get started, take a look at our [Contributing](https://ui.adslot.com/contributing) guidelines
+
+### Native
 
 - Clone the repo: `git clone git@github.com:Adslot/adslot-ui.git`
+- Install NPM dependencies: `npm run deps`
 
-- Install NPM dependencies: `npm i`
+### Visual Studio Code Remote - Containers
+
+- Install [Docker](https://docs.docker.com/get-docker/)
+- Install [Visual Studio Code](https://code.visualstudio.com/)
+- Install [Visual Studio Code Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in your VS Code.
+- Start VS Code and run `Remote-Containers: Clone Repository in Container Volume...` from the Command Palette.
+- Authenticate with your GitHub account.
+- Enter `adslot/adslot-ui` in the input box that appears and press `Enter`.
+- VS Code window (instance) will reload, clone the source code of this project, and start building the dev container. A progress notifications provides status updates.
+- After the build completes, VS Code will automatically connect to the container. You can now work with the repository source code in this independent environment as you would if you had cloned the code locally.
+
+Notes:
+- Due to bind mount performance issues on Windows and macOS, the steps above uses the [Clone Repository in Container Volume](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume) method. Other options can be found [here](https://code.visualstudio.com/docs/remote/containers).
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "generate-docs": "node ./scripts/generateDocs.js",
     "clean": "rimraf dist/* docs/*",
+    "deps": "ADBLOCK=true DISABLE_OPENCOLLECTIVE=true npm ci",
     "dist:dev": "node ./scripts/build.js",
     "dist:prod": "cross-env NODE_ENV=dist node ./scripts/build.js",
     "dist:demo": "cross-env NODE_ENV=production DEMO_ASSETS=true node ./scripts/build.js",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
- Add VS Code `.devcontainer.json` which allows for easy development environment setup using VS Code and Docker
- Add `npm run deps` run script

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->
- Open VSCode and use `Remote-Containers: Clone Repository in Container Volume...` (for significant performance improvement on MacOS): https://code.visualstudio.com/docs/remote/containers-advanced#_use-clone-repository-in-container-volume
- VSCode would automatically start and run `npm run deps` in terminal
- Open a separate terminal tab and run `npm start`
- Access docs/demo at http://localhost:8888

## Screenshots (if appropriate):
