### PR TITLE
fix: Accordion propTypes

### DIFF
--- a/src/components/Accordion/index.jsx
+++ b/src/components/Accordion/index.jsx
@@ -52,7 +52,7 @@ const Accordion = ({ dts, children, maxExpand, defaultActivePanelIds, onPanelCli
   );
 };
 
-Accordion.prototypes = {
+Accordion.propTypes = {
   /**
    * render `data-test-selector` onto the component. It can be useful for testing.
    */


### PR DESCRIPTION
## Description
fixes a spelling mistake from Accordion refactor

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):
