### PR TITLE
docs: add documentation for component methods

### DIFF
--- a/www/containers/Props.jsx
+++ b/www/containers/Props.jsx
@@ -59,6 +59,75 @@ const Props = ({ componentName, customMapper }) => {
             </tbody>
           </table>
         </div>
+        {componentProps.methods && componentProps.methods.length > 0 && (
+          <>
+            <h3>Methods</h3>
+            {_.map(componentProps.methods, (method) => {
+              return (
+                <div key={method.name} className="aui--docs-method-block">
+                  <section className="aui--docs-method-details">
+                    <h4>
+                      <code>
+                        <strong>{HtmlParser(_.get(method, 'name'), '')}</strong> (
+                        {method.params.map((param, i) => (
+                          <span key={param.name}>
+                            {param.name}
+                            {param.optional && '?'}
+                            {param.type?.name && `: ${HtmlParser(_.get(param, 'type.name'), '')}}`}
+                            {i !== method.params.length - 1 && ', '}
+                          </span>
+                        ))}
+                        ){method.returns?.type && ` => ${HtmlParser(_.get(method, 'returns.type.name'), '')}`}
+                      </code>
+                    </h4>
+                    {method.description && (
+                      <p>
+                        <strong>Description </strong>
+                        {HtmlParser(method.description)}
+                      </p>
+                    )}
+                    {method.returns && (
+                      <p>
+                        <strong>Returns </strong>
+                        <code>{HtmlParser(_.get(method, 'returns.type.name'), '')}</code>
+                        {_.get(method, 'returns.description') &&
+                          ` - ${HtmlParser(_.get(method, 'returns.description'), '')}`}
+                      </p>
+                    )}
+                  </section>
+                  {method.params && method.params.length > 0 && (
+                    <>
+                      <table className="table table-striped">
+                        <thead>
+                          <tr>
+                            <th>Param</th>
+                            <th>Required</th>
+                            <th>Type</th>
+                            <th>Description</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {_.map(method.params, (param) => (
+                            <tr key={param.name}>
+                              <td>
+                                <code>{HtmlParser(_.get(param, 'name'), '')}</code>
+                              </td>
+                              <td>
+                                <code>{!param.optional && 'true'}</code>
+                              </td>
+                              <td>{param.type && <code>{HtmlParser(_.get(param, 'type.name'), '')}</code>}</td>
+                              <td>{param.description && HtmlParser(_.get(param, 'description'), '')}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </>
+                  )}
+                </div>
+              );
+            })}
+          </>
+        )}
       </React.Fragment>
     );
   }

--- a/www/containers/styles.scss
+++ b/www/containers/styles.scss
@@ -96,6 +96,19 @@ body {
     margin-top: 10px;
   }
 
+  .aui--docs-method-block {
+    border: 1px solid $color-gray-lighter;
+    margin-bottom: 20px;
+
+    .aui--docs-method-details {
+      padding: 10px;
+    }
+
+    .table {
+      margin-bottom: 0;
+    }
+  }
+
   .aui--docs-note-panel {
     .text {
       &-blue {


### PR DESCRIPTION
Add Methods section to docs

## Description
Methods are available in the `props.json` file but they're not being documented.

Was a little complicated having a single table for all methods like the PropTypes table, because of having to do multiple rows for params within the method row. So I've separated them into blocks with a params table.

The screen shot aims to show the full documentation capability using JSDoc.

e.g
```
/**
* stateToHTML method description
* @param {string} input - the input string
* @param {boolean} anotherParam - a boolean flag
* @returns {object} the return type contains all the stuff you need
**/
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):
![Screen Shot 2021-10-01 at 4 28 58 pm](https://user-images.githubusercontent.com/13904763/135576665-165af384-ba43-4924-b015-9c8d4573361c.png)

