### PR TITLE
fix: fix disabled button with href props

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -31,15 +31,21 @@ const Button = (props) => {
 
   const renderChildren = () =>
     href ? (
-      <a
-        data-testid="button-anchor"
-        className="aui--button-anchor"
-        href={href}
-        target={target}
-        rel="noopener noreferrer"
-      >
-        {children}
-      </a>
+      !disabled ? (
+        <a
+          data-testid="button-anchor"
+          className="aui--button-anchor"
+          href={href}
+          target={target}
+          rel="noopener noreferrer"
+        >
+          {children}
+        </a>
+      ) : (
+        <div className="aui--button-anchor" data-testid="button-anchor">
+          {children}
+        </div>
+      )
     ) : (
       children
     );

--- a/src/components/Button/index.spec.jsx
+++ b/src/components/Button/index.spec.jsx
@@ -55,4 +55,23 @@ describe('<Button />', () => {
     const { getByTestId } = render(<Button isLoading size="large" />);
     expect(getByTestId('spinner')).toHaveClass('spinner-medium');
   });
+
+  it('should render button with href', () => {
+    const { getByText } = render(
+      <Button href="www.some-url.com" target="_blank">
+        Test
+      </Button>
+    );
+    expect(getByText('Test')).toHaveAttribute('href', 'www.some-url.com');
+  });
+
+  it('should render disabled href button', () => {
+    const { getByTestId, getByText } = render(
+      <Button disabled href="www.some-url.com" target="_blank">
+        Test
+      </Button>
+    );
+    expect(getByTestId('button-wrapper')).toBeDisabled();
+    expect(getByText('Test')).not.toHaveAttribute('href');
+  });
 });

--- a/www/examples/Button.mdx
+++ b/www/examples/Button.mdx
@@ -16,7 +16,7 @@ import DesignNotes from '../containers/DesignNotes.jsx';
     Error
   </Button>
   <Button theme="default">Default</Button>
-  <Button bsSthemetyle="default" className="some class">
+  <Button theme="default" className="some class">
     Default with Class
   </Button>
   <Button disabled>Disabled</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
- update button to only have a valid href or target if it is not disabled

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
before:
![image](https://user-images.githubusercontent.com/57419508/161693322-32176d84-8762-4c49-abdc-79692720d4df.png)

after:
![image](https://user-images.githubusercontent.com/57419508/161693480-fa2af52a-b3b4-477b-9267-9d78729c1f60.png)

