### PR TITLE
[ADS-6578] chore: override lodash of pegjs-otf grandchild dep to resolve dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9551,6 +9551,15 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -18698,12 +18707,6 @@
         "static-module": "3.0.0",
         "through": "2.3.8"
       }
-    },
-    "node_modules/pegjs-otf/node_modules/lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
     },
     "node_modules/pegjs-util": {
       "version": "1.4.14",
@@ -31657,6 +31660,15 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
     "eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -38538,18 +38550,10 @@
       "integrity": "sha512-GZ5hd1HL6fUuqqRU6tmLAhWFJCnsfbcKfuiVsJEiX9limjsFOx4oxGxri7tKcWgQPIA5e6I+IOlbaDo4er1xNA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10",
+        "lodash": "4.17.21",
         "pegjs": "0.10.0",
         "static-module": "3.0.0",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        }
       }
     },
     "pegjs-util": {

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "@babel/cli": "^7.17.0",
     "@babel/core": "^7.17.0",
     "@babel/generator": "^7.16.7",
-    "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/plugin-proposal-class-properties": "^7.16.7",
+    "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@commitlint/cli": "^16.1.0",
@@ -174,6 +174,15 @@
     "moment": "^2.29.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
+  },
+  "overrides": {
+    "react-to-typescript-definitions": {
+      "astq": {
+        "pegjs-otf": {
+          "lodash": "4.17.21"
+        }
+      }
+    }
   },
   "engines": {
     "node": "^16"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Override `lodash` which is a grandchild dependency of `pegjs-otf` to resolve dependabot alerts.

This has been marked as `wontfix` for `react-to-typescript-definitions` package by the maintainer thus using `overrides` in npm to resolve the issue: https://github.com/KnisterPeter/react-to-typescript-definitions/issues/1147

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->
Ran `npm run generate-types` and no diff generated

## Screenshots (if appropriate):
