### PR TITLE
[ADS-5774] chore: upgrade webpack-dev-server to 4.1.1 to resolve dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4935,10 +4935,10 @@
         }
       }
     },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+    "ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true
     },
     "ansi-regex": {
@@ -22529,12 +22529,12 @@
       }
     },
     "webpack-dev-server": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.0.0.tgz",
-      "integrity": "sha512-ya5cjoBSf3LqrshZn2HMaRZQx8YRNBE+tx+CQNFGaLLHrvs4Y1aik0sl5SFhLz2cW1O9/NtyaZhthc+8UiuvkQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.1.1.tgz",
+      "integrity": "sha512-Kl1mnCEw8Cy1Kw173gCxLIB242LfPKEOj9WoKhKz/MbryZTNrILzOJTk8kiczw/YUEPzn3gcltCQv6hDsLudRg==",
       "dev": true,
       "requires": {
-        "ansi-html": "^0.0.7",
+        "ansi-html-community": "^0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.2",
@@ -22588,9 +22588,9 @@
           }
         },
         "ws": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.0.tgz",
-          "integrity": "sha512-uYhVJ/m9oXwEI04iIVmgLmugh2qrZihkywG9y5FfZV2ATeLIzHf93qs+tUNqlttbQK957/VX3mtwAS+UfIwA4g==",
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.1.tgz",
+          "integrity": "sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.0.0",
+    "webpack-dev-server": "^4.1.1",
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Upgrade webpack-dev-server to 4.1.1 to resolve dependabot alert for `ansi-html`

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
