### PR TITLE
v30.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "30.2.0",
+  "version": "30.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "30.2.0",
+      "version": "30.2.1",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "30.2.0",
+  "version": "30.2.1",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [ca797e90a840319c1424bf7c894cae62c26cfc19] chore(deps): update react monorepo to ^16.14.0
 
- [f6f7f92db3a432f910a1ccbe8eced02678e17d9d] chore(deps): update dependency autoprefixer to ^10.4.4
 
- [3d64c70ad12728f03781e9845022767b3a76e4aa] chore(deps): update dependency bootstrap-sass to ^3.4.3
 
- [40b1c2439b1c803df99e92122c85c2f077879a80] chore(deps): update dependency lint-staged to ^12.3.7
 
- [26042b94db0eea253f622422c1483e9326171391] chore(deps): update commitlint monorepo
 
- [dcc8f8aecab3a5d5512603ea4bfaf6a749068f76] chore(deps): update dependency css-loader to ^6.7.1
 
- [07a0c6a0beb8324cacb2f4cc9fb0855d7c1850dc] chore(deps): update dependency eslint to ^8.12.0
 
- [06e3cdd87d4a2b1677d9798598d1f7289bf4ea52] chore(deps): update dependency sass-loader to ^12.6.0
 
- [957b19efec12d39efd26cc3d1b058ad8fb2a5730] chore(deps): update actions/checkout action to v3
 
- [4914cc4e661146bf82e6887b4b3f3aeea8b61cf6] chore(deps): update actions/setup-node action to v3
 
- [dbf11475625b819890d48147ebac0be86c8e0606] chore(deps): update dependency sass to ^1.49.11
 
- [2afc78a3640c538bd887fb2cb767d1f5c82e46e2] chore(deps): update dependency prettier to ^2.6.2
 
- [b8009a634c2abf7a2fb1c07ab0c52b6a2d5c7742] chore(deps): update dependency core-js to ^3.21.1
 
- [e7640dc872295c00edaecce5de3d113edfeadf25] chore(deps): update dependency react-router-dom to ^6.3.0
 
- [713f89d61c7c705f7bb04100254f3f149a7e751d] chore(deps): update webpack
 
- [e1ffbf43271aff135293b69fb177502aa7cf5def] chore(deps): update @testing-library
 
- [3607b7c55e8221c575a23e1588202246c2ab74c2] fix: fix disabled button with href props
 
- [58cf9e3e15621836aca37b8f6b0d089763ada9e9] chore: override lodash of pegjs-otf grandchild dep to resolve dependabot alerts
 
- [6ca8c3a725b734b713073d2de31eba1af08f5038] chore(deps): update babel monorepo
 
- [e064226e2bbadef03b7d7fbc2babebd5398a5b45] chore: upgrade react-toastify v8
 
- [38ed7f6b8241df907a66fa41039935a804718b12] chore(deps): update dependency mini-css-extract-plugin to ^2.6.0
 
- [e0feddbbd63f09733d666f1c741ccb0d70bb2744] chore(deps): update dependency prism-react-renderer to ^1.3.1
 
- [1a439b101b6e7a9dfaaf5716c273597032781a48] chore(deps): update dependency react-live to ^2.4.1
 
- [ec360df2c7b044d1f0aa8fcc97422e67be209246] chore(deps): update jest monorepo to ^27.5.1
 
- [3c4bca299a704ae71b6e3f5121656c2aae5c7a10] fix: re-fix lodash dependabot alert issue
 
- [f32ebf31c20de13cada5d9d98afac0d99415f070] fix(deps): update dependency react-datepicker to ^4.7.0
 
- [7d9f731f5f2df259d712a0d3ca29dd33b84686a5] chore: add types related checks
 
- [0b141f310b556cb0a6a4dcf5cc866bf3cdd644f2] Merge branch 'master' into renovate-react-datepicker-4.x
 
- [b1a699114dbb00632750b8e388c6f16629902c20] fix: re-fix lodash dependabot alert issue due to renovate
 
- [e35f1aa156658614d9f2dfa78bec70ee25c5ad6d] build(deps): bump moment from 2.29.1 to 2.29.2
 
	


	Bumps [moment](https://github.com/moment/moment) from 2.29.1 to 2.29.2.


	- [Release notes](https://github.com/moment/moment/releases)


	- [Changelog](https://github.com/moment/moment/blob/develop/CHANGELOG.md)


	- [Commits](https://github.com/moment/moment/compare/2.29.1...2.29.2)


	


	---


	updated-dependencies:


	- dependency-name: moment


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [4e39ecc9edb637b7b3b95e78a6ac1cbf38425689] build: release patch version 30.2.1
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v30.2.0...v30.2.1