### PR TITLE
feat: add partial switch support

### DIFF
--- a/src/components/Switch/index.jsx
+++ b/src/components/Switch/index.jsx
@@ -1,8 +1,10 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import classnames from 'classnames';
 import './styles.scss';
 
+const PARTIAL_STATE = 'partial';
 class Switch extends React.PureComponent {
   state = { checked: this.props.defaultChecked || false };
 
@@ -29,20 +31,33 @@ class Switch extends React.PureComponent {
       );
 
     const toggleInputChecked = !_.isNil(checked) ? checked : this.state.checked;
+
+    const componentClassName = classnames([
+      'aui--switch--input',
+      {
+        checked: toggleInputChecked === true,
+        'partial-checked': checked === PARTIAL_STATE,
+        disabled,
+      },
+      className,
+    ]);
+
     return (
-      <label className="aui--switch-label">
-        <input
-          data-testid="switch-checkbox"
-          type="checkbox"
-          checked={toggleInputChecked}
-          value={value}
-          disabled={disabled}
-          onChange={this.handleChange}
-          className={className}
-          data-test-selector={dts}
-        />
-        <span className="aui--switch-slider round" />
-      </label>
+      <div className="aui--switch--component">
+        <label className="aui--switch-label">
+          <input
+            data-testid="switch-checkbox"
+            type="checkbox"
+            checked={toggleInputChecked}
+            value={value}
+            disabled={disabled}
+            onChange={this.handleChange}
+            className={componentClassName}
+            data-test-selector={dts}
+          />
+          <span className="aui--switch-slider" />
+        </label>
+      </div>
     );
   }
 }
@@ -59,9 +74,9 @@ Switch.propTypes = {
    */
   defaultChecked: PropTypes.bool,
   /**
-   * 	switch value, if the value is controlled
+   * 	switch value, if the value is controlled: oneOf([true, false, 'partial']
    */
-  checked: PropTypes.bool,
+  checked: PropTypes.oneOf([true, false, PARTIAL_STATE]),
   value: PropTypes.string,
   disabled: PropTypes.bool,
   /**

--- a/src/components/Switch/index.spec.jsx
+++ b/src/components/Switch/index.spec.jsx
@@ -19,6 +19,12 @@ describe('<Switch />', () => {
     expect(getByTestId('switch-checkbox')).toBeChecked();
   });
 
+  it('should correctly render partial state', () => {
+    const { getByTestId, queryByTestId } = render(<Switch checked={'partial'} onChange={jest.fn()} />);
+    expect(queryByTestId('switch-checkbox')).toBeInTheDocument();
+    expect(getByTestId('switch-checkbox')).toHaveClass('partial-checked');
+  });
+
   it('should throw warning if checked is provided without onChange', () => {
     console.warn = jest.fn();
     render(<Switch checked />);

--- a/src/components/Switch/styles.scss
+++ b/src/components/Switch/styles.scss
@@ -1,66 +1,68 @@
 @import '~styles/color';
 @import '~styles/variable';
 
-.aui--switch-label {
-  position: relative;
-  display: inline-block;
-  width: 40px;
-  height: 20px;
-}
+.aui--switch--component {
+  .aui--switch-label {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 20px;
 
-.aui--switch-label input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
+    .aui--switch--input {
+      opacity: 0;
+      width: 0;
+      height: 0;
 
-.aui--switch-slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: $color-white;
-  transition: .4s;
-  border-style: solid;
-  border-color: $color-gray;
-  border-width: thin;
-}
+      &.checked + .aui--switch-slider {
+        background-color: $color-blue-light;
 
-.aui--switch-slider::before {
-  position: absolute;
-  content: '';
-  height: 12px;
-  width: 12px;
-  margin-left: 3px;
-  margin-top: 3px;
-  background-color: $color-blue;
-  transition: .4s;
-}
+        &::before {
+          transform: translateX(20px);
+        }
+      }
 
-input {
-  &:checked + .aui--switch-slider {
-    background-color: $color-blue-light;
+      &.partial-checked + .aui--switch-slider {
+        background-color: $color-gray-light;
+
+        &::before {
+          transform: translateX(10px);
+        }
+      }
+
+      &.disabled + .aui--switch-slider {
+        background-color: $color-gray-light;
+
+        &::before {
+          background-color: $color-gray-dark;
+        }
+      }
+    }
+
+    .aui--switch-slider {
+      position: absolute;
+      cursor: pointer;
+      background-color: $color-white;
+      transition: .4s;
+      border-radius: 34px;
+      border-style: solid;
+      border-color: $color-gray;
+      border-width: thin;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+
+      &::before {
+        position: absolute;
+        content: '';
+        border-radius: 50%;
+        height: 12px;
+        width: 12px;
+        margin-left: 3px;
+        margin-top: 3px;
+        background-color: $color-blue;
+        transition: .4s;
+      }
+    }
   }
-
-  &:checked + .aui--switch-slider::before {
-    transform: translateX(20px);
-  }
-
-  &:disabled + .aui--switch-slider {
-    background-color: $color-gray-light;
-  }
-
-  &:disabled + .aui--switch-slider::before {
-    background-color: $color-gray-dark;
-  }
-}
-
-.aui--switch-slider.round {
-  border-radius: 34px;
-}
-
-.aui--switch-slider.round::before {
-  border-radius: 50%;
 }

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -3,92 +3,21 @@
     {
       "description": "",
       "displayName": "Accordion",
-      "methods": [
-        {
-          "name": "onPanelClick",
-          "docblock": null,
-          "modifiers": [],
-          "params": [
-            {
-              "name": "panelId",
-              "type": null
-            }
-          ],
-          "returns": null
-        },
-        {
-          "name": "renderPanelFromChildren",
-          "docblock": null,
-          "modifiers": [],
-          "params": [
-            {
-              "name": "child",
-              "type": null
-            }
-          ],
-          "returns": null
-        }
-      ],
+      "methods": [],
       "props": {
-        "dts": {
-          "type": {
-            "name": "string"
-          },
-          "required": false,
-          "description": "render `data-test-selector` onto the component. It can be useful for testing."
-        },
-        "onPanelClick": {
-          "type": {
-            "name": "func"
-          },
-          "required": false,
-          "description": "onPanelClick(panelId) takes in a single parameter which is the id of the clicked panel."
-        },
-        "children": {
-          "type": {
-            "name": "node"
-          },
-          "required": false,
-          "description": "<span>\n Accept an array of <a href=\"/panel-example\">Panel</a> or\n <a href=\"/accordion-panel-example\">Accordion.Panel</a>\n </span>"
-        },
-        "defaultActivePanelIds": {
-          "type": {
-            "name": "arrayOf",
-            "value": {
-              "name": "string"
-            }
-          },
-          "required": false,
-          "description": "",
-          "defaultValue": {
-            "value": "[]",
-            "computed": false
-          }
-        },
         "maxExpand": {
-          "type": {
-            "name": "union",
-            "value": [
-              {
-                "name": "number"
-              },
-              {
-                "name": "enum",
-                "value": [
-                  {
-                    "value": "'max'",
-                    "computed": false
-                  }
-                ]
-              }
-            ]
-          },
-          "required": false,
-          "description": "Determine how many Panels can be expanded, accepted value is a positive number, or <code>max</code> to have no restriction",
           "defaultValue": {
             "value": "'max'",
             "computed": false
-          }
+          },
+          "required": false
+        },
+        "defaultActivePanelIds": {
+          "defaultValue": {
+            "value": "[]",
+            "computed": false
+          },
+          "required": false
         }
       }
     }
@@ -190,7 +119,11 @@
             "name": "string"
           },
           "required": false,
-          "description": ""
+          "description": "",
+          "defaultValue": {
+            "value": "'Cancel'",
+            "computed": false
+          }
         }
       }
     }
@@ -1371,20 +1304,7 @@
     {
       "description": "",
       "displayName": "DatePicker",
-      "methods": [
-        {
-          "name": "handleDateChangeRaw",
-          "docblock": null,
-          "modifiers": [],
-          "params": [
-            {
-              "name": "event",
-              "type": null
-            }
-          ],
-          "returns": null
-        }
-      ],
+      "methods": [],
       "props": {
         "disableInlineEditing": {
           "type": {
@@ -1396,6 +1316,13 @@
             "value": "false",
             "computed": false
           }
+        },
+        "dts": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
         }
       }
     }
@@ -3555,27 +3482,7 @@
     {
       "description": "",
       "displayName": "RadioGroup",
-      "methods": [
-        {
-          "name": "onChangeDefault",
-          "docblock": null,
-          "modifiers": [],
-          "params": [
-            {
-              "name": "event",
-              "type": null
-            }
-          ],
-          "returns": null
-        },
-        {
-          "name": "renderChildren",
-          "docblock": null,
-          "modifiers": [],
-          "params": [],
-          "returns": null
-        }
-      ],
+      "methods": [],
       "props": {
         "id": {
           "type": {
@@ -4734,10 +4641,24 @@
         },
         "checked": {
           "type": {
-            "name": "bool"
+            "name": "enum",
+            "value": [
+              {
+                "value": "true",
+                "computed": false
+              },
+              {
+                "value": "false",
+                "computed": false
+              },
+              {
+                "value": "'partial'",
+                "computed": false
+              }
+            ]
           },
           "required": false,
-          "description": "switch value, if the value is controlled"
+          "description": "switch value, if the value is controlled: oneOf([true, false, 'partial']"
         },
         "value": {
           "type": {
@@ -4852,20 +4773,7 @@
     {
       "description": "",
       "displayName": "Tabs",
-      "methods": [
-        {
-          "name": "switchTab",
-          "docblock": null,
-          "modifiers": [],
-          "params": [
-            {
-              "name": "key",
-              "type": null
-            }
-          ],
-          "returns": null
-        }
-      ],
+      "methods": [],
       "props": {
         "id": {
           "type": {
@@ -5075,16 +4983,8 @@
   "src/components/TextEllipsis/index.jsx": [
     {
       "description": "",
-      "displayName": "TextEllipsisComponent",
-      "methods": [
-        {
-          "name": "setTruncate",
-          "docblock": null,
-          "modifiers": [],
-          "params": [],
-          "returns": null
-        }
-      ],
+      "displayName": "TextEllipsis",
+      "methods": [],
       "props": {
         "children": {
           "type": {
@@ -5100,7 +5000,7 @@
             "computed": true
           },
           "required": false,
-          "description": "Can use `placement` and `trigger` props from <a href=\"/popover\">Popover</a> to control popover.",
+          "description": "",
           "defaultValue": {
             "value": "{\n  placement: 'top',\n  trigger: 'hover',\n}",
             "computed": false

--- a/www/examples/Switch.mdx
+++ b/www/examples/Switch.mdx
@@ -4,7 +4,7 @@ import Props from '../containers/Props.jsx';
 
 ```jsx live=true
 const Example = () => {
-  const [isToggleOn, setIsToggleOn] = React.useState(true);
+  const [isToggleOn, setIsToggleOn] = React.useState('partial');
   const onChange = (newValue) => setIsToggleOn(newValue);
 
   return (
@@ -28,7 +28,7 @@ const Example = () => {
         </div>
       </div>
       <div>
-        <div style={{ paddingTop: 20 }}>Controlled Switch</div>
+        <div style={{ paddingTop: 20 }}>Controlled Switch (Partial Initial State)</div>
         <div style={{ paddingTop: 10 }}>
           <Switch checked={isToggleOn} onChange={onChange} />
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a third state partial to the switch similar to checkbox partial state

It is a breaking change as truthy expressions cannot be added unless explicit conversion to bool

eg:
<Switch checked={arr.length} ../> -> Breaking

<Switch checked={!!arr.length} ../> -> will work fine

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Add a third switch state for partial state when the state needs to represent a bunch of checked/unchecked children

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3688957/139190858-f40d1ab9-8607-445d-802c-e68171717f1e.png)
