### PR TITLE
v30.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "30.2.1",
+  "version": "30.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "30.2.1",
+      "version": "30.2.2",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "30.2.1",
+  "version": "30.2.2",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [fb95e190beb1aa074438375e3696875214170806] chore: upgrade webpack-dev-server to latest to resolve async dependabot alert
 
- [299ca6a23fa1f9f3f1146b602e4a3798c3e7d25f] fix: upgrade richtext mention
 
- [b9442eef16d310c54c55050cf36796c3ea7e4f2d] chore: upgrade @draft-js-plugins/editor and remove @popperjs/core
 
- [49fd76f70468578408e0570a2ad3e4026112cb0b] chore: use top level override for lodash
 
	


	Switch to using top level override for `lodash` so that renovate correctly adheres to it

- [8df0e9bb98575ff8e6b27fd1979ea6740f324001] chore(deps): update dependency lint-staged to ^12.4.1
 
- [69f68dd0fe039de8e1ce9165087e9cfe3a8b80fd] chore(deps): update dependency autoprefixer to ^10.4.7
 
- [f36f7f29c8441135bc4bd83e1445cb11ca741e23] fix: fix package-lock
 
- [237a4ae5054006a7c7e562d141e57fb417551762] chore(deps): update commitlint monorepo to v17
 
- [23a1df8366977333bf66a3cd274db1709bcb5939] fix: select container
 
- [de6384605699e1c2c28c778f2565cfb4de65bcbd] build: release patch version 30.2.2
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v30.2.1...v30.2.2