### PR TITLE
fix: revert sideEffects

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -89,7 +89,6 @@ module.exports = webpackMerge(commonConfig, {
       },
       {
         test: /\.((c|sc)ss)$/i,
-        sideEffects: true,
         use: [
           MiniCssExtractPlugin.loader,
           {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
     "lib",
     "es"
   ],
-  "sideEffects": [
-    "./src/**/*.scss",
-    "./dist/*.css"
-  ],
   "license": "MIT",
   "scripts": {
     "generate-docs": "node ./scripts/generateDocs.js",


### PR DESCRIPTION
## Description
As the tree shaking is causing some issues with css ordering that breaks the styles for at least 1 component, we've decided to revert this change for now.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
