### PR TITLE
[ASC-144] fix: richTextEditor onChange issue

### DIFF
--- a/scripts/generate-types/typesPostFixes.js
+++ b/scripts/generate-types/typesPostFixes.js
@@ -178,6 +178,7 @@ exports.replacements = (componentName) => ({
         stateFromHTML: (input: string) => EditorState;
         stateToPlainText: (input: ContentState) => string;
         stateToEntityList: (input: ContentState) => RawDraftContentState['entityMap'];
+        plainTextFromHTML: (input: string) => string;
       };`,
       ],
     ],

--- a/src/components/RichTextEditor/index.d.ts
+++ b/src/components/RichTextEditor/index.d.ts
@@ -11,14 +11,8 @@ export interface RichTextEditorMentions {
 export interface RichTextEditorProps {
   className?: string;
   placeholder?: string;
-  /**
-   * Editor State
-   */
-  initialValue?: EditorState;
-  /**
-   * Editor State: Instance of <a href="https://draftjs.org/docs/api-reference-editor-state">draft-js editor state</a>
-   */
-  value?: EditorState;
+  initialValue?: string;
+  value?: string;
   onChange?: (...args: any[]) => any;
   mentions?: RichTextEditorMentions[];
   onFileSelect?: (...args: any[]) => any;
@@ -33,6 +27,7 @@ declare const RichTextEditor: React.FC<RichTextEditorProps> & {
   stateFromHTML: (input: string) => EditorState;
   stateToPlainText: (input: ContentState) => string;
   stateToEntityList: (input: ContentState) => RawDraftContentState['entityMap'];
+  plainTextFromHTML: (input: string) => string;
 };
 
 export default RichTextEditor;

--- a/www/examples/RichTextEditor.mdx
+++ b/www/examples/RichTextEditor.mdx
@@ -36,11 +36,15 @@ You have flexibility to create an controlled or uncontrolled editor based on you
 ```jsx live=true
 const Example = () => {
   const [state, setState] = React.useState(' ');
+  const [changeCount, setChangeCount] = React.useState(0);
   return (
     <>
       <div style={{ width: '600px' }}>
         <RichTextEditor
-          onChange={(output) => setState(RichTextEditor.stateToHTML(output))}
+          onChange={(output) => {
+            setState(output);
+            setChangeCount(changeCount + 1);
+          }}
           placeholder="Custom placeholder"
         />
       </div>
@@ -48,6 +52,12 @@ const Example = () => {
       <div style={{ marginTop: 30, width: '600px' }}>
         <p>HTML Output:</p>
         <code>{state}</code>
+      </div>
+
+      <div style={{ marginTop: 30, width: '600px' }}>
+        <p>
+          Change Time Count: <b>{changeCount}</b>
+        </p>
       </div>
     </>
   );
@@ -61,19 +71,31 @@ render(Example);
 ```jsx live=true
 const Example = () => {
   const [state, setState] = React.useState(
-    RichTextEditor.stateFromHTML(
-      `<p>test</p> <p>asdasdasdasd</p> <ul> <li>test</li> </ul> <ol> <li>test</li> <li>123</li> </ol>`
-    )
+    `<p>test</p> <p>asdasdasdasd</p> <ul> <li>test</li> </ul> <ol> <li>test</li> <li>123</li> </ol>`
   );
+  const [changeCount, setChangeCount] = React.useState(0);
+
   return (
     <>
       <div style={{ width: '600px' }}>
-        <RichTextEditor value={state} onChange={setState} />
+        <RichTextEditor
+          value={state}
+          onChange={(output) => {
+            setState(output);
+            setChangeCount(changeCount + 1);
+          }}
+        />
       </div>
 
       <div style={{ marginTop: 30, width: '600px' }}>
         <p>HTML Output:</p>
-        <code>{RichTextEditor.stateToHTML(state)}</code>
+        <code>{state}</code>
+      </div>
+
+      <div style={{ marginTop: 30, width: '600px' }}>
+        <p>
+          Change Time Count: <b>{changeCount}</b>
+        </p>
       </div>
     </>
   );
@@ -107,35 +129,31 @@ const Example = () => {
     },
   ];
 
-  const [state, setState] = React.useState(RichTextEditor.stateFromHTML(' '));
+  const [state, setState] = React.useState('');
+  const [changeCount, setChangeCount] = React.useState(0);
 
   return (
     <>
       <div style={{ width: '600px' }}>
-        <RichTextEditor value={state} onChange={setState} mentions={contacts} />
+        <RichTextEditor
+          value={state}
+          onChange={(output) => {
+            setState(output);
+            setChangeCount(changeCount + 1);
+          }}
+          mentions={contacts}
+        />
       </div>
 
       <div style={{ marginTop: 30, width: '600px' }}>
         <p>Contacts List:</p>
-        <>
-          {_(RichTextEditor.stateToEntityList(state))
-            .filter({ type: 'mention' })
-            .map(
-              (
-                {
-                  data: {
-                    mention: { name, title },
-                  },
-                },
-                index
-              ) => (
-                <div key={index}>
-                  {index + 1}: {name} {title ? `, ${title}` : ''}
-                </div>
-              )
-            )
-            .value()}
-        </>
+        <code>{state}</code>
+      </div>
+
+      <div style={{ marginTop: 30, width: '600px' }}>
+        <p>
+          Change Time Count: <b>{changeCount}</b>
+        </p>
       </div>
     </>
   );
@@ -148,7 +166,8 @@ render(Example);
 
 ```jsx live=true
 const Example = () => {
-  const [state, setState] = React.useState(RichTextEditor.stateFromHTML(' '));
+  const [state, setState] = React.useState('');
+  const [changeCount, setChangeCount] = React.useState(0);
 
   const onFileSelect = () => '../assets/tile/adslot-logo-1.png';
 
@@ -157,12 +176,21 @@ const Example = () => {
   return (
     <>
       <div style={{ width: '600px' }}>
-        <RichTextEditor value={state} onChange={setState} onFileSelect={onFileSelect} onFileRemove={onFileRemove} />
+        <RichTextEditor
+          value={state}
+          onChange={(output) => {
+            setState(output);
+            setChangeCount(changeCount + 1);
+          }}
+          onFileSelect={onFileSelect}
+          onFileRemove={onFileRemove}
+          onHTMLChange={() => setChangeCount(changeCount + 1)}
+        />
       </div>
 
       <div style={{ marginTop: 30, width: '600px' }}>
         <p>PlainText Output:</p>
-        <code>{RichTextEditor.stateToPlainText(state)}</code>
+        <code>{state}</code>
       </div>
     </>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
The `RichTextEditor` use draft-js-editor-plugin library, and it allows component trigger `onChange` at initialRender, see [source code here](https://github.com/draft-js-plugins/draft-js-plugins/blob/master/packages/editor/src/Editor/index.tsx) from `113-139`.
And because of the nature of [EditorState](https://draftjs.org/docs/api-reference-editor-state/#content):

> The current text content state
> The current selection state
> The fully decorated representation of the contents
> Undo/redo stacks
> The most recent type of change made to the contents

It is triggering `onChange` fairly frequent. 

And regarding html `<p><br></p>`, it is inserted by default when empty editor state convert to html.

## Changes
This PR includes changes:
1.  type of value: from `EditorState` to `string`;
2. onChange: from `EditorState onChange` to `value(html input) onChange` ;
3. if the value is `<p><br></p>`, return ``


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

Will need to update all the affected files as API change.

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
