### PR TITLE
fix: date picker css fixes

### DIFF
--- a/src/components/DatePicker/styles.scss
+++ b/src/components/DatePicker/styles.scss
@@ -3,6 +3,10 @@
 @import '../../../node_modules/react-datepicker/dist/react-datepicker.css';
 
 // sass-lint:disable class-name-format
+.aui--date-picker {
+  display: inline-block;
+}
+
 .react-datepicker {
   $datepicker-font-family: $font-family-sans-serif;
   $datepicker-font-size: $font-size-base;
@@ -38,7 +42,8 @@
       color: $datepicker-color-disabled;
     }
 
-    &--selected {
+    &--selected,
+    &--keyboard-selected {
       background-color: $datepicker-selected-bg-color;
       color: $color-inverse;
 
@@ -96,6 +101,14 @@
     }
   }
 
+  &__navigation-icon--previous::before {
+    content: none;
+  }
+
+  &__navigation-icon--next::before {
+    content: none;
+  }
+
   &__navigation--previous {
     border: 0;
     left: 7px;
@@ -151,6 +164,7 @@
 
   &__close-icon {
     &::after {
+      box-shadow: 0 0 0 3px $input-bg;
       background-color: $color-gray-darker;
       right: 15px;
     }
@@ -164,11 +178,11 @@
     .react-datepicker__triangle {
       &,
       &::before {
-        border-bottom-color: $color-gray-white;
+        border-bottom-color: $color-border-light;
       }
 
-      &::before {
-        border-bottom-color: $color-border-light;
+      &::after {
+        border-bottom-color: $color-gray-white;
       }
     }
   }

--- a/src/styles/variable.scss
+++ b/src/styles/variable.scss
@@ -90,6 +90,7 @@ $table-bg-hover: $color-gray-white; // for hover;
 $table-border-color: $color-gray-light; // table and cell border;
 
 // == Forms
+$input-bg: $color-white;
 $input-bg-disabled: $color-gray-lighter;
 $input-color: $color-text-form;
 $input-border: $color-border-lighter;


### PR DESCRIPTION
## Description
• Fix some issues with nav arrows and popper triangle due to changes in upgraded `react-datepicker` css.
• Fix close icon (`isClearable` prop) - the calender icon shows under the close icon. I couldn't hide the calender icon when the close icon is present (at least not with css only), so I added a white (`$input-bg`) ring around the close icon to mask it.

The upgrade also forces block/100% width on the input container(s), which would make the input too wide by default, and in turn messes up the triangle placement. So I've made the `aui--date-picker` wrapper `inline-block` to keep the previous behaviour.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):

current:
![Screen Shot 2021-11-30 at 5 02 34 pm](https://user-images.githubusercontent.com/13904763/143994125-9b2bbaf8-9082-421e-ac8a-7403241723cc.png)


fix:
![Screen Shot 2021-11-30 at 4 33 04 pm](https://user-images.githubusercontent.com/13904763/143993379-66cfccee-064a-4168-a996-9d900d375e48.png)

close icon:
![Screen Shot 2021-12-01 at 3 58 55 pm](https://user-images.githubusercontent.com/13904763/144174746-ce5aebe9-c57b-48b8-9bf1-c03db4df78c0.png)
