### PR TITLE
v28.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "28.0.1",
+  "version": "28.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "28.0.1",
+  "version": "28.0.2",
   "description": "Core component library. By Adslot",
   "main": "dist/adslot-ui-main.js",
   "files": [


### PR DESCRIPTION
### Changes

- [d11eeea09f9a6551fa61f6b1c49e76e94b6400c7] chore: upgrade wepback to 5
 
- [6f5cdf76c222be6f8c3a6513fb05c92032e6650e] test: fix tests and eslint errors
 
- [7deb8597b1412c0877e0c70e565768266bab6369] chore: update svgo
 
- [82328fa2ce08c5dc056765aad9053701626c6551] chore: upgrade node modules
 
- [60a1b78e3ae41043c229bdae18ca893da3943d99] chore: dist
 
- [3bc89b65e2b7d21d4dff0efb7d904e8a9cfb67b7] fix: fix deps issues post webpack5 merge
 
	


	- Fix package-lock missing optional dep


	- Remove unused file-loader dev dep


	- Downgrade husky to 4.3.8 for now


	- Remove unused url-loader dev dep

- [6eea2a5dad3714d6508ef90a47caa69971977af8] build: release patch version 28.0.2
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v28.0.1...v28.0.2