### PR TITLE
chore: upgrade @draft-js-plugins/editor and remove @popperjs/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "30.2.1",
       "license": "MIT",
       "dependencies": {
-        "@draft-js-plugins/editor": "^4.1.0",
+        "@draft-js-plugins/editor": "^4.1.3",
         "@draft-js-plugins/mention": "^5.2.1",
-        "@popperjs/core": "^2.4.0",
         "@types/draft-js": "^0.11.8",
         "@types/react-datepicker": "^4.3.4",
         "@types/react-select": "^3.0.8",
@@ -3219,16 +3218,17 @@
       }
     },
     "node_modules/@draft-js-plugins/editor": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@draft-js-plugins/editor/-/editor-4.1.0.tgz",
-      "integrity": "sha512-i95uGF1GOFwP99qRCjtocGAYanULtkX9/XPeXKwjKx65vnOt/0dvBBdSvzSgrJ9pncHHLUqDfFQKXy/09fTmvg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/editor/-/editor-4.1.3.tgz",
+      "integrity": "sha512-Mxr1GUFzN0VcVVP6XClvWS2o33Rh8ZG3l41h9l27hJoLRYVywpuzI6TXD0UFYDIHX50fz6n70sQCdoHmkBsfKQ==",
       "dependencies": {
         "immutable": "~3.7.4",
-        "prop-types": "^15.5.8"
+        "prop-types": "^15.8.1"
       },
       "peerDependencies": {
         "draft-js": "^0.11.0",
-        "react": "^16.3.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@draft-js-plugins/editor/node_modules/immutable": {
@@ -26588,12 +26588,12 @@
       "dev": true
     },
     "@draft-js-plugins/editor": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@draft-js-plugins/editor/-/editor-4.1.0.tgz",
-      "integrity": "sha512-i95uGF1GOFwP99qRCjtocGAYanULtkX9/XPeXKwjKx65vnOt/0dvBBdSvzSgrJ9pncHHLUqDfFQKXy/09fTmvg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/editor/-/editor-4.1.3.tgz",
+      "integrity": "sha512-Mxr1GUFzN0VcVVP6XClvWS2o33Rh8ZG3l41h9l27hJoLRYVywpuzI6TXD0UFYDIHX50fz6n70sQCdoHmkBsfKQ==",
       "requires": {
         "immutable": "~3.7.4",
-        "prop-types": "^15.5.8"
+        "prop-types": "^15.8.1"
       },
       "dependencies": {
         "immutable": {

--- a/package.json
+++ b/package.json
@@ -149,9 +149,8 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@draft-js-plugins/editor": "^4.1.0",
+    "@draft-js-plugins/editor": "^4.1.3",
     "@draft-js-plugins/mention": "^5.2.1",
-    "@popperjs/core": "^2.4.0",
     "@types/draft-js": "^0.11.8",
     "@types/react-datepicker": "^4.3.4",
     "@types/react-select": "^3.0.8",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
- Upgrade `@draft-js-plugins/editor` and  dependencies as Renovate does not correctly support [npm overrides](https://github.com/renovatebot/renovate/issues/15278) yet
- Removed unused `@popperjs/core`

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->
Tested by @renrizzolo

## Screenshots (if appropriate):
