### PR TITLE
fix: status pill order

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,6 @@ export {
   Spinner,
   SplitPane,
   Statistic,
-  StatusPill,
   SvgSymbol,
   Switch,
   Tab,
@@ -141,6 +140,8 @@ export {
   Toast,
   Tile,
   Pill,
+  // StatusPill must be after Pill due to css ordering
+  StatusPill,
   Skeleton,
   Paragraph,
 };


### PR DESCRIPTION
## Description
StatusPill is composed on top of the Pill component. 
Due to changed order of css from marking the component as sideEffect free, in the production build, StatusPill needs to be exported after Pill, so its css will override Pill's.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):
