### PR TITLE
fix: upgrade richtext mention

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.0",
-        "@draft-js-plugins/mention": "^4.6.1",
+        "@draft-js-plugins/mention": "^5.2.1",
         "@popperjs/core": "^2.4.0",
         "@types/draft-js": "^0.11.8",
         "@types/react-datepicker": "^4.3.4",
@@ -3240,22 +3240,23 @@
       }
     },
     "node_modules/@draft-js-plugins/mention": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@draft-js-plugins/mention/-/mention-4.6.1.tgz",
-      "integrity": "sha512-9h1KfTbKW4qw1YqsgHKu5SOMoTNlG5K2uihmfrv2tJ0k6lFIWZDNy4p9N4oPwghfeiplFIZf6kwTBAjFtF7g/g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/mention/-/mention-5.2.1.tgz",
+      "integrity": "sha512-toegJW/iY+/SVsbLtfGC46ApJ7EhTyd1iN47iYVOp+fMuFMC18GNeu4uJxz49hZ6qHkhxOFeEFevJ2TcK1CBhQ==",
       "dependencies": {
-        "@popperjs/core": "^2.9.2",
-        "@types/lodash": "^4.14.171",
+        "@popperjs/core": "^2.11.5",
+        "@types/lodash": "^4.14.181",
         "clsx": "^1.0.4",
         "immutable": "~3.7.4",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
-        "prop-types": "^15.5.8",
+        "prop-types": "^15.8.1",
         "react-popper": "^2.2.5"
       },
       "peerDependencies": {
         "draft-js": "^0.10.1 || ^0.11.0",
-        "react": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@draft-js-plugins/mention/node_modules/immutable": {
@@ -4862,9 +4863,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
-      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -5470,9 +5471,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.178",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -26603,17 +26604,17 @@
       }
     },
     "@draft-js-plugins/mention": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@draft-js-plugins/mention/-/mention-4.6.1.tgz",
-      "integrity": "sha512-9h1KfTbKW4qw1YqsgHKu5SOMoTNlG5K2uihmfrv2tJ0k6lFIWZDNy4p9N4oPwghfeiplFIZf6kwTBAjFtF7g/g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/mention/-/mention-5.2.1.tgz",
+      "integrity": "sha512-toegJW/iY+/SVsbLtfGC46ApJ7EhTyd1iN47iYVOp+fMuFMC18GNeu4uJxz49hZ6qHkhxOFeEFevJ2TcK1CBhQ==",
       "requires": {
-        "@popperjs/core": "^2.9.2",
-        "@types/lodash": "^4.14.171",
+        "@popperjs/core": "^2.11.5",
+        "@types/lodash": "^4.14.181",
         "clsx": "^1.0.4",
         "immutable": "~3.7.4",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
-        "prop-types": "^15.5.8",
+        "prop-types": "^15.8.1",
         "react-popper": "^2.2.5"
       },
       "dependencies": {
@@ -27868,9 +27869,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
-      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@selderee/plugin-htmlparser2": {
       "version": "0.6.0",
@@ -28389,9 +28390,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.178",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
     },
     "@types/mdast": {
       "version": "3.0.10",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   },
   "dependencies": {
     "@draft-js-plugins/editor": "^4.1.0",
-    "@draft-js-plugins/mention": "^4.6.1",
+    "@draft-js-plugins/mention": "^5.2.1",
     "@popperjs/core": "^2.4.0",
     "@types/draft-js": "^0.11.8",
     "@types/react-datepicker": "^4.3.4",

--- a/src/components/RichTextEditor/index.jsx
+++ b/src/components/RichTextEditor/index.jsx
@@ -13,6 +13,7 @@ import MentionAction from './MentionAction';
 import FileUploadAction from './FileUploadAction';
 import MentionEntry from './MentionEntry';
 import FilePreviewList from './FilePreviewList';
+import Popover from '../Popover';
 import './styles.scss';
 
 const { EditorState, Modifier, convertToRaw, RichUtils } = draftJs;
@@ -52,9 +53,15 @@ const RichTextEditor = ({
         placement: 'bottom-start',
         strategy: 'fixed',
         modifiers: [
-          { name: 'flip', enabled: false },
+          { name: 'flip', enabled: true },
           { name: 'preventOverflow', enabled: false },
           { name: 'hide', enabled: false },
+          {
+            name: 'offset',
+            options: {
+              offset: [-12, 12],
+            },
+          },
         ],
       },
       theme: {
@@ -147,6 +154,18 @@ const RichTextEditor = ({
             suggestions={suggestions}
             onSearchChange={handleMentionSearchChange}
             entryComponent={MentionEntry}
+            popoverContainer={({ children, ...rest }) => {
+              const { popperOptions, store } = rest;
+              return (
+                <Popover.WithRef
+                  popoverClassNames="aui--mention"
+                  refElement={store.getReferenceElement()}
+                  {...popperOptions}
+                  popoverContent={children}
+                  isOpen={true}
+                />
+              );
+            }}
           />
         )}
       </div>

--- a/src/components/RichTextEditor/styles.scss
+++ b/src/components/RichTextEditor/styles.scss
@@ -89,9 +89,18 @@
   }
 }
 
+.aui--mention {
+  .popover-content {
+    padding: 0;
+    overflow-y: auto;
+    max-height: 250px;
+  }
+}
+
 .aui--mention-entry {
   background-color: $color-white;
-  width: 350px;
+  width: auto;
+  min-width: 250px;
 
   &__is-focused {
     background: $color-blue-light;
@@ -103,7 +112,11 @@
     align-items: center;
 
     &__left {
-      margin: 5px 20px;
+      margin: 5px 10px 5px 20px;
+    }
+
+    &__right {
+      margin: 0 10px;
     }
 
     .mention-entry--title,


### PR DESCRIPTION

## Description
- Upgrade `@draft-js/plugin-mention` (closes #1312)
- use adslot-ui Popover for mention component
- enable `flip` so the mention list will still be in view when the Rich Text Editor is at the bottom of a modal/page

![Screen Shot 2022-05-06 at 10 55 53 am](https://user-images.githubusercontent.com/13904763/167054159-55ab3ec8-d140-458f-99c6-2adedc4a586f.png)

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
