### PR TITLE
v30.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "30.1.0",
+  "version": "30.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "30.1.0",
+      "version": "30.2.0",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "30.1.0",
+  "version": "30.2.0",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [4a001be414979514da66c0c0eb070aad1dc8d152] chore(deps): update dependency @testing-library/jest-dom to ^5.16.2
 
- [166f5ccf834f82291f34bfe3ea43e8025f9ca872] chore(deps): update webpack
 
- [de3a7d541e0e58eae18a3b9955d12b1f946559d0] chore(deps): update babel monorepo
 
- [acddf39bb4454c7848ed3580f78e944ac027dba6] chore(deps): update dependency @commitlint/cli to ^16.1.0
 
- [ca3e8cbac53a065b64192e11daad26e3463a6843] chore(deps): update dependency axios to ^0.25.0
 
- [73e9d35f973af8035c10fa8d797c6be9f54635a2] chore(deps): update dependency css-loader to ^6.6.0
 
- [823c0106fc72bf253df5e87402b6079babc696f8] chore(deps): update dependency eslint to ^8.8.0
 
- [3c6d7fd9d12c8cdfd5f375dd643dc4d86e93258f] chore(deps): update dependency lint-staged to ^12.3.3
 
- [fa2a2fefa8d1cfd30e129bc7d461155b5be830bd] chore(deps): update dependency sass to ^1.49.7
 
- [365869414a992e493017ffe578894c5dac5fa074] chore(deps): update dependency mini-css-extract-plugin to ^2.5.3
 
- [da2d8914eb1443544d2fad7b1b16b08cf4ab589f] chore: remove fast-glob dep as we already have node-glob
 
- [1feee2eac06421a4e998c9bbc16375e25b252f60] chore(deps): update dependency follow-redirects to 1.14.8 [security]
 
- [33be5804dc55fff32bc1e795c3eceda22bfb73a0] fix: sass allow leading zero for prettier
 
- [643175db23ce469b088b9319bfc52f2ef097857a] chore: resolve follow-redirects, node-forge, minimist dependabot alerts
 
	


	- Upgrade axios and reinstall webpack-dev-server dev deps


	- Upgrade minimist transitive dep to latest version

- [b7cd3a7e4abc9ced826e8d07e9bb3c6fa2fe5a08] fix: tree shaking & regeneratorRuntime
 
- [7a989176f0aaa6335788a5948db3430386481920] fix: revert sideEffects
 
- [35ed54ea9fee2edd7e40b80d871756bedd931344] chore: remove dev build
 
- [3d29642f4f307c0a90e38c4ba24a41e73e59dc94] feat: generate types
 
- [be744994b245b426d2e86e13f8bf7860fe900901] chore: generate types 🎉
 
- [f6dc0a4cfc75bb08edfd4841eb4cb278a46896a9] build: release minor version 30.2.0
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v30.1.0...v30.2.0