### PR TITLE
chore: add cancel text props on action panel

### DIFF
--- a/src/components/ActionPanel/index.jsx
+++ b/src/components/ActionPanel/index.jsx
@@ -6,7 +6,7 @@ import Button from '../Button';
 import './styles.scss';
 
 const ActionPanel = React.forwardRef((props, ref) => {
-  const { title, className, size, onClose, children, actionButton, isModal, closeIcon } = props;
+  const { title, className, size, onClose, children, actionButton, isModal, closeIcon, cancelText } = props;
 
   const addBodyClass = (classname) => document.body.classList.add(classname);
   const removeBodyClass = (classname) => document.body.classList.remove(classname);
@@ -43,7 +43,7 @@ const ActionPanel = React.forwardRef((props, ref) => {
                 className={classNames('close-button', { 'close-svg-icon': !actionButton })}
                 dts="header-close-button"
               >
-                {actionButton ? 'Cancel' : closeIcon}
+                {actionButton ? cancelText : closeIcon}
               </Button>
               {actionButton}
             </span>
@@ -69,6 +69,7 @@ ActionPanel.propTypes = {
   actionButton: PropTypes.node,
   closeIcon: PropTypes.node,
   isModal: PropTypes.bool,
+  cancelText: PropTypes.string,
 };
 
 ActionPanel.defaultProps = {
@@ -76,6 +77,7 @@ ActionPanel.defaultProps = {
   actionButton: null,
   isModal: false,
   closeIcon: <div className="close-icon" />,
+  cancelText: 'Cancel',
 };
 
 export default ActionPanel;

--- a/src/components/ActionPanel/index.spec.jsx
+++ b/src/components/ActionPanel/index.spec.jsx
@@ -42,6 +42,7 @@ describe('<ActionPanel />', () => {
     expect(document.body).toHaveClass('modal-open');
     expect(wrapper.queryByTestId('action-panel-modal-wrapper')).toBeInTheDocument();
     expect(wrapper.getByTestId('action-panel-wrapper')).toHaveClass('aui--action-panel is-large action-modal');
+    expect(wrapper.getAllByTestId('button-wrapper')[0]).toHaveTextContent('Cancel'); // default cancel text is 'Cancel'
     wrapper.unmount();
     expect(document.body).not.toHaveClass('modal-open');
   });
@@ -57,5 +58,22 @@ describe('<ActionPanel />', () => {
 
     wrapper.unmount();
     expect(document.body).not.toHaveClass('modal-open');
+  });
+
+  it('should render a user specified text on the cancel button', () => {
+    let wrapper;
+    act(() => {
+      wrapper = render(
+        <ActionPanel
+          {...makeProps({
+            isModal: true,
+            size: 'large',
+            actionButton: <Button>Action</Button>,
+            cancelText: 'This is a cancel text',
+          })}
+        />
+      );
+    });
+    expect(wrapper.getAllByTestId('button-wrapper')[0]).toHaveTextContent('This is a cancel text');
   });
 });

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -191,6 +191,13 @@
             "value": "false",
             "computed": false
           }
+        },
+        "cancelText": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
         }
       }
     }
@@ -957,13 +964,13 @@
       "methods": [
         {
           "name": "usePreventSwipeClicks",
-          "docblock": "A hook to prevent child click handlers from firing immediately after swiping the Carousel\n\n@returns {object} - handlers to be spread onto any carousel items with `onClick` handlers",
+          "docblock": "A hook to prevent child click handlers from firing immediately after swiping the Carousel\n\n@returns {object} - to be spread onto any carousel items with `onClick` handlers",
           "modifiers": [
             "static"
           ],
           "params": [],
           "returns": {
-            "description": "handlers to be spread onto any carousel items with `onClick` handlers",
+            "description": "to be spread onto any carousel items with `onClick` handlers",
             "type": {
               "name": "object"
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Add a cancelText props on Action Panel, so the user can specify the text for close/cancel button when action panel is being used as modal (default is 'Cancel');

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
