### PR TITLE
[ADS-5650] ci: accommodate master branch deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,14 @@ jobs:
       - run: npm run dist
       - name: Deploy docs to Netlify
         run: |
-          # Truncate branch name at 37 characters per alias requirement: https://cli.netlify.com/commands/deploy/
-          BRANCH_NAME=${{github.head_ref}}
-          BRANCH_NAME=${BRANCH_NAME:0:37}
+          BRANCH_NAME=""
+          if [[ ${{github.ref}} == "refs/heads/master" ]]; then
+            BRANCH_NAME="master"
+          else
+            # Truncate branch name at 37 characters per alias requirement: https://cli.netlify.com/commands/deploy/
+            BRANCH_NAME=${{github.head_ref}}
+            BRANCH_NAME=${BRANCH_NAME:0:37}
+          fi
 
           NETLIFY_AUTH_TOKEN=${{secrets.NETLIFY_AUTH_TOKEN}} NETLIFY_SITE_ID=${{secrets.NETLIFY_SITE_ID}} \
             npx netlify-cli deploy --dir=docs --message="${BRANCH_NAME}" --alias="${BRANCH_NAME}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Add additional logic to handle `master` branch deploys which do not have the `github.head_ref` variable which was missed in https://github.com/Adslot/adslot-ui/pull/1183

Latest `master` branch will be available at https://master--adslot-ui.netlify.app/ after this PR merges

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
