### PR TITLE
[ASC-114] fix: change Tag baseClass to className

### DIFF
--- a/src/components/Tag/index.jsx
+++ b/src/components/Tag/index.jsx
@@ -21,15 +21,15 @@ ActionButton.propTypes = {
   actionIcon: PropTypes.node,
 };
 
-const Tag = ({ children, inverse, id, onAction, accent, baseClass, actionIcon, dts: customDts }) => {
+const Tag = ({ children, inverse, id, onAction, accent, className, actionIcon, dts: customDts }) => {
   const classes = classnames([
     defaultComponentClass,
     {
-      [`${baseClass}-inverse`]: inverse,
-      [`${baseClass}-accent accent-${accent}`]: accent,
+      [`${defaultComponentClass}-inverse`]: inverse,
+      [`${defaultComponentClass}-accent accent-${accent}`]: accent,
       [`${defaultComponentClass}-actionable`]: onAction,
-      [`${baseClass}`]: baseClass !== defaultComponentClass,
     },
+    className,
   ]);
   const dts = customDts || `tag-${id}`;
 
@@ -45,7 +45,7 @@ Tag.propTypes = {
   children: PropTypes.node.isRequired,
   id: PropTypes.string,
   accent: PropTypes.string,
-  baseClass: PropTypes.string,
+  className: PropTypes.string,
   inverse: PropTypes.bool,
   onAction: PropTypes.func,
   actionIcon: PropTypes.node,
@@ -54,7 +54,6 @@ Tag.propTypes = {
 
 Tag.defaultProps = {
   id: 'default',
-  baseClass: 'tag-component',
 };
 
 export default Tag;

--- a/src/components/Tag/index.spec.jsx
+++ b/src/components/Tag/index.spec.jsx
@@ -73,8 +73,8 @@ describe('<Tag />', () => {
     expect(queryAllByTestId('tag-child')).toHaveLength(2);
   });
 
-  it('should render a tag with base class', () => {
-    const { getByTestId } = render(<Tag baseClass="foo">You are it!</Tag>);
+  it('should render a tag with custom className', () => {
+    const { getByTestId } = render(<Tag className="foo">You are it!</Tag>);
     expect(getByTestId('tag-wrapper')).toHaveClass('tag-component foo');
   });
 

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -4978,16 +4978,12 @@
           "required": false,
           "description": ""
         },
-        "baseClass": {
+        "className": {
           "type": {
             "name": "string"
           },
           "required": false,
-          "description": "",
-          "defaultValue": {
-            "value": "'tag-component'",
-            "computed": false
-          }
+          "description": ""
         },
         "inverse": {
           "type": {

--- a/www/examples/Tag.mdx
+++ b/www/examples/Tag.mdx
@@ -51,7 +51,7 @@ const Example = () => {
           key={tag.id}
           id={tag.id}
           accent={tag.accent}
-          baseClass={tag.baseClass}
+          className={tag.className}
           onAction={deleteTag}
           inverse
           actionIcon={<SvgSymbol href={tag.actionIconSvgHref} />}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Deprecate `baseClass` and use `className` instead.
https://adslot.atlassian.net/browse/ASC-114

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
