### PR TITLE
fix: use sass variables in action panel max-height

### DIFF
--- a/src/components/ActionPanel/styles.scss
+++ b/src/components/ActionPanel/styles.scss
@@ -20,7 +20,7 @@
     border: 0;
 
     .aui--action-panel-body {
-      max-height: calc(100vh - var(--action-panel-margin-top) - var(--action-panel-margin-bottom) - var(--action-panel-header-height));
+      max-height: calc(100vh - #{$action-panel-margin * 2} - #{$action-panel-header-height});
       overflow: auto;
     }
   }


### PR DESCRIPTION
The action panel changes in #1179 were supposed to use sass variables, but I unintentionally committed css variables that I was testing with. This reverts that.

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
can be testing in https://action-panel-fix--adslot-ui.netlify.app/action-panel by opening the action panel modal and adding more content inside `aui--action-panel-body` and optionally resize browser height to simulate a smaller screen

## Screenshots (if appropriate):
![Screen Shot 2021-08-06 at 10 33 26 am](https://user-images.githubusercontent.com/13904763/128438234-880519cb-db72-4e5d-90b2-0d6995dbc6cb.png)
