### PR TITLE
[ADS-5995] fix: large button variable width

### DIFF
--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -203,9 +203,8 @@
   }
 
   &.btn-large {
-    width: 264px;
-    height: 42px;
-    font-size: 15px;
+    padding: 5px 20px;
+    font-size: $font-size-subheader;
   }
 
   &.btn-inverse:not([disabled]).btn-primary {

--- a/www/examples/Button.mdx
+++ b/www/examples/Button.mdx
@@ -16,7 +16,7 @@ import DesignNotes from '../containers/DesignNotes.jsx';
     Error
   </Button>
   <Button theme="default">Default</Button>
-  <Button bsSthemetyle="default" className="some class">
+  <Button theme="default" className="some class">
     Default with Class
   </Button>
   <Button disabled>Disabled</Button>
@@ -56,6 +56,5 @@ import DesignNotes from '../containers/DesignNotes.jsx';
   Campaign, Save, Reject etc.
   <br />
   <br />
-  <span className="text-bold">Large button</span> is designed to have a fixed 264px x 42px size.
 </DesignNotes>
 <Props componentName="Button" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Remove the fix width and height on large button and give it 5px padding top/bottom and 20px padding left/right
https://adslot.atlassian.net/browse/ADS-5995

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
