### PR TITLE
[ADS-5650] ci: deploy docs to netlify as part of build github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and Deploy
 
 on:
   push:
@@ -22,6 +22,14 @@ jobs:
       - run: npm -v
       - run: npm ci
       - run: npm run dist
+      - name: Deploy docs to Netlify
+        run: |
+          # Truncate branch name at 37 characters per alias requirement: https://cli.netlify.com/commands/deploy/
+          BRANCH_NAME=${{github.head_ref}}
+          BRANCH_NAME=${BRANCH_NAME:0:37}
+
+          NETLIFY_AUTH_TOKEN=${{secrets.NETLIFY_AUTH_TOKEN}} NETLIFY_SITE_ID=${{secrets.NETLIFY_SITE_ID}} \
+            npx netlify-cli deploy --dir=docs --message="${BRANCH_NAME}" --alias="${BRANCH_NAME}"
       - name: Notify Slack channel
         if: always() && job.status != 'success' && github.ref == 'refs/heads/master'
         env:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Implement draft branch (PR) deploys to Netlify, each branch push would have generated docs deployed to `https://<branch-name>--adslot-ui.netlify.app/`.

E.g. this PR's generated docs can be found at https://netlify-deploy--adslot-ui.netlify.app/

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
![Screen Shot 2021-07-26 at 9 52 02 pm](https://user-images.githubusercontent.com/818316/126984420-4e286476-86f0-4373-9c70-2159b6bbcb9d.png)