### PR TITLE
[ADS-6456] fix: tree shaking & regeneratorRuntime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -35,11 +35,21 @@ const env = {
   },
   esm: {
     presets: [['@babel/preset-env', { useBuiltIns: false, modules: false }]],
-    plugins: ['jsx-remove-data-test-id', inlineSvgPlugin, ['transform-remove-imports', { test: '\\.(scss|css)$' }]],
+    plugins: [
+      ['@babel/plugin-transform-runtime', { regenerator: true }],
+      'jsx-remove-data-test-id',
+      inlineSvgPlugin,
+      ['transform-remove-imports', { test: '\\.(scss|css)$' }],
+    ],
   },
   cjs: {
     presets: [['@babel/preset-env', { useBuiltIns: false, modules: 'cjs' }]],
-    plugins: ['jsx-remove-data-test-id', inlineSvgPlugin, ['transform-remove-imports', { test: '\\.(scss|css)$' }]],
+    plugins: [
+      ['@babel/plugin-transform-runtime', { regenerator: true }],
+      'jsx-remove-data-test-id',
+      inlineSvgPlugin,
+      ['transform-remove-imports', { test: '\\.(scss|css)$' }],
+    ],
   },
 };
 

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -69,6 +69,7 @@ module.exports = webpackMerge(commonConfig, {
       },
       {
         test: /\.((c|sc)ss)$/i,
+        sideEffects: true,
         use: [
           'style-loader',
           {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -89,6 +89,7 @@ module.exports = webpackMerge(commonConfig, {
       },
       {
         test: /\.((c|sc)ss)$/i,
+        sideEffects: true,
         use: [
           MiniCssExtractPlugin.loader,
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "devDependencies": {
         "@babel/cli": "^7.17.0",
         "@babel/core": "^7.17.0",
+        "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
         "@commitlint/cli": "^16.1.0",
@@ -2183,6 +2184,57 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
+      "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.5.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/@babel/helper-plugin-utils": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz",
+      "integrity": "sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.3.1",
+        "core-js-compat": "^3.21.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
@@ -25142,6 +25194,44 @@
           "version": "7.16.7",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
           "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
+      "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.5.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+          "dev": true
+        },
+        "babel-plugin-polyfill-corejs3": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz",
+          "integrity": "sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.3.1",
+            "core-js-compat": "^3.21.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "lib",
     "es"
   ],
+  "sideEffects": [
+    "./src/**/*.scss",
+    "./dist/*.css"
+  ],
   "license": "MIT",
   "scripts": {
     "generate-docs": "node ./scripts/generateDocs.js",
@@ -71,6 +75,7 @@
     "@babel/cli": "^7.17.0",
     "@babel/core": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
+    "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-react": "^7.16.7",
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",


### PR DESCRIPTION
- add `sideEffects` for tree shaking of esm build (ref: https://webpack.js.org/guides/tree-shaking/)
- add `@babel/plugin-transform-runtime` to fix undefined `regeneratorRuntime` in esm/cjs builds. 
  - async/await in `RichTextEditor` transpiles to use `regeneratorRuntime` but it's not actually imported/polyfilled.
  - This is due to not using `corejs` builtins in the esm/cjs builds, but also having a `browserslist` that would cause polyfilling of async/await. 
  
## Description
I have tested the tree shaking as below - looks to be working properly (these are unminified stats)

```
import { Button } from 'adslot-ui';
```
Without `sideEffects` field, using esm build:
```
dist/assets/index.f07c8cc8.js      128.05 KiB / gzip: 23.11 KiB
dist/assets/vendor.a8808d79.js     2080.81 KiB / gzip: 424.74 KiB
```

With `sideEffects` field, using esm build:

```
dist/assets/index.53979bf6.js      5.92 KiB / gzip: 1.96 KiB
dist/assets/vendor.83d8442c.js     407.97 KiB / gzip: 90.17 KiB
```

For us, the common chunk size could be reduced by around 8%.

### minified adslot-ui bundle

| chunk                     | parsed    | gzip      |
| ------------------------- | --------- | --------- |
| common                    | 4.46 MB   | **1.17 MB**   |
| \|---node_modules         | 1.61 MB   | 472.01 KB |
| \|---adslot-ui (inc deps) | 1.2 MB    | 347.71 KB |
| moduleX        | 789.29 KB | 139.81 KB |
| Total                     | 7.5 MB    | 2.11 MB   |

### ESM adslot-ui

| chunk              | parsed    | gzip      |
| ------------------ | --------- | --------- |
| common             | 4.26 MB   | **1.11 MB**   |
| \|---node_modules  | 1.4 MB    | 412.27 KB |
| \|---adslot-ui     | 290.16 KB | 73.87 KB  |
| moduleX | 789.29 KB | 139.81 KB |
| Total              | 7.3 MB    | 2.05 MB   |

### ESM adslot-ui with tree shaking

| chunk              | parsed    | gzip      |
| ------------------ | --------- | --------- |
| common             | 4.19 MB   | **1.09 MB**   |
| \|---node_modules  | 1.33 MB   | 392.48 KB |
| \|---adslot-ui     | 274.25 KB | 71.13 KB  |
| moduleX | 865.34 KB | 161.3 KB  |
| Total              | 7.31 MB   | 2.06 MB   |


### Why does x increase?
all of adslot-ui is included in that module, so the portions that are unused in `common` are included in `moduleX`.



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


