### PR TITLE
fix: [carousel] prevent clicks when swiping

### DIFF
--- a/src/components/Carousel/index.jsx
+++ b/src/components/Carousel/index.jsx
@@ -36,4 +36,36 @@ CarouselComponent.defaultProps = {
   dots: true,
 };
 
+const SWIPE_DELTA = 3;
+
+const usePreventCarouselSwipeClicks = () => {
+  const [mousePos, setMousePos] = React.useState({});
+
+  const onMouseDownCapture = (e) => {
+    setMousePos({ clientX: e.clientX, clientY: e.clientY });
+  };
+
+  const onClickCapture = (e) => {
+    const deltaX = Math.abs(mousePos.clientX - e.clientX);
+    const deltaY = Math.abs(mousePos.clientY - e.clientY);
+
+    if (deltaX > SWIPE_DELTA || deltaY > SWIPE_DELTA) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  };
+
+  return {
+    onMouseDownCapture,
+    onClickCapture,
+  };
+};
+
+/**
+ * A hook to prevent child click handlers from firing immediately after swiping the Carousel
+ *
+ * @returns {object} - to be spread onto any carousel items with `onClick` handlers
+ */
+CarouselComponent.usePreventSwipeClicks = usePreventCarouselSwipeClicks;
+
 export default CarouselComponent;

--- a/src/components/Carousel/index.spec.jsx
+++ b/src/components/Carousel/index.spec.jsx
@@ -9,6 +9,19 @@ const getByDataIndex = queryByAttribute.bind(null, 'data-index');
 const getById = queryByAttribute.bind(null, 'id');
 const queryAllByClass = queryAllByAttribute.bind(null, 'class');
 
+const CarouselHookTest = React.forwardRef(({ onClick }, ref) => {
+  const props = Carousel.usePreventSwipeClicks();
+  return (
+    <Carousel ref={ref} slidesToShow={1}>
+      {_.map(new Array(5), (value, index) => (
+        <button {...props} onClick={onClick} id={`btn-${index}`} key={index}>
+          <img src={`path/to/image-${index}.jpg`} alt={index} id={`img-${index}`} />
+        </button>
+      ))}
+    </Carousel>
+  );
+});
+
 describe('<Carousel />', () => {
   it('should render with defaults', () => {
     const { container } = render(<Carousel />);
@@ -88,5 +101,35 @@ describe('<Carousel />', () => {
     fireEvent.click(getByText('3'));
     expect(getByDataIndex(container, '2')).toHaveClass('slick-current');
     expect(getById(getByDataIndex(container, '3'), 'img-3')).toBeTruthy();
+  });
+
+  it('should not fire click events when swiping with usePreventSwipeClicks', () => {
+    const onClick = jest.fn();
+    const ref = { current: false };
+    const { container } = render(<CarouselHookTest ref={ref} onClick={onClick} />);
+
+    fireEvent.mouseDown(getById(getByDataIndex(container, '1'), 'btn-1'), {
+      clientX: 0,
+      clientY: 0,
+    });
+
+    fireEvent.click(getById(getByDataIndex(container, '1'), 'btn-1'), {
+      clientX: 100,
+      clientY: 0,
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(0);
+
+    fireEvent.mouseDown(getById(getByDataIndex(container, '1'), 'btn-1'), {
+      clientX: 0,
+      clientY: 0,
+    });
+
+    fireEvent.click(getById(getByDataIndex(container, '1'), 'btn-1'), {
+      clientX: 3,
+      clientY: 0,
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -954,7 +954,23 @@
     {
       "description": "",
       "displayName": "CarouselComponent",
-      "methods": [],
+      "methods": [
+        {
+          "name": "usePreventSwipeClicks",
+          "docblock": "A hook to prevent child click handlers from firing immediately after swiping the Carousel\n\n@returns {object} - handlers to be spread onto any carousel items with `onClick` handlers",
+          "modifiers": [
+            "static"
+          ],
+          "params": [],
+          "returns": {
+            "description": "handlers to be spread onto any carousel items with `onClick` handlers",
+            "type": {
+              "name": "object"
+            }
+          },
+          "description": "A hook to prevent child click handlers from firing immediately after swiping the Carousel"
+        }
+      ],
       "props": {
         "className": {
           "type": {

--- a/www/examples/Carousel.mdx
+++ b/www/examples/Carousel.mdx
@@ -35,6 +35,37 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 </Carousel>
 ```
 
+<br />
+
+### `usePreventSwipeClicks` hook
+
+This hook should be used when carousel items have an `onClick` handler,
+to avoid the click being triggered when letting go of the mouse button after swiping.
+
+- The hook returns an object that has the required click capture handlers
+
+```jsx live=true
+const SwipeClickPreventionCarouselExample = () => {
+  const handlers = Carousel.usePreventSwipeClicks();
+  const onClick = () => alert('slide clicked');
+  return (
+    <Carousel>
+      {Array.from(Array(4).keys()).map((_, i) => (
+        <div key={i} {...handlers} onClick={onClick}>
+          <img
+            src={`./assets/carousel/carousel-${i + 1}.jpg`}
+            alt={`Slide ${i + 1}`}
+            style={{ paddingRight: 20, width: 420, height: 300 }}
+          />
+        </div>
+      ))}
+    </Carousel>
+  );
+};
+
+render(<SwipeClickPreventionCarouselExample />);
+```
+
 ### Design Notes
 
 <DesignNotes>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When dragging the carousel and letting go on top of a child with an `onClick`, that `onClick` will be fired.

## Description

This PR adds a hook that can be used to prevent unwanted clicks from firing when swiping.

### Usage
```jsx
import { Carousel } from 'adslot-ui'
 const Component = () => {
  // the returned value is an object that has the required click capture handlers
  const itemProps = Carousel.usePreventSwipeClicks(); 
  return (
    <Carousel>
      <button {...itemProps} onClick={someClickHandler}></button>
    </Carousel>
  )
}
```


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):
