### PR TITLE
[ASC-142][ASC-145] Paragraph - height animation, use RichTextEditor for html

### DIFF
--- a/config/testSetup.js
+++ b/config/testSetup.js
@@ -11,3 +11,8 @@ window.matchMedia = jest.fn().mockImplementation((query) => {
 });
 
 Object.defineProperty(window, 'scrollTo', { value: () => {}, writable: true });
+window.ResizeObserver = class ResizeObserver {
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "draft-js": "^0.11.7",
         "draft-js-export-html": "^1.4.1",
         "draft-js-import-html": "^1.4.1",
-        "html-to-text": "^8.2.1",
         "react-datepicker": "^4.10.0",
         "react-popper": "^2.3.0",
         "react-select": "^5.7.0",
@@ -5568,18 +5567,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@selderee/plugin-htmlparser2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
-      "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
-      "dependencies": {
-        "domhandler": "^4.2.0",
-        "selderee": "^0.6.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.44",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.44.tgz",
@@ -9749,6 +9736,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9910,11 +9898,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
-    },
     "node_modules/dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -9983,6 +9966,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
       "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -9996,6 +9980,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10019,6 +10004,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
       "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "dev": true,
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -10033,6 +10019,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
       "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+      "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -10252,6 +10239,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -12671,6 +12659,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
       "bin": {
         "he": "bin/he"
       }
@@ -12783,25 +12772,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/html-to-text": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.1.tgz",
-      "integrity": "sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==",
-      "dependencies": {
-        "@selderee/plugin-htmlparser2": "^0.6.0",
-        "deepmerge": "^4.2.2",
-        "he": "^1.2.0",
-        "htmlparser2": "^6.1.0",
-        "minimist": "^1.2.6",
-        "selderee": "^0.6.0"
-      },
-      "bin": {
-        "html-to-text": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10.23.2"
-      }
-    },
     "node_modules/html-void-elements": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
@@ -12839,6 +12809,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
       "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -17912,7 +17883,8 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -17936,11 +17908,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/moo": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
-      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -17978,32 +17945,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node_modules/nearley": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dependencies": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "bin": {
-        "nearley-railroad": "bin/nearley-railroad.js",
-        "nearley-test": "bin/nearley-test.js",
-        "nearley-unparse": "bin/nearley-unparse.js",
-        "nearleyc": "bin/nearleyc.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://nearley.js.org/#give-to-nearley"
-      }
-    },
-    "node_modules/nearley/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -18564,18 +18505,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
-    },
-    "node_modules/parseley": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
-      "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
-      "dependencies": {
-        "moo": "^0.5.1",
-        "nearley": "^2.20.1"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -20225,23 +20154,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
-    },
-    "node_modules/randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dependencies": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -21504,14 +21416,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -21679,17 +21583,6 @@
       "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
       "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==",
       "dev": true
-    },
-    "node_modules/selderee": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
-      "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
-      "dependencies": {
-        "parseley": "^0.7.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
-      }
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -28923,15 +28816,6 @@
       "integrity": "sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug==",
       "dev": true
     },
-    "@selderee/plugin-htmlparser2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
-      "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
-      "requires": {
-        "domhandler": "^4.2.0",
-        "selderee": "^0.6.0"
-      }
-    },
     "@sinclair/typebox": {
       "version": "0.24.44",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.44.tgz",
@@ -32131,7 +32015,8 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
     },
     "default-gateway": {
       "version": "6.0.3",
@@ -32242,11 +32127,6 @@
         "path-type": "^4.0.0"
       }
     },
-    "discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
-    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -32309,6 +32189,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
       "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -32318,7 +32199,8 @@
     "domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true
     },
     "domexception": {
       "version": "4.0.0",
@@ -32333,6 +32215,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
       "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "dev": true,
       "requires": {
         "domelementtype": "^2.2.0"
       }
@@ -32341,6 +32224,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
       "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+      "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -32511,7 +32395,8 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true
     },
     "envinfo": {
       "version": "7.8.1",
@@ -34316,7 +34201,8 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "header-case": {
       "version": "2.0.4",
@@ -34407,19 +34293,6 @@
       "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
       "dev": true
     },
-    "html-to-text": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.1.tgz",
-      "integrity": "sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==",
-      "requires": {
-        "@selderee/plugin-htmlparser2": "^0.6.0",
-        "deepmerge": "^4.2.2",
-        "he": "^1.2.0",
-        "htmlparser2": "^6.1.0",
-        "minimist": "^1.2.6",
-        "selderee": "^0.6.0"
-      }
-    },
     "html-void-elements": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
@@ -34443,6 +34316,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
       "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
@@ -38199,7 +38073,8 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -38217,11 +38092,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "peer": true
-    },
-    "moo": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
-      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
     },
     "ms": {
       "version": "2.0.0",
@@ -38250,24 +38120,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "nearley": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "requires": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        }
-      }
     },
     "negotiator": {
       "version": "0.6.3",
@@ -38677,15 +38529,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
-    },
-    "parseley": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
-      "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
-      "requires": {
-        "moo": "^0.5.1",
-        "nearley": "^2.20.1"
-      }
     },
     "parseurl": {
       "version": "1.3.3",
@@ -39740,20 +39583,6 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
-    "railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
-    },
-    "randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "requires": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -40740,11 +40569,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-    },
     "retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -40868,14 +40692,6 @@
       "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
       "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==",
       "dev": true
-    },
-    "selderee": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
-      "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
-      "requires": {
-        "parseley": "^0.7.0"
-      }
     },
     "select-hose": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "draft-js": "^0.11.7",
     "draft-js-export-html": "^1.4.1",
     "draft-js-import-html": "^1.4.1",
-    "html-to-text": "^8.2.1",
     "react-datepicker": "^4.10.0",
     "react-popper": "^2.3.0",
     "react-select": "^5.7.0",

--- a/scripts/generate-types/typesPostFixes.js
+++ b/scripts/generate-types/typesPostFixes.js
@@ -166,20 +166,29 @@ exports.replacements = (componentName) => ({
       [
         `import * as React from 'react';`,
         `import * as React from 'react';
-        import { EditorState, ContentState, RawDraftContentState } from 'draft-js';
+        import { EditorState, RawDraftContentState } from 'draft-js';
         import { createEditorStateWithText } from '@draft-js-plugins/editor';`,
       ],
       [
         `declare const RichTextEditor: React.FC<RichTextEditorProps>`,
         `declare const RichTextEditor: React.FC<RichTextEditorProps> & {
-        createEmpty: typeof EditorState.createEmpty;
-        createWithText: typeof createEditorStateWithText;
-        stateToHTML: (input: ContentState) => string;
-        stateFromHTML: (input: string) => EditorState;
-        stateToPlainText: (input: ContentState) => string;
-        stateToEntityList: (input: ContentState) => RawDraftContentState['entityMap'];
-        plainTextFromHTML: (input: string) => string;
-      };`,
+          createEmpty: typeof EditorState.createEmpty;
+          createWithText: typeof createEditorStateWithText;
+          stateToHTML: (input: EditorState) => string;
+          stateFromHTML: (input: string, options?: { parser?: (html: string) => HTMLBodyElement }) => EditorState;
+          stateToPlainText: (input: EditorState) => string;
+          stateToEntityList: (input: EditorState) => RawDraftContentState['entityMap'];
+          plainTextFromHTML: (input: string) => string;
+          useTruncateState: ({
+            editorState,
+            briefCharCount,
+            truncateString,
+          }: {
+            editorState: EditorState;
+            briefCharCount: number;
+            truncateString: string;
+          }) => { totalCharCount: number; truncatedState: EditorState };
+        };`,
       ],
     ],
   },

--- a/src/components/Accordion/__snapshots__/index.spec.jsx.snap
+++ b/src/components/Accordion/__snapshots__/index.spec.jsx.snap
@@ -26,9 +26,13 @@ exports[`<Accordion /> should have default props 1`] = `
           Panel 1
         </div>
         <div
-          class="panel-component-content"
-          data-testid="panel-content"
-        />
+          class="panel-component-content-wrapper animate"
+        >
+          <div
+            class="panel-component-content"
+            data-testid="panel-content"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/Panel/index.d.ts
+++ b/src/components/Panel/index.d.ts
@@ -9,8 +9,9 @@ export interface PanelProps {
   isCollapsed?: boolean;
   onClick?: (...args: any[]) => any;
   children?: React.ReactNode;
+  animate?: boolean;
 }
 
-export default class Panel extends React.Component<PanelProps, any> {
-  render(): JSX.Element;
-}
+declare const Panel: React.FC<PanelProps>;
+
+export default Panel;

--- a/src/components/Panel/index.jsx
+++ b/src/components/Panel/index.jsx
@@ -1,28 +1,34 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useCollapse } from '../../hooks/useCollapse';
 import './styles.css';
 
-class Panel extends React.PureComponent {
-  onHeaderClick = () => this.props.onClick(this.props.id);
+const Panel = ({ onClick, className, children, dts, icon, id, isCollapsed, title, animate = true }) => {
+  const onHeaderClick = () => {
+    onClick(id);
+  };
 
-  render() {
-    const { className, children, dts, icon, isCollapsed, title } = this.props;
-    const classesCombined = classnames(['panel-component', { collapsed: isCollapsed }, className]);
+  const { collapsed, height, containerRef } = useCollapse({
+    collapsed: isCollapsed,
+  });
 
-    return (
-      <div data-testid="panel-wrapper" className={classesCombined} data-test-selector={dts}>
-        <div data-testid="panel-header" className="panel-component-header clearfix" onClick={this.onHeaderClick}>
-          {icon}
-          {title}
-        </div>
-        <div data-testid="panel-content" className="panel-component-content">
+  const classesCombined = classnames(['panel-component', { collapsed }, className]);
+
+  return (
+    <div data-testid="panel-wrapper" className={classesCombined} data-test-selector={dts}>
+      <div data-testid="panel-header" className="panel-component-header clearfix" onClick={onHeaderClick}>
+        {icon}
+        {title}
+      </div>
+      <div style={{ height }} className={classnames('panel-component-content-wrapper', { animate })}>
+        <div ref={containerRef} data-testid="panel-content" className="panel-component-content">
           {children}
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 Panel.propTypes = {
   id: PropTypes.string.isRequired,
@@ -33,6 +39,7 @@ Panel.propTypes = {
   isCollapsed: PropTypes.bool,
   onClick: PropTypes.func,
   children: PropTypes.node,
+  animate: PropTypes.bool,
 };
 
 export default Panel;

--- a/src/components/Panel/styles.css
+++ b/src/components/Panel/styles.css
@@ -2,7 +2,7 @@
 
 .panel-component {
   background-color: $color-white;
-  transition: background-color 250ms ease-out;
+  transition: background-color 250ms 75ms ease-out;
 }
 
 .panel-component ~ .panel-component {
@@ -35,6 +35,14 @@
   position: relative;
   width: 22px;
   fill: $color-grey-800;
+}
+
+.panel-component-content-wrapper {
+  overflow: hidden;
+
+  &.animate {
+    transition: all 250ms ease;
+  }
 }
 
 .panel-component-header,

--- a/src/components/Paragraph/index.d.ts
+++ b/src/components/Paragraph/index.d.ts
@@ -1,16 +1,33 @@
 import * as React from 'react';
 
+export type ParagraphChildren = string | React.ReactNode;
+
 export type ParagraphClassName = string | string[];
 
 export interface ParagraphProps {
   /**
-   * The maximum of word count for brief content
+   * The maximum character count for brief content
    */
-  briefWordCount: number;
+  briefCharCount?: number;
+  /**
+   * A fallback maximum height for the brief content.
+   * This height won't be exceeded, even if props.briefCharCount isn't reached
+   * (e.g due to new lines in HTML)
+   * @default 100
+   */
+  briefMaxHeight?: number;
+  /**
+   * Removes Read More button, only showing text in the current collapsed state
+   */
+  hideReadMore?: boolean;
+  /**
+   * Control collapsed state
+   */
+  collapsed?: boolean;
   /**
    * Content inside paragraph
    */
-  content?: string;
+  children: ParagraphChildren;
   /**
    * Custom classnames
    */
@@ -19,12 +36,40 @@ export interface ParagraphProps {
    * Generate "data-test-selector" on the paragraph
    */
   dts?: string;
-  /**
-   * Define if the content is HTML type or not
-   */
-  isHtml?: boolean;
 }
 
-declare const Paragraph: React.FC<ParagraphProps>;
+declare const Paragraph: React.FC<ParagraphProps> & {
+  ReadMore: typeof Paragraph;
+  HTML: typeof HTML;
+};
 
 export default Paragraph;
+
+export interface HTMLProps {
+  /**
+   * Control the html truncation state
+   */
+  truncated?: boolean;
+  /**
+   * the string to append to truncated text
+   * @default '...'
+   */
+  truncateString?: string;
+  /**
+   * HTML content
+   */
+  content?: string;
+  /**
+   * Optional parser to sanitize content with
+   */
+  parser?: (...args: any[]) => any;
+  /**
+   * limits the content to this length when truncated
+   */
+  briefCharCount?: number;
+  dts?: string;
+}
+
+declare const HTML: React.FC<HTMLProps>;
+
+declare const ReadMoreProdiver: React.FC;

--- a/src/components/Paragraph/index.spec.jsx
+++ b/src/components/Paragraph/index.spec.jsx
@@ -1,14 +1,25 @@
 import React from 'react';
 import { render, cleanup, fireEvent } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import Paragraph from '.';
 
 afterEach(cleanup);
 
 describe('<Paragraph />', () => {
-  const plainText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-  Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. \n
-  Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-  Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
+  let resizeListener;
+
+  beforeEach(() => {
+    global.ResizeObserver = class ResizeObserver {
+      observe = jest.fn();
+      unobserve = jest.fn();
+      disconnect = jest.fn();
+      constructor(ls) {
+        resizeListener = ls;
+      }
+    };
+  });
+
+  const plainText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`;
 
   const htmlText = `
     <details>
@@ -25,36 +36,185 @@ describe('<Paragraph />', () => {
   `;
 
   it('should render with plain content', () => {
-    const { getByTestId, queryByTestId } = render(<Paragraph content={plainText} briefWordCount={15} />);
+    const { getByTestId, queryByTestId } = render(<Paragraph children={plainText} />);
     expect(queryByTestId('paragraph-wrapper')).toBeInTheDocument();
-    expect(getByTestId('paragraph-brief')).toHaveTextContent('Lorem ipsum...');
+    expect(getByTestId('paragraph-content')).toHaveTextContent(plainText);
 
-    expect(queryByTestId('paragraph-expandable-content')).toBeInTheDocument();
     expect(queryByTestId('paragraph-read-more-button')).toBeInTheDocument();
   });
 
-  it('should render with isHtml', () => {
-    const { getByTestId, queryByTestId } = render(<Paragraph content={htmlText} briefWordCount={15} isHtml />);
+  it('should not have read more button if hideReadMore is true', () => {
+    const { getByTestId, queryByTestId } = render(
+      <Paragraph hideReadMore>
+        <Paragraph.HTML briefCharCount={11} content={plainText} />
+      </Paragraph>
+    );
     expect(queryByTestId('paragraph-wrapper')).toBeInTheDocument();
-    expect(getByTestId('paragraph-brief')).toHaveTextContent('Lorem ipsum...');
+    expect(getByTestId('paragraph-content')).toHaveTextContent('Lorem ipsum...');
 
-    expect(queryByTestId('paragraph-expandable-content')).toBeInTheDocument();
-    expect(queryByTestId('paragraph-read-more-button')).toBeInTheDocument();
+    expect(queryByTestId('paragraph-read-more-button')).not.toBeInTheDocument();
+  });
+
+  it('should not have read more button if text is less than briefCharCount', () => {
+    const { getByTestId, queryByTestId } = render(
+      <Paragraph>
+        <Paragraph.HTML briefCharCount={500} content={plainText} />
+      </Paragraph>
+    );
+
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 200,
+          },
+        },
+      ]);
+    });
+
+    expect(queryByTestId('paragraph-wrapper')).toBeInTheDocument();
+    expect(getByTestId('paragraph-content')).toHaveTextContent(plainText);
+
+    expect(queryByTestId('paragraph-read-more-button')).not.toBeInTheDocument();
+  });
+
+  it("should not show ellipsis if briefCharCount isn't reached", () => {
+    const { getByTestId, queryByTestId } = render(
+      <Paragraph children={'Lorem ipsum'}>
+        <Paragraph.HTML briefCharCount={11} content={plainText} />
+      </Paragraph>
+    );
+    expect(queryByTestId('paragraph-wrapper')).toBeInTheDocument();
+    expect(getByTestId('paragraph-content')).toHaveTextContent('Lorem ipsum');
+  });
+
+  it('should be able to customize the truncate string', () => {
+    const { getByTestId, queryByTestId } = render(
+      <Paragraph children={'Lorem ipsum Dolor'}>
+        <Paragraph.HTML briefCharCount={11} truncateString=" [...]" content={plainText} />
+      </Paragraph>
+    );
+    expect(queryByTestId('paragraph-wrapper')).toBeInTheDocument();
+    expect(getByTestId('paragraph-content')).toHaveTextContent('Lorem ipsum [...]');
+  });
+
+  it('should not exceed briefMaxHeight', () => {
+    const { getByTestId, queryByTestId } = render(
+      <Paragraph briefMaxHeight={50}>
+        <Paragraph.HTML
+          briefCharCount={100}
+          content={`<p>Lorum<p/><p>Lorum<p/><p>Lorum</p><p> <p/><p> <p/><p> <p/><p>Lorum</p>`}
+        />
+      </Paragraph>
+    );
+
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 100,
+          },
+        },
+      ]);
+    });
+
+    expect(queryByTestId('paragraph-wrapper')).toBeInTheDocument();
+    expect(getByTestId('expandable-content')).toHaveStyle(`height: 50px`);
+    expect(getByTestId('paragraph-content')).toHaveTextContent(`Lorum Lorum`);
+    expect(getByTestId('expandable-content')).toHaveClass('paragraph-fade-bottom');
+  });
+
+  it('should allow no briefMaxHeight', () => {
+    const { getByTestId, queryByTestId } = render(
+      <Paragraph briefMaxHeight={null}>
+        <Paragraph.HTML
+          briefCharCount={100}
+          content={`<p>Lorum<p/><p>Lorum<p/><p>Lorum</p><p> <p/><p> <p/><p> <p/><p>Lorum</p>`}
+        />
+      </Paragraph>
+    );
+
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 100,
+          },
+        },
+      ]);
+    });
+
+    expect(queryByTestId('paragraph-wrapper')).toBeInTheDocument();
+
+    expect(getByTestId('expandable-content')).toHaveStyle(`height: 100px`);
+    expect(getByTestId('paragraph-content')).toHaveTextContent(`Lorum Lorum`);
+  });
+
+  it('should render expected heights', () => {
+    const { getByTestId, queryByTestId } = render(<Paragraph children={plainText} />);
+
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 50,
+          },
+        },
+      ]);
+    });
+
+    expect(queryByTestId('paragraph-wrapper')).toBeInTheDocument();
+    expect(getByTestId('expandable-content')).toHaveStyle(`height: 50px`);
+
+    fireEvent.click(getByTestId('paragraph-read-more-button'));
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 200,
+          },
+        },
+      ]);
+    });
+    expect(getByTestId('expandable-content')).toHaveStyle(`height: 200px`);
+
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 50,
+          },
+        },
+      ]);
+    });
+
+    fireEvent.click(getByTestId('paragraph-read-more-button'));
+    expect(getByTestId('expandable-content')).toHaveStyle(`height: 50px`);
   });
 
   it('should be able to click read more button to expand paragraph', () => {
-    const { getByTestId, queryByTestId } = render(<Paragraph content={htmlText} briefWordCount={15} isHtml />);
+    const { getByTestId, queryByTestId } = render(
+      <Paragraph>
+        <Paragraph.HTML briefCharCount={11} content={htmlText} />
+      </Paragraph>
+    );
     expect(queryByTestId('paragraph-wrapper')).toBeInTheDocument();
 
-    expect(queryByTestId('paragraph-brief')).toBeInTheDocument();
-    expect(queryByTestId('paragraph-expandable-content')).toBeInTheDocument();
-    expect(getByTestId('paragraph-expandable-content')).toHaveClass('expandable-content collapsed');
+    expect(queryByTestId('paragraph-content')).toBeInTheDocument();
 
     expect(queryByTestId('paragraph-read-more-button')).toBeInTheDocument();
     fireEvent.click(getByTestId('paragraph-read-more-button'));
 
-    expect(queryByTestId('paragraph-brief')).not.toBeInTheDocument();
-    expect(queryByTestId('paragraph-expandable-content')).toBeInTheDocument();
-    expect(getByTestId('paragraph-expandable-content')).toHaveClass('expandable-content expanded');
+    expect(getByTestId('paragraph-content')).toHaveTextContent(
+      `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
+    );
+    fireEvent.click(getByTestId('paragraph-read-more-button'));
+    expect(getByTestId('paragraph-content')).toHaveTextContent(`Lorem ipsum...`);
+  });
+
+  it('should be usable without ReadMore', () => {
+    const { getByTestId, queryByTestId } = render(<Paragraph.HTML truncated briefCharCount={20} content={plainText} />);
+    expect(getByTestId('paragraph-html-content')).toHaveTextContent(`Lorem ipsum dolor si...`);
+    expect(queryByTestId('paragraph-read-more-button')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Paragraph/styles.css
+++ b/src/components/Paragraph/styles.css
@@ -1,35 +1,45 @@
+@import url('../../styles/variable');
+
+@keyframes fade-default {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
 .aui--paragraph {
   margin: 0;
   font-size: 14px;
-  white-space: pre-line;
-}
 
-.aui--paragraph .expandable-content {
-  overflow: hidden;
-}
+  & .expandable-content {
+    overflow: hidden;
+    transition: height 400ms ease;
+  }
 
-.aui--paragraph .expandable-content.expanded {
-  max-height: 800px;
-  opacity: 1;
-  transition: 1s ease;
-}
+  & .paragraph-content {
+    display: flex;
+    flex-direction: column;
+  }
 
-.aui--paragraph .expandable-content.collapsed {
-  max-height: 0;
-  opacity: 0;
-  transition: 0.4s ease;
-}
+  & .paragraph-fade-bottom {
+    mask-image: linear-gradient(to bottom, $color-black 50%, transparent 100%);
+  }
 
-.aui--paragraph-read-more {
-  padding: 4px 0;
-}
+  & .aui--paragraph-read-more {
+    padding: 4px 0;
 
-.aui--paragraph-read-more.aui--button.aui-link:focus {
-  color: #337ab7;
-  text-decoration: none;
-}
+    &.aui--button.btn-link {
+      &:focus {
+        color: $color-primary-base;
+        text-decoration: none;
+      }
 
-.aui--paragraph-read-more.aui--button.aui-link:hover,
-.aui--paragraph-read-more.aui--button.aui-link :hover:focus {
-  text-decoration: underline;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
 }

--- a/src/components/RichTextEditor/index.d.ts
+++ b/src/components/RichTextEditor/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EditorState, ContentState, RawDraftContentState } from 'draft-js';
+import { EditorState, RawDraftContentState } from 'draft-js';
 import { createEditorStateWithText } from '@draft-js-plugins/editor';
 
 export interface RichTextEditorMentions {
@@ -23,11 +23,20 @@ export interface RichTextEditorProps {
 declare const RichTextEditor: React.FC<RichTextEditorProps> & {
   createEmpty: typeof EditorState.createEmpty;
   createWithText: typeof createEditorStateWithText;
-  stateToHTML: (input: ContentState) => string;
-  stateFromHTML: (input: string) => EditorState;
-  stateToPlainText: (input: ContentState) => string;
-  stateToEntityList: (input: ContentState) => RawDraftContentState['entityMap'];
+  stateToHTML: (input: EditorState) => string;
+  stateFromHTML: (input: string, options?: { parser?: (html: string) => HTMLBodyElement }) => EditorState;
+  stateToPlainText: (input: EditorState) => string;
+  stateToEntityList: (input: EditorState) => RawDraftContentState['entityMap'];
   plainTextFromHTML: (input: string) => string;
+  useTruncateState: ({
+    editorState,
+    briefCharCount,
+    truncateString,
+  }: {
+    editorState: EditorState;
+    briefCharCount: number;
+    truncateString: string;
+  }) => { totalCharCount: number; truncatedState: EditorState };
 };
 
 export default RichTextEditor;

--- a/src/components/RichTextEditor/index.jsx
+++ b/src/components/RichTextEditor/index.jsx
@@ -16,10 +16,11 @@ import FilePreviewList from './FilePreviewList';
 import Popover from '../Popover';
 import './styles.css';
 
-const { EditorState, Modifier, convertToRaw, RichUtils } = draftJs;
+const { Modifier, EditorState, convertToRaw, RichUtils, SelectionState } = draftJs;
 
 const editorStateToHTML = (input) => stateToHTML(input.getCurrentContent());
-const editorStateFromHTML = (input) => EditorState.createWithContent(stateFromHTML(input));
+const editorStateFromHTML = (input, options = {}) =>
+  EditorState.createWithContent(stateFromHTML(input, { parser: options.parser }));
 const isEditorStateEmpty = (html) => html === '<p><br></p>';
 
 const getInitialEditorState = (value, initialValue) => {
@@ -233,9 +234,83 @@ RichTextEditor.defaultProps = {
 RichTextEditor.createEmpty = EditorState.createEmpty;
 RichTextEditor.createWithText = createEditorStateWithText;
 RichTextEditor.stateToHTML = editorStateToHTML;
+/**
+ * @example
+ * // parser exaple with dom-purify
+ * const DOMPurifyDefaultConfig = {
+ *   USE_PROFILES: { html: true },
+ *   FORBID_TAGS: ['style'],
+ *   FORBID_ATTR: ['style'],
+ * };
+ * const parser = (html) => DOMPurify.sanitize(html, { ...DOMPurifyConfig, RETURN_DOM: true });
+ *
+ * RichTextEditor.stateFromHTML(html, { parser });
+ **/
 RichTextEditor.stateFromHTML = editorStateFromHTML;
 RichTextEditor.stateToPlainText = (input) => input.getCurrentContent().getPlainText();
 RichTextEditor.stateToEntityList = (input) => convertToRaw(input.getCurrentContent()).entityMap;
 RichTextEditor.plainTextFromHTML = (input) => RichTextEditor.stateToPlainText(editorStateFromHTML(input));
+RichTextEditor.useTruncateState = ({ editorState, briefCharCount, truncateString }) => {
+  const totalCharCount = React.useMemo(() => {
+    const contentState = editorState.getCurrentContent();
+    const blocks = contentState.getBlocksAsArray();
+    return contentState.getPlainText().length - (blocks.length - 1);
+  }, [editorState]);
+
+  const truncatedState = React.useMemo(() => {
+    // text doesn't exceed limit
+    if (totalCharCount <= briefCharCount) {
+      return editorState;
+    }
+
+    const contentState = editorState.getCurrentContent();
+    const blocks = contentState.getBlocksAsArray();
+    const lastBlock = contentState.getLastBlock();
+
+    let anchor = lastBlock;
+    let anchorOffset = 0;
+    let acc = 0;
+
+    // get the anchor offset and start block of the text to be removed
+    for (let i = 0; i < blocks.length; i++) {
+      const curr = blocks[i];
+      if (curr.getLength() + acc >= briefCharCount) {
+        anchor = curr;
+        const offset = curr.getLength() + acc - briefCharCount;
+        anchorOffset = offset === 0 ? curr.getLength() : -offset;
+        break;
+      }
+      acc += curr.getLength();
+    }
+
+    // select from anchor offset to end of last block
+    const targetRange = new SelectionState({
+      anchorKey: anchor.getKey(),
+      anchorOffset,
+      focusKey: lastBlock.getKey(),
+      focusOffset: lastBlock.getLength(),
+    });
+
+    const replaced = Modifier.removeRange(contentState, targetRange, 'forward');
+
+    // insert truncateString at end
+    if (truncateString) {
+      const end = replaced.getLastBlock();
+      const newSelection = SelectionState.createEmpty(anchor.getKey())
+        .set('anchorOffset', end.getLength())
+        .set('focusOffset', end.getLength());
+
+      const withTruncateString = Modifier.insertText(replaced, newSelection, truncateString, null);
+
+      return EditorState.push(editorState, withTruncateString, 'remove-range');
+    }
+    return EditorState.push(editorState, replaced, 'remove-range');
+  }, [briefCharCount, editorState, totalCharCount, truncateString]);
+
+  return {
+    totalCharCount,
+    truncatedState,
+  };
+};
 
 export default RichTextEditor;

--- a/src/hooks/useCollapse.js
+++ b/src/hooks/useCollapse.js
@@ -1,0 +1,62 @@
+import _ from 'lodash';
+import React from 'react';
+
+/**
+ * @param {Object} useCollapse
+ * @param {number} useCollapse.collapsedHeight height to collapse to (default 0)
+ * @param {number} useCollapse.collapsed optionally control collapsed state
+ */
+export const useCollapse = ({ collapsedHeight = 0, collapsed: collapsedProp = false }) => {
+  const containerRef = React.useRef();
+  const elHeightRef = React.useRef();
+  const collapsedHeightRef = React.useRef();
+
+  const [height, _setHeight] = React.useState();
+  const [collapsed, setCollapsed] = React.useState(collapsedProp);
+
+  const setHeight = React.useCallback(
+    (elHeight) => {
+      if (!containerRef.current) return;
+      collapsedHeightRef.current = _.isNumber(collapsedHeight) ? Math.min(collapsedHeight, elHeight) : elHeight;
+      if (!collapsed) {
+        _setHeight(elHeight);
+      } else {
+        _setHeight(collapsedHeightRef.current);
+      }
+    },
+    [collapsedHeight, collapsed]
+  );
+
+  React.useLayoutEffect(() => {
+    setCollapsed(collapsedProp);
+  }, [collapsedProp]);
+
+  React.useEffect(() => {
+    if (!containerRef.current) return;
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        // borderBoxSize is not an array in old versions of Firefox
+        elHeightRef.current = _.castArray(entry.borderBoxSize)[0]?.blockSize ?? entry.contentRect.height;
+
+        setHeight(elHeightRef.current);
+      }
+    });
+    resizeObserver.observe(containerRef.current);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [setHeight]);
+
+  const collapsedHeightExceeded = _.isNil(collapsedHeight) || collapsedHeightRef.current === collapsedHeight;
+
+  React.useLayoutEffect(() => {
+    if (!containerRef.current || !elHeightRef.current) return;
+    setHeight(elHeightRef.current);
+  }, [setHeight]);
+
+  const toggleCollapsed = () => {
+    setCollapsed(!collapsed);
+  };
+
+  return { collapsed, toggleCollapsed, height, collapsedHeightExceeded, containerRef };
+};

--- a/src/hooks/useCollapse.spec.js
+++ b/src/hooks/useCollapse.spec.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, cleanup, fireEvent, act } from '@testing-library/react';
+import { useCollapse } from './useCollapse';
+
+afterEach(cleanup);
+
+describe('useCollapse()', () => {
+  const Component = ({ collapsedHeight, collapsed: collapsedProp, noRef, children }) => {
+    const { collapsed, toggleCollapsed, height, containerRef } = useCollapse({
+      collapsedHeight,
+      collapsed: collapsedProp,
+    });
+
+    return (
+      <div data-testid="wrapper" style={{ height }}>
+        <span ref={noRef ? null : containerRef}>{children}</span>
+        <button onClick={toggleCollapsed}>{collapsed ? 'expand' : 'collapse'}</button>
+      </div>
+    );
+  };
+
+  let resizeListener;
+
+  beforeEach(() => {
+    global.ResizeObserver = class ResizeObserver {
+      observe = jest.fn();
+      unobserve = jest.fn();
+      disconnect = jest.fn();
+      constructor(ls) {
+        resizeListener = ls;
+      }
+    };
+  });
+
+  it('should set height', () => {
+    const { getByTestId, getByRole } = render(
+      <Component>
+        <div style={{ height: 1000 }} />
+      </Component>
+    );
+
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 1000,
+          },
+        },
+      ]);
+    });
+    expect(getByTestId('wrapper')).toHaveStyle({ height: '1000px' });
+
+    expect(getByRole('button')).toHaveAccessibleName('collapse');
+    fireEvent.click(getByRole('button'));
+    expect(getByRole('button')).toHaveAccessibleName('expand');
+    expect(getByTestId('wrapper')).toHaveStyle({ height: 0 });
+  });
+
+  it('should be controllable', () => {
+    const { getByTestId, getByRole } = render(
+      <Component collapsedHeight={25} collapsed>
+        <div style={{ height: 1000 }} />
+      </Component>
+    );
+
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 1000,
+          },
+        },
+      ]);
+    });
+
+    expect(getByTestId('wrapper')).toHaveStyle({ height: '25px' });
+    expect(getByRole('button')).toHaveAccessibleName('expand');
+  });
+
+  it('should do nothing without container ref', () => {
+    const { getByTestId, getByRole } = render(
+      <Component collapsedHeight={25} noRef>
+        <div style={{ height: 1000 }} />
+      </Component>
+    );
+
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 1000,
+          },
+        },
+      ]);
+    });
+
+    expect(getByTestId('wrapper')).toHaveStyle({ height: undefined });
+    fireEvent.click(getByRole('button'));
+    expect(getByTestId('wrapper')).toHaveStyle({ height: undefined });
+  });
+
+  it('should collapse to collapsedHeight', () => {
+    const { getByTestId, getByRole } = render(
+      <Component collapsedHeight={25}>
+        <div style={{ height: 1000 }} />
+      </Component>
+    );
+
+    act(() => {
+      resizeListener([
+        {
+          contentRect: {
+            height: 1000,
+          },
+        },
+      ]);
+    });
+
+    expect(getByTestId('wrapper')).toHaveStyle({ height: '1000px' });
+
+    expect(getByRole('button')).toHaveAccessibleName('collapse');
+    fireEvent.click(getByRole('button'));
+    expect(getByRole('button')).toHaveAccessibleName('expand');
+    expect(getByTestId('wrapper')).toHaveStyle({ height: '25px' });
+  });
+});

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -3198,15 +3198,7 @@
     {
       "description": "",
       "displayName": "Panel",
-      "methods": [
-        {
-          "name": "onHeaderClick",
-          "docblock": null,
-          "modifiers": [],
-          "params": [],
-          "returns": null
-        }
-      ],
+      "methods": [],
       "props": {
         "id": {
           "type": {
@@ -3263,6 +3255,17 @@
           },
           "required": false,
           "description": ""
+        },
+        "animate": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "true",
+            "computed": false
+          }
         }
       }
     }
@@ -3271,24 +3274,86 @@
     {
       "description": "",
       "displayName": "Paragraph",
-      "methods": [],
+      "methods": [
+        {
+          "name": "ReadMore",
+          "docblock": null,
+          "modifiers": [
+            "static"
+          ],
+          "params": [
+            {
+              "name": "{\n  briefMaxHeight = 200,\n  hideReadMore,\n  collapsed: collapsedProp = true,\n  className,\n  children,\n  dts,\n}",
+              "type": null
+            }
+          ],
+          "returns": null
+        },
+        {
+          "name": "HTML",
+          "docblock": null,
+          "modifiers": [
+            "static"
+          ],
+          "params": [
+            {
+              "name": "{ dts, truncated, content, briefCharCount = 240, truncateString = '...', parser }",
+              "type": null
+            }
+          ],
+          "returns": null
+        }
+      ],
       "props": {
-        "briefWordCount": {
+        "briefCharCount": {
           "type": {
             "name": "number"
           },
           "required": false,
-          "description": "The maximum of word count for brief content",
+          "description": "The maximum character count for brief content"
+        },
+        "briefMaxHeight": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "A fallback maximum height for the brief content.\n This height won't be exceeded, even if props.briefCharCount isn't reached\n (e.g due to new lines in HTML)\n @default 100",
           "defaultValue": {
-            "value": "255",
+            "value": "200",
             "computed": false
           }
         },
-        "content": {
+        "hideReadMore": {
           "type": {
-            "name": "string"
+            "name": "bool"
           },
           "required": false,
+          "description": "Removes Read More button, only showing text in the current collapsed state"
+        },
+        "collapsed": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "Control collapsed state",
+          "defaultValue": {
+            "value": "true",
+            "computed": false
+          }
+        },
+        "children": {
+          "type": {
+            "name": "union",
+            "value": [
+              {
+                "name": "string"
+              },
+              {
+                "name": "node"
+              }
+            ]
+          },
+          "required": true,
           "description": "Content inside paragraph"
         },
         "className": {
@@ -3315,17 +3380,68 @@
           },
           "required": false,
           "description": "Generate \"data-test-selector\" on the paragraph"
-        },
-        "isHtml": {
+        }
+      }
+    },
+    {
+      "description": "",
+      "displayName": "ReadMoreProdiver",
+      "methods": []
+    },
+    {
+      "description": "",
+      "displayName": "HTML",
+      "methods": [],
+      "props": {
+        "truncated": {
           "type": {
             "name": "bool"
           },
           "required": false,
-          "description": "Define if the content is HTML type or not",
+          "description": "Control the html truncation state"
+        },
+        "truncateString": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "the string to append to truncated text\n@default '...'",
           "defaultValue": {
-            "value": "false",
+            "value": "'...'",
             "computed": false
           }
+        },
+        "content": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "HTML content"
+        },
+        "parser": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "Optional parser to sanitize content with"
+        },
+        "briefCharCount": {
+          "type": {
+            "name": "number"
+          },
+          "required": false,
+          "description": "limits the content to this length when truncated",
+          "defaultValue": {
+            "value": "240",
+            "computed": false
+          }
+        },
+        "dts": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
         }
       }
     }
@@ -4069,18 +4185,21 @@
         },
         {
           "name": "stateFromHTML",
-          "docblock": null,
+          "docblock": "@example\n// parser exaple with dom-purify\nconst DOMPurifyDefaultConfig = {\n  USE_PROFILES: { html: true },\n  FORBID_TAGS: ['style'],\n  FORBID_ATTR: ['style'],\n};\nconst parser = (html) => DOMPurify.sanitize(html, { ...DOMPurifyConfig, RETURN_DOM: true });\n\nRichTextEditor.stateFromHTML(html, { parser });",
           "modifiers": [
             "static"
           ],
           "params": [
             {
               "name": "input",
-              "optional": false,
-              "type": null
+              "optional": false
+            },
+            {
+              "name": "options"
             }
           ],
-          "returns": null
+          "returns": null,
+          "description": null
         },
         {
           "name": "stateToPlainText",
@@ -4111,6 +4230,35 @@
             }
           ],
           "returns": null
+        },
+        {
+          "name": "plainTextFromHTML",
+          "docblock": null,
+          "modifiers": [
+            "static"
+          ],
+          "params": [
+            {
+              "name": "input",
+              "optional": false,
+              "type": null
+            }
+          ],
+          "returns": null
+        },
+        {
+          "name": "useTruncateState",
+          "docblock": null,
+          "modifiers": [
+            "static"
+          ],
+          "params": [
+            {
+              "name": "{ editorState, briefCharCount, truncateString }",
+              "type": null
+            }
+          ],
+          "returns": null
         }
       ],
       "props": {
@@ -4134,19 +4282,17 @@
         },
         "initialValue": {
           "type": {
-            "name": "instanceOf",
-            "value": "EditorState"
+            "name": "string"
           },
           "required": false,
-          "description": "Editor State"
+          "description": ""
         },
         "value": {
           "type": {
-            "name": "instanceOf",
-            "value": "EditorState"
+            "name": "string"
           },
           "required": false,
-          "description": "Editor State: Instance of <a href=\"https://draftjs.org/docs/api-reference-editor-state\">draft-js editor state</a>"
+          "description": ""
         },
         "onChange": {
           "type": {

--- a/www/examples/Paragraph.mdx
+++ b/www/examples/Paragraph.mdx
@@ -5,30 +5,56 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 
 ```jsx live=true
 const Example = () => {
-  const content = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. \n
-    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
+  const text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
 
   const richText = `
-    <details>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-        magna aliqua.Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-        consequat.
-      </p>
-      <p>
-        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.Excepteur
-        sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
-    </details>
+      <p><strong>Record numbers and consumer trust</strong><br>
+We are seeing some of our strongest traffic and highest trust scores from global audiences than ever before</p>
+<p>We're the no.1 trusted newsbrand in the UK87% of people trust what they see in The Guardian online. 79% feel it offers them something they can't get elsewhere.*</p>
   `;
+  const [content, setContent] = React.useState(RichTextEditor.stateFromHTML(richText));
 
   return (
     <React.Fragment>
-      <Paragraph briefWordCount={200} content={content} />
+      <h4>
+        <strong>Read More with plain text / max height</strong>
+      </h4>
       <br />
-      <Paragraph briefWordCount={200} content={richText} isHtml />
+      <Paragraph.ReadMore briefMaxHeight={45}>{text}</Paragraph.ReadMore>
+      <br />
+      <br />
+      <h4>
+        <strong>Read More with html text / character limit</strong>
+      </h4>
+      <br />
+      <Paragraph.ReadMore>
+        <Paragraph.HTML briefCharCount={100} content={text} />
+      </Paragraph.ReadMore>
+      <br />
+      <br />
+      <h4>
+        <strong>Example linked to RichText editor content</strong>
+      </h4>
+      <p>Input:</p>
+      <RichTextEditor value={content} onChange={setContent} />
+      <br />
+      <p>Output:</p>
+      <div style={{ maxWidth: 850 }}>
+        <InformationBox>
+          <Paragraph.ReadMore briefMaxHeight={200}>
+            <Paragraph.HTML content={RichTextEditor.stateToHTML(content)} />
+          </Paragraph.ReadMore>
+        </InformationBox>
+      </div>
+      <br />
+      <br />
+      <h4>
+        <strong>Just HTML</strong>
+      </h4>
+      <Paragraph.HTML content={RichTextEditor.stateToHTML(content)} />
     </React.Fragment>
   );
 };


### PR DESCRIPTION
## Description
**ASC-142**
- add `useCollapse` hook
  - use in `Panel` and `Paragrah.ReadMore`

**ASC-145**
- Paragraph
  - split up into `Paragraph.ReadMore`, and `Paragrah.HTML`
  - Use RichTextEditor methods for handling of html passed to `Paragrah.HTML`
  - remove `isHtml` prop - no longer matters if content is html or plain text
  - Add `briefCharCount` prop to HTML - either to statically truncate `Paragrah.HTML` content, or set the max char count when combined with `Paragrah.ReadMore`
  - Add `briefMaxHeight` prop to ReadMore - clamps the maximum height of the brief state, regardless of the max char count (useful when the html has few characters but a lot of height due to line breaks, or if the container's width is reduced). 
 
### Usage

Set max height of collapsed state (fades bottom)
 ```jsx
<Paragraph.ReadMore briefMaxHeight={100}>
  <Paragraph.HTML content={`<p>...</p>`} />
</Paragraph.ReadMore>
 ```
 
 **Limit html to 100 characters**
 ```jsx
<Paragraph.ReadMore>
  <Paragraph.HTML briefCharCount={100} content={text} />
</Paragraph.ReadMore>
 ```

**Just display html** 
```jsx
<Paragraph.HTML content={text} />
```

- RichTextEditor 
  - add `useTruncateState` hook method for truncating the length of a RichTextEditor state
  - Add option to pass a parser to `stateFromHTML`. Using a client side sanitizer like `dompurify` would prevent the ability to paste unsupported markup like images into the editor
  - fix some incorrect types

**parser example with `dom-purify`**
```jsx
 import DOMPurify from 'dom-purify';
 
 const DOMPurifyConfig = {
  USE_PROFILES: { html: true },
  FORBID_TAGS: ['style'],
  FORBID_ATTR: ['style'],
  RETURN_DOM: true
 };
 
 const parser = (html) => DOMPurify.sanitize(html, DOMPurifyConfig);
 
 const parsedState = RichTextEditor.stateFromHTML(html, { parser });
 
```

`parser` prop exists on `Paragraph.HTML` component

N.B sanitization is up to the consumer, we don't depend on `dom-purify`

- Deps
  removes `html-to-text` (74.3kB min/gzip)

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Prop name changed: `briefWordCount` -> `briefCharCount`

## Manual testing step?

## Screenshots (if appropriate):


![Kapture 2023-02-03 at 10 34 56](https://user-images.githubusercontent.com/13904763/216475714-68982bf5-8c71-4027-9834-87681dec4354.gif)

Dynamic updating
![Kapture 2023-02-03 at 10 37 03](https://user-images.githubusercontent.com/13904763/216475579-8ec948a8-8ae2-47ae-a6fd-455ad7c79fbd.gif)

New `useCollapse` animation in action on the Accordion component
![Kapture 2023-02-03 at 10 38 28](https://user-images.githubusercontent.com/13904763/216475533-36749386-3765-441b-86b9-b4475cf05050.gif)
