### PR TITLE
[ADS-5952] feat: add Pill/StatusPill sizes prop

### DIFF
--- a/src/components/Pill/index.jsx
+++ b/src/components/Pill/index.jsx
@@ -4,15 +4,21 @@ import React from 'react';
 import { expandDts } from '../../lib/utils';
 import './styles.scss';
 
-const Pill = ({ className, children, onClick, dts }) => (
+const sizes = ['large', 'medium', 'small'];
+
+const Pill = ({ className, children, onClick, size, dts }) => (
   <div
-    className={classnames('aui--pill', { 'aui--pill-clickable': onClick }, className)}
+    className={classnames('aui--pill', `aui--pill-${size}`, { 'aui--pill-clickable': onClick }, className)}
     onClick={onClick}
     {...expandDts(dts)}
   >
     <div className="aui--pill-children">{children}</div>
   </div>
 );
+
+Pill.defaultProps = {
+  size: sizes[1],
+};
 
 Pill.propTypes = {
   /**
@@ -27,6 +33,10 @@ Pill.propTypes = {
    *  	Custome onClick event
    */
   onClick: PropTypes.func,
+  /**
+   * one of ["large",  "medium", "small"]
+   */
+  size: PropTypes.oneOf(sizes),
   /**
    * 	Generate "data-test-selector" on the pill
    */

--- a/src/components/Pill/index.spec.jsx
+++ b/src/components/Pill/index.spec.jsx
@@ -10,8 +10,7 @@ const queryAllByClass = queryAllByAttribute.bind(null, 'class');
 describe('<Pill />', () => {
   it('should have default style', () => {
     const { container } = render(<Pill>Test</Pill>);
-
-    expect(queryAllByClass(container, 'aui--pill')).toHaveLength(1);
+    expect(queryAllByClass(container, 'aui--pill aui--pill-medium')).toHaveLength(1);
     expect(queryAllByClass(container, 'aui--pill-children')).toHaveLength(1);
     expect(queryAllByClass(container, 'aui--pill-clickable')).toHaveLength(0);
     expect(getByClass(container, 'aui--pill-children')).toHaveTextContent('Test');
@@ -19,19 +18,24 @@ describe('<Pill />', () => {
 
   it('should allow className prop', () => {
     const { container } = render(<Pill className="test">Test</Pill>);
-    expect(queryAllByClass(container, 'aui--pill test')).toHaveLength(1);
+    expect(queryAllByClass(container, 'aui--pill aui--pill-medium test')).toHaveLength(1);
+  });
+
+  it('should allow size prop', () => {
+    const { container } = render(<Pill size="large">Test</Pill>);
+    expect(queryAllByClass(container, 'aui--pill aui--pill-large')).toHaveLength(1);
   });
 
   it('should allow onClick prop', () => {
     const onClickMock = jest.fn();
     const { container } = render(<Pill onClick={onClickMock}>Test</Pill>);
-    expect(queryAllByClass(container, 'aui--pill aui--pill-clickable')).toHaveLength(1);
-    fireEvent.click(getByClass(container, 'aui--pill aui--pill-clickable'));
+    expect(queryAllByClass(container, 'aui--pill aui--pill-medium aui--pill-clickable')).toHaveLength(1);
+    fireEvent.click(getByClass(container, 'aui--pill aui--pill-medium aui--pill-clickable'));
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
 
   it('should support custom dts', () => {
     const { container } = render(<Pill dts="test-dts">Test</Pill>);
-    expect(getByClass(container, 'aui--pill')).toHaveAttribute('data-test-selector', 'test-dts');
+    expect(getByClass(container, 'aui--pill aui--pill-medium')).toHaveAttribute('data-test-selector', 'test-dts');
   });
 });

--- a/src/components/Pill/styles.scss
+++ b/src/components/Pill/styles.scss
@@ -1,11 +1,21 @@
 @import '~styles/variable';
 
+$padding-small: 2px 5px;
+$padding-medium: 5px 12px;
+$padding-large: 6px 20px;
+
+$font-size-small: $font-size-small;
+$font-size-medium: $font-size-base;
+$font-size-large: $font-size-subheader;
+
+$border-radius-small: 4px;
+$border-radius-medium: 12px;
+$border-radius-large: 999px;
+
 .aui--pill {
-  font-size: $font-size-base;
-  display: inline-block;
-  padding: 5px 12px;
+  display: inline-flex;
+  align-items: center;
   border: 1px solid $color-status-light;
-  border-radius: 12px;
   user-select: none;
   font-weight: $font-weight-bold;
   line-height: 1;
@@ -16,7 +26,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    line-height: 16px;
   }
 
   &-clickable {
@@ -25,5 +34,29 @@
       background-color: $color-background-highlighted;
       cursor: pointer;
     }
+  }
+
+  &-small {
+    padding: $padding-small;
+    font-size: $font-size-small;
+    border-radius: $border-radius-small;
+    line-height: 1;
+
+    .aui--svg-symbol-component {
+      width: 12px;
+      height: 12px;
+    }
+  }
+
+  &-medium {
+    padding: $padding-medium;
+    font-size: $font-size-medium;
+    border-radius: $border-radius-medium;
+  }
+
+  &-large {
+    padding: $padding-large;
+    font-size: $font-size-large;
+    border-radius: $border-radius-large;
   }
 }

--- a/src/components/StatusPill/index.jsx
+++ b/src/components/StatusPill/index.jsx
@@ -5,14 +5,17 @@ import Pill from '../Pill';
 import './styles.scss';
 
 const styles = ['primary', 'success', 'warning', 'error', 'light'];
+const sizes = ['large', 'medium', 'small'];
 
-const StatusPill = ({ displayStyle, status, inverse, dts }) => (
+const StatusPill = ({ displayStyle, status, inverse, size, className, dts }) => (
   <Pill
     className={classnames([
       'aui--status-pill',
       `aui--status-pill-${displayStyle}`,
       { 'aui--status-pill-inverse': inverse },
+      className,
     ])}
+    size={size}
     dts={dts}
   >
     {status}
@@ -21,6 +24,7 @@ const StatusPill = ({ displayStyle, status, inverse, dts }) => (
 
 StatusPill.defaultProps = {
   displayStyle: styles[0],
+  size: sizes[1],
   inverse: false,
 };
 
@@ -34,6 +38,10 @@ StatusPill.propTypes = {
    */
   displayStyle: PropTypes.oneOf(styles),
   /**
+   * one of ["large",  "medium", "small"]
+   */
+  size: PropTypes.oneOf(sizes),
+  /**
    * Status pill with inverse style
    */
   inverse: PropTypes.bool,
@@ -41,6 +49,7 @@ StatusPill.propTypes = {
    * 	Generate "data-test-selector" on the status pill
    */
   dts: PropTypes.string,
+  className: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
 };
 
 export default StatusPill;

--- a/src/components/StatusPill/index.spec.jsx
+++ b/src/components/StatusPill/index.spec.jsx
@@ -10,29 +10,42 @@ const queryAllByClass = queryAllByAttribute.bind(null, 'class');
 describe('<StatusPill />', () => {
   it('should have default style', () => {
     const { container, getByText } = render(<StatusPill status="test" />);
-    expect(queryAllByClass(container, 'aui--pill aui--status-pill aui--status-pill-primary')).toHaveLength(1);
-    expect(getByText('test', getByClass(container, 'aui--pill aui--status-pill aui--status-pill-primary'))).toHaveClass(
-      'aui--pill-children'
-    );
+    expect(
+      queryAllByClass(container, 'aui--pill aui--pill-medium aui--status-pill aui--status-pill-primary')
+    ).toHaveLength(1);
+    expect(
+      getByText('test', getByClass(container, 'aui--pill aui--pill-medium aui--status-pill aui--status-pill-primary'))
+    ).toHaveClass('aui--pill-children');
   });
 
   it('should allow style prop', () => {
     const { container } = render(<StatusPill status="test" displayStyle="success" />);
-    expect(queryAllByClass(container, 'aui--pill aui--status-pill aui--status-pill-success')).toHaveLength(1);
+    expect(
+      queryAllByClass(container, 'aui--pill aui--pill-medium aui--status-pill aui--status-pill-success')
+    ).toHaveLength(1);
   });
 
   it('should allow inverse prop', () => {
     const { container } = render(<StatusPill status="test" displayStyle="success" inverse />);
     expect(
-      queryAllByClass(container, 'aui--pill aui--status-pill aui--status-pill-success aui--status-pill-inverse')
+      queryAllByClass(
+        container,
+        'aui--pill aui--pill-medium aui--status-pill aui--status-pill-success aui--status-pill-inverse'
+      )
+    ).toHaveLength(1);
+  });
+
+  it('should support className prop', () => {
+    const { container } = render(<StatusPill status="test" className="test" />);
+    expect(
+      queryAllByClass(container, 'aui--pill aui--pill-medium aui--status-pill aui--status-pill-primary test')
     ).toHaveLength(1);
   });
 
   it('should support custom dts', () => {
     const { container } = render(<StatusPill status="test" dts="test-dts" />);
-    expect(getByClass(container, 'aui--pill aui--status-pill aui--status-pill-primary')).toHaveAttribute(
-      'data-test-selector',
-      'test-dts'
-    );
+    expect(
+      getByClass(container, 'aui--pill aui--pill-medium aui--status-pill aui--status-pill-primary')
+    ).toHaveAttribute('data-test-selector', 'test-dts');
   });
 });

--- a/src/components/StatusPill/styles.scss
+++ b/src/components/StatusPill/styles.scss
@@ -12,24 +12,16 @@ $color-light: $color-status-light;
 $color-inverse-border: $color-status-light;
 
 .aui--status-pill {
-  font-size: $font-size-base;
-  display: inline-block;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 24px;
-  padding: 5px 12px;
   border: 1px solid transparent;
-  border-radius: 12px;
   user-select: none;
   font-weight: $font-weight-bold;
   line-height: 1;
   color: $color-gray-darker;
 
-  .aui--pill-children {
-    line-height: normal;
-  }
-
-  &.aui--status-pill-primary {
+  &-primary {
     background-color: $color-primary-background;
 
     &.aui--status-pill-inverse {
@@ -39,7 +31,7 @@ $color-inverse-border: $color-status-light;
     }
   }
 
-  &.aui--status-pill-success {
+  &-success {
     background-color: $color-success-background;
 
     &.aui--status-pill-inverse {
@@ -49,7 +41,7 @@ $color-inverse-border: $color-status-light;
     }
   }
 
-  &.aui--status-pill-warning {
+  &-warning {
     background-color: $color-warning-background;
 
     &.aui--status-pill-inverse {
@@ -59,7 +51,7 @@ $color-inverse-border: $color-status-light;
     }
   }
 
-  &.aui--status-pill-error {
+  &-error {
     background-color: $color-error-background;
 
     &.aui--status-pill-inverse {
@@ -69,7 +61,7 @@ $color-inverse-border: $color-status-light;
     }
   }
 
-  &.aui--status-pill-light {
+  &-light {
     background-color: $color-light;
 
     &.aui--status-pill-inverse {

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -190,7 +190,11 @@
             "name": "string"
           },
           "required": false,
-          "description": ""
+          "description": "",
+          "defaultValue": {
+            "value": "'Cancel'",
+            "computed": false
+          }
         }
       }
     }
@@ -3114,6 +3118,31 @@
           "required": false,
           "description": "Custome onClick event"
         },
+        "size": {
+          "type": {
+            "name": "enum",
+            "value": [
+              {
+                "value": "'large'",
+                "computed": false
+              },
+              {
+                "value": "'medium'",
+                "computed": false
+              },
+              {
+                "value": "'small'",
+                "computed": false
+              }
+            ]
+          },
+          "required": false,
+          "description": "one of [\"large\",  \"medium\", \"small\"]",
+          "defaultValue": {
+            "value": "sizes[1]",
+            "computed": true
+          }
+        },
         "dts": {
           "type": {
             "name": "string"
@@ -4633,6 +4662,31 @@
             "computed": true
           }
         },
+        "size": {
+          "type": {
+            "name": "enum",
+            "value": [
+              {
+                "value": "'large'",
+                "computed": false
+              },
+              {
+                "value": "'medium'",
+                "computed": false
+              },
+              {
+                "value": "'small'",
+                "computed": false
+              }
+            ]
+          },
+          "required": false,
+          "description": "one of [\"large\",  \"medium\", \"small\"]",
+          "defaultValue": {
+            "value": "sizes[1]",
+            "computed": true
+          }
+        },
         "inverse": {
           "type": {
             "name": "bool"
@@ -4650,6 +4704,24 @@
           },
           "required": false,
           "description": "Generate \"data-test-selector\" on the status pill"
+        },
+        "className": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "string"
+              },
+              {
+                "name": "arrayOf",
+                "value": {
+                  "name": "string"
+                }
+              }
+            ]
+          },
+          "required": false,
+          "description": ""
         }
       }
     }

--- a/www/containers/styles.scss
+++ b/www/containers/styles.scss
@@ -38,6 +38,23 @@ body {
     flex-direction: row;
     padding: 72px 12px 0;
   }
+
+  .grid {
+    display: flex;
+    flex-direction: row;
+
+    &-small {
+      grid-gap: 6px;
+    }
+
+    &-medium {
+      grid-gap: 12px;
+    }
+
+    &-large {
+      grid-gap: 18px;
+    }
+  }
 }
 
 .adslot-ui-sidebar-area {

--- a/www/examples/Pill.mdx
+++ b/www/examples/Pill.mdx
@@ -7,12 +7,35 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 const Example = () => {
   return (
     <React.Fragment>
-      <div style={{ display: 'flex' }}>
+      <label>Medium Pills (default)</label>
+      <div className="grid grid-small">
         <Pill className="example-1" onClick={() => {}}>
           <SvgSymbol href="./assets/svg-symbols.svg#calendar" />
           <div style={{ marginLeft: 5 }}>Calendar</div>
         </Pill>
         <Pill className="example-2">
+          <div>Site</div>
+        </Pill>
+      </div>
+      <br />
+      <label>Large Pills</label>
+      <div className="grid grid-small">
+        <Pill size="large" className="example-1" onClick={() => {}}>
+          <SvgSymbol href="./assets/svg-symbols.svg#calendar" />
+          <div style={{ marginLeft: 5 }}>Calendar</div>
+        </Pill>
+        <Pill size="large" className="example-2">
+          <div>Site</div>
+        </Pill>
+      </div>
+      <br />
+      <label>Small Pills</label>
+      <div className="grid grid-small">
+        <Pill size="small" className="example-1" onClick={() => {}}>
+          <SvgSymbol href="./assets/svg-symbols.svg#calendar" />
+          <div style={{ marginLeft: 5 }}>Calendar</div>
+        </Pill>
+        <Pill size="small" className="example-2">
           <div>Site</div>
         </Pill>
       </div>

--- a/www/examples/StatusPill.mdx
+++ b/www/examples/StatusPill.mdx
@@ -5,7 +5,7 @@ import Props from '../containers/Props.jsx';
 ```jsx live=true
 <>
   <label>Status pills</label>
-  <div>
+  <div className="grid grid-small">
     <StatusPill status="Primary" />
     <StatusPill status="Success" displayStyle="success" />
     <StatusPill status="Warning" displayStyle="warning" />
@@ -14,12 +14,53 @@ import Props from '../containers/Props.jsx';
   </div>
   <br />
   <label>Inverse status pills</label>
-  <div>
+  <div className="grid grid-small">
     <StatusPill status="Primary" inverse />
     <StatusPill status="Success" displayStyle="success" inverse />
     <StatusPill status="Warning" displayStyle="warning" inverse />
     <StatusPill status="Error" displayStyle="error" inverse />
     <StatusPill status="Light" displayStyle="light" inverse />
+  </div>
+</>
+```
+
+### Status Pill sizes
+
+```jsx live=true
+<>
+  <label>Large status pills</label>
+  <div className="grid grid-small">
+    <StatusPill size="large" status="Primary" />
+    <StatusPill size="large" status="Success" displayStyle="success" />
+    <StatusPill size="large" status="Warning" displayStyle="warning" />
+    <StatusPill size="large" status="Error" displayStyle="error" />
+    <StatusPill size="large" status="Light" displayStyle="light" />
+  </div>
+  <br />
+  <div className="grid grid-small">
+    <StatusPill size="large" status="Primary" inverse />
+    <StatusPill size="large" status="Success" displayStyle="success" inverse />
+    <StatusPill size="large" status="Warning" displayStyle="warning" inverse />
+    <StatusPill size="large" status="Error" displayStyle="error" inverse />
+    <StatusPill size="large" status="Light" displayStyle="light" inverse />
+  </div>
+  <br />
+  <label>Small status pills</label>
+
+  <div className="grid grid-small">
+    <StatusPill size="small" status="Primary" />
+    <StatusPill size="small" status="Success" displayStyle="success" />
+    <StatusPill size="small" status="Warning" displayStyle="warning" />
+    <StatusPill size="small" status="Error" displayStyle="error" />
+    <StatusPill size="small" status="Light" displayStyle="light" />
+  </div>
+  <br />
+  <div className="grid grid-small">
+    <StatusPill size="small" status="Primary" inverse />
+    <StatusPill size="small" status="Success" displayStyle="success" inverse />
+    <StatusPill size="small" status="Warning" displayStyle="warning" inverse />
+    <StatusPill size="small" status="Error" displayStyle="error" inverse />
+    <StatusPill size="small" status="Light" displayStyle="light" inverse />
   </div>
 </>
 ```


### PR DESCRIPTION
Adds optional `sizes` prop to `Pill` and `StatusPill`
options are `small`, `medium` (default/current), `large`

Add `className` to StatusPill
Fix some oddities with line-height / height differences when svg icons are used

## Description

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Screenshots (if appropriate):

![Screen Shot 2021-10-19 at 1 04 09 pm](https://user-images.githubusercontent.com/13904763/137831800-384fea20-76dc-4114-ae47-49d4cc80166b.png)

![Screen Shot 2021-10-19 at 1 04 03 pm](https://user-images.githubusercontent.com/13904763/137831805-5f47a7bc-04e4-4bdc-8fa2-608861087541.png)

