### PR TITLE
chore: upgrade react-to-typescript-definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "react-html-parser": "^2.0.2",
         "react-live": "^2.4.1",
         "react-router-dom": "^6.3.0",
-        "react-to-typescript-definitions": "^3.1.0",
+        "react-to-typescript-definitions": "^3.1.1",
         "remark-emoji": "^2.2.0",
         "rimraf": "^3.0.2",
         "sass": "^1.49.11",
@@ -6518,7 +6518,7 @@
     "node_modules/array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
       "dev": true
     },
     "node_modules/array-ify": {
@@ -6654,19 +6654,19 @@
       "dev": true
     },
     "node_modules/astq": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/astq/-/astq-2.3.6.tgz",
-      "integrity": "sha512-OGGcbdqSgfpTknS4VfpA8KZ3+i7PnyBZydmSSNm+432uGzZwwB0+seF6ehZagrilODcg39yJThNsJ4QRp9wnrQ==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/astq/-/astq-2.7.8.tgz",
+      "integrity": "sha512-IWbj7sBjgcr0iEWgu8JjXV2nw+oPaVX8USIAQYgMVp5FVthZfQNjDP3aYwJCTFgpzsqqKeQ5IlXnNrSRJhAsig==",
       "dev": true,
       "dependencies": {
-        "asty": "1.7.16",
-        "cache-lru": "1.1.5",
+        "asty": "1.8.17",
+        "cache-lru": "1.1.11",
         "pegjs": "0.10.0",
-        "pegjs-otf": "1.2.10",
-        "pegjs-util": "1.4.14"
+        "pegjs-otf": "1.2.20",
+        "pegjs-util": "1.4.21"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/astral-regex": {
@@ -6679,12 +6679,12 @@
       }
     },
     "node_modules/asty": {
-      "version": "1.7.16",
-      "resolved": "https://registry.npmjs.org/asty/-/asty-1.7.16.tgz",
-      "integrity": "sha512-OCVqzR2chwoAl0qNlrZfXw/4f8Jt0oODzD5s9HUe2kDsuFBopEcZzqVfIBa+zfWxAXoUcDDaHTFTT63C5qIdpA==",
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/asty/-/asty-1.8.17.tgz",
+      "integrity": "sha512-4YEFz3wgcPLO8sbdOtz/R24zaypCoNjYkZxMe36AUAqjiZXdZWdYn5Er5YpCqlzrQPSN/EF72fG0MSHYCpfJbQ==",
       "dev": true,
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/async": {
@@ -7635,9 +7635,9 @@
       }
     },
     "node_modules/cache-lru": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/cache-lru/-/cache-lru-1.1.5.tgz",
-      "integrity": "sha512-SYW1cyR6CdxiGM1DyXqoYAUvBLnGFhChfZBGeeNlX984JErv/oHaYInRPRFqBU49wgOuHlqJaercDc3vhReK4g==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/cache-lru/-/cache-lru-1.1.11.tgz",
+      "integrity": "sha512-Eczyf7U6aaBsvwqEq3k18lDSRIgxFPw6iYvfPHluTr2zOmg/1sIPmooLPDIa2YQP3SEvogSPZfpa6wScXKwFOg==",
       "dev": true
     },
     "node_modules/call-bind": {
@@ -9490,7 +9490,7 @@
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
@@ -17554,7 +17554,7 @@
     "node_modules/merge-source-map": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+      "integrity": "sha512-PGSmS0kfnTnMJCzJ16BLLCEe6oeYCamKFFdQKshi4BmM6FUwipjVOcBFGxqtQtirtAG4iZvHlqST9CpZKqlRjA==",
       "dev": true,
       "dependencies": {
         "source-map": "^0.5.6"
@@ -18533,7 +18533,7 @@
     "node_modules/pegjs": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
+      "integrity": "sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==",
       "dev": true,
       "bin": {
         "pegjs": "bin/pegjs"
@@ -18543,21 +18543,21 @@
       }
     },
     "node_modules/pegjs-otf": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/pegjs-otf/-/pegjs-otf-1.2.10.tgz",
-      "integrity": "sha512-GZ5hd1HL6fUuqqRU6tmLAhWFJCnsfbcKfuiVsJEiX9limjsFOx4oxGxri7tKcWgQPIA5e6I+IOlbaDo4er1xNA==",
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/pegjs-otf/-/pegjs-otf-1.2.20.tgz",
+      "integrity": "sha512-kzHnUnWWIc5NVf//R8qhHJ6HhbXvkKN0zyHjNwPgrSnmY1cpbI5UVx9QaT+vzJlikyBeZ8ZRMS4a6Jhcn88Dgw==",
       "dev": true,
       "dependencies": {
-        "lodash": "4.17.10",
+        "lodash": "4.17.21",
         "pegjs": "0.10.0",
-        "static-module": "3.0.0",
+        "static-module": "3.0.4",
         "through": "2.3.8"
       }
     },
     "node_modules/pegjs-util": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/pegjs-util/-/pegjs-util-1.4.14.tgz",
-      "integrity": "sha512-7Ec71xZLJbke+i6YoTmI7i7w4M5q2ghdQ0bvcuowfrixGtFP9/DhCAuAmpXRQJ4ooDp7X5uMSyju4G2P5vfJ/A==",
+      "version": "1.4.21",
+      "resolved": "https://registry.npmjs.org/pegjs-util/-/pegjs-util-1.4.21.tgz",
+      "integrity": "sha512-0z15BXCjxwgeD+pO5QImUgOFsJ86jFt6oDqatveLggeARSS5wmrt9SxCONkUvOeSsob2faVBC9H4wpl4zudg9A==",
       "dev": true,
       "dependencies": {
         "pegjs": ">=0.10.0"
@@ -20193,12 +20193,12 @@
       }
     },
     "node_modules/react-to-typescript-definitions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-to-typescript-definitions/-/react-to-typescript-definitions-3.1.0.tgz",
-      "integrity": "sha512-cQtEOpx3MdqpZskPtgdkfdXK4FrpGEyWFWliFtdcuOgZEz5fFRkTg/mOWEFKUIqnAZS39yN/HL8hufG0z3X3Cw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-to-typescript-definitions/-/react-to-typescript-definitions-3.1.1.tgz",
+      "integrity": "sha512-LCrFEU43965ctYK8gcLpOSsGuyS5Fz7nniPTCnirIj++ANIBJJsujuIFd1ONn3Yoxfq7NWQVBE9XFNiT+LsOYA==",
       "dev": true,
       "dependencies": {
-        "astq": "2.3.6",
+        "astq": "2.7.8",
         "babel-generator": "6.26.1",
         "babylon": "7.0.0-beta.47",
         "chalk": "4.1.2",
@@ -22166,7 +22166,7 @@
     "node_modules/static-eval/node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
@@ -22196,7 +22196,7 @@
     "node_modules/static-eval/node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -22225,34 +22225,34 @@
       }
     },
     "node_modules/static-module": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.0.tgz",
-      "integrity": "sha512-SM757x+T52ye+QNDo80F53rNpir/ZyyFL0NjPXHRXb1hT1eC2Tzq+LV5P2X12UzHJH5SfD248I5/jzUoSey89Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.4.tgz",
+      "integrity": "sha512-gb0v0rrgpBkifXCa3yZXxqVmXDVE+ETXj6YlC/jt5VzOnGXR2C15+++eXuMDUYsePnbhf+lwW0pE1UXyOLtGCw==",
       "dev": true,
       "dependencies": {
         "acorn-node": "^1.3.0",
         "concat-stream": "~1.6.0",
         "convert-source-map": "^1.5.1",
         "duplexer2": "~0.1.4",
-        "escodegen": "~1.9.0",
+        "escodegen": "^1.11.1",
         "has": "^1.0.1",
-        "magic-string": "^0.22.4",
+        "magic-string": "0.25.1",
         "merge-source-map": "1.0.4",
-        "object-inspect": "~1.4.0",
+        "object-inspect": "^1.6.0",
         "readable-stream": "~2.3.3",
         "scope-analyzer": "^2.0.1",
         "shallow-copy": "~0.0.1",
-        "static-eval": "^2.0.0",
+        "static-eval": "^2.0.5",
         "through2": "~2.0.3"
       }
     },
     "node_modules/static-module/node_modules/escodegen": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dev": true,
       "dependencies": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1"
@@ -22268,23 +22268,10 @@
         "source-map": "~0.6.1"
       }
     },
-    "node_modules/static-module/node_modules/esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/static-module/node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
@@ -22295,19 +22282,13 @@
       }
     },
     "node_modules/static-module/node_modules/magic-string": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
+      "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
       "dev": true,
       "dependencies": {
-        "vlq": "^0.2.2"
+        "sourcemap-codec": "^1.4.1"
       }
-    },
-    "node_modules/static-module/node_modules/object-inspect": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
-      "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw==",
-      "dev": true
     },
     "node_modules/static-module/node_modules/optionator": {
       "version": "0.8.3",
@@ -22329,7 +22310,7 @@
     "node_modules/static-module/node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -22366,12 +22347,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/static-module/node_modules/vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
-      "dev": true
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -26181,7 +26156,7 @@
         "@commitlint/load": "^17.0.0",
         "@commitlint/read": "^17.0.0",
         "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
         "yargs": "^17.0.0"
@@ -26213,7 +26188,7 @@
       "dev": true,
       "requires": {
         "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.19"
       }
     },
     "@commitlint/execute-rule": {
@@ -26330,7 +26305,7 @@
         "chalk": "^4.1.0",
         "cosmiconfig": "^7.0.0",
         "cosmiconfig-typescript-loader": "^2.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.19",
         "resolve-from": "^5.0.0",
         "typescript": "^4.6.4"
       },
@@ -26424,7 +26399,7 @@
         "@commitlint/config-validator": "^17.0.0",
         "@commitlint/types": "^17.0.0",
         "import-fresh": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.19",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       }
@@ -27774,7 +27749,7 @@
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
             "json5": "^2.1.2",
-            "lodash": "^4.17.21",
+            "lodash": "^4.17.19",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
@@ -28018,7 +27993,7 @@
         "css": "^3.0.0",
         "css.escape": "^1.5.1",
         "dom-accessibility-api": "^0.5.6",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
       "dependencies": {
@@ -29218,7 +29193,7 @@
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
       "dev": true
     },
     "array-ify": {
@@ -29318,16 +29293,16 @@
       "dev": true
     },
     "astq": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/astq/-/astq-2.3.6.tgz",
-      "integrity": "sha512-OGGcbdqSgfpTknS4VfpA8KZ3+i7PnyBZydmSSNm+432uGzZwwB0+seF6ehZagrilODcg39yJThNsJ4QRp9wnrQ==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/astq/-/astq-2.7.8.tgz",
+      "integrity": "sha512-IWbj7sBjgcr0iEWgu8JjXV2nw+oPaVX8USIAQYgMVp5FVthZfQNjDP3aYwJCTFgpzsqqKeQ5IlXnNrSRJhAsig==",
       "dev": true,
       "requires": {
-        "asty": "1.7.16",
-        "cache-lru": "1.1.5",
+        "asty": "1.8.17",
+        "cache-lru": "1.1.11",
         "pegjs": "0.10.0",
-        "pegjs-otf": "1.2.10",
-        "pegjs-util": "1.4.14"
+        "pegjs-otf": "1.2.20",
+        "pegjs-util": "1.4.21"
       }
     },
     "astral-regex": {
@@ -29337,9 +29312,9 @@
       "dev": true
     },
     "asty": {
-      "version": "1.7.16",
-      "resolved": "https://registry.npmjs.org/asty/-/asty-1.7.16.tgz",
-      "integrity": "sha512-OCVqzR2chwoAl0qNlrZfXw/4f8Jt0oODzD5s9HUe2kDsuFBopEcZzqVfIBa+zfWxAXoUcDDaHTFTT63C5qIdpA==",
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/asty/-/asty-1.8.17.tgz",
+      "integrity": "sha512-4YEFz3wgcPLO8sbdOtz/R24zaypCoNjYkZxMe36AUAqjiZXdZWdYn5Er5YpCqlzrQPSN/EF72fG0MSHYCpfJbQ==",
       "dev": true
     },
     "async": {
@@ -30056,9 +30031,9 @@
       }
     },
     "cache-lru": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/cache-lru/-/cache-lru-1.1.5.tgz",
-      "integrity": "sha512-SYW1cyR6CdxiGM1DyXqoYAUvBLnGFhChfZBGeeNlX984JErv/oHaYInRPRFqBU49wgOuHlqJaercDc3vhReK4g==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/cache-lru/-/cache-lru-1.1.11.tgz",
+      "integrity": "sha512-Eczyf7U6aaBsvwqEq3k18lDSRIgxFPw6iYvfPHluTr2zOmg/1sIPmooLPDIa2YQP3SEvogSPZfpa6wScXKwFOg==",
       "dev": true
     },
     "call-bind": {
@@ -30605,7 +30580,7 @@
       "requires": {
         "is-text-path": "^1.0.1",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
         "through2": "^4.0.0"
@@ -31444,7 +31419,7 @@
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
@@ -37531,7 +37506,7 @@
     "merge-source-map": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+      "integrity": "sha512-PGSmS0kfnTnMJCzJ16BLLCEe6oeYCamKFFdQKshi4BmM6FUwipjVOcBFGxqtQtirtAG4iZvHlqST9CpZKqlRjA==",
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
@@ -38257,25 +38232,25 @@
     "pegjs": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
+      "integrity": "sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==",
       "dev": true
     },
     "pegjs-otf": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/pegjs-otf/-/pegjs-otf-1.2.10.tgz",
-      "integrity": "sha512-GZ5hd1HL6fUuqqRU6tmLAhWFJCnsfbcKfuiVsJEiX9limjsFOx4oxGxri7tKcWgQPIA5e6I+IOlbaDo4er1xNA==",
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/pegjs-otf/-/pegjs-otf-1.2.20.tgz",
+      "integrity": "sha512-kzHnUnWWIc5NVf//R8qhHJ6HhbXvkKN0zyHjNwPgrSnmY1cpbI5UVx9QaT+vzJlikyBeZ8ZRMS4a6Jhcn88Dgw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10",
+        "lodash": "4.17.21",
         "pegjs": "0.10.0",
-        "static-module": "3.0.0",
+        "static-module": "3.0.4",
         "through": "2.3.8"
       }
     },
     "pegjs-util": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/pegjs-util/-/pegjs-util-1.4.14.tgz",
-      "integrity": "sha512-7Ec71xZLJbke+i6YoTmI7i7w4M5q2ghdQ0bvcuowfrixGtFP9/DhCAuAmpXRQJ4ooDp7X5uMSyju4G2P5vfJ/A==",
+      "version": "1.4.21",
+      "resolved": "https://registry.npmjs.org/pegjs-util/-/pegjs-util-1.4.21.tgz",
+      "integrity": "sha512-0z15BXCjxwgeD+pO5QImUgOFsJ86jFt6oDqatveLggeARSS5wmrt9SxCONkUvOeSsob2faVBC9H4wpl4zudg9A==",
       "dev": true,
       "requires": {
         "pegjs": ">=0.10.0"
@@ -38772,7 +38747,7 @@
       "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.20",
         "renderkid": "^3.0.0"
       }
     },
@@ -39459,12 +39434,12 @@
       }
     },
     "react-to-typescript-definitions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-to-typescript-definitions/-/react-to-typescript-definitions-3.1.0.tgz",
-      "integrity": "sha512-cQtEOpx3MdqpZskPtgdkfdXK4FrpGEyWFWliFtdcuOgZEz5fFRkTg/mOWEFKUIqnAZS39yN/HL8hufG0z3X3Cw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-to-typescript-definitions/-/react-to-typescript-definitions-3.1.1.tgz",
+      "integrity": "sha512-LCrFEU43965ctYK8gcLpOSsGuyS5Fz7nniPTCnirIj++ANIBJJsujuIFd1ONn3Yoxfq7NWQVBE9XFNiT+LsOYA==",
       "dev": true,
       "requires": {
-        "astq": "2.3.6",
+        "astq": "2.7.8",
         "babel-generator": "6.26.1",
         "babylon": "7.0.0-beta.47",
         "chalk": "4.1.2",
@@ -39809,7 +39784,7 @@
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
             "json5": "^2.1.2",
-            "lodash": "^4.17.21",
+            "lodash": "^4.17.19",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
@@ -40243,7 +40218,7 @@
             "js-yaml": "^3.5.1",
             "json-stable-stringify": "^1.0.0",
             "levn": "^0.3.0",
-            "lodash": "^4.17.21",
+            "lodash": "^4.0.0",
             "mkdirp": "^0.5.0",
             "optionator": "^0.8.1",
             "path-is-absolute": "^1.0.0",
@@ -40442,7 +40417,7 @@
             "ajv": "^4.7.0",
             "ajv-keywords": "^1.0.0",
             "chalk": "^1.1.1",
-            "lodash": "^4.17.21",
+            "lodash": "^4.0.0",
             "slice-ansi": "0.0.4",
             "string-width": "^2.0.0"
           }
@@ -41023,7 +40998,7 @@
         "levn": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2",
@@ -41047,7 +41022,7 @@
         "prelude-ls": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
           "dev": true
         },
         "source-map": {
@@ -41069,50 +41044,44 @@
       }
     },
     "static-module": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.0.tgz",
-      "integrity": "sha512-SM757x+T52ye+QNDo80F53rNpir/ZyyFL0NjPXHRXb1hT1eC2Tzq+LV5P2X12UzHJH5SfD248I5/jzUoSey89Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.4.tgz",
+      "integrity": "sha512-gb0v0rrgpBkifXCa3yZXxqVmXDVE+ETXj6YlC/jt5VzOnGXR2C15+++eXuMDUYsePnbhf+lwW0pE1UXyOLtGCw==",
       "dev": true,
       "requires": {
         "acorn-node": "^1.3.0",
         "concat-stream": "~1.6.0",
         "convert-source-map": "^1.5.1",
         "duplexer2": "~0.1.4",
-        "escodegen": "~1.9.0",
+        "escodegen": "^1.11.1",
         "has": "^1.0.1",
-        "magic-string": "^0.22.4",
+        "magic-string": "0.25.1",
         "merge-source-map": "1.0.4",
-        "object-inspect": "~1.4.0",
+        "object-inspect": "^1.6.0",
         "readable-stream": "~2.3.3",
         "scope-analyzer": "^2.0.1",
         "shallow-copy": "~0.0.1",
-        "static-eval": "^2.0.0",
+        "static-eval": "^2.0.5",
         "through2": "~2.0.3"
       },
       "dependencies": {
         "escodegen": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+          "version": "1.14.3",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
           "dev": true,
           "requires": {
-            "esprima": "^3.1.3",
+            "esprima": "^4.0.1",
             "estraverse": "^4.2.0",
             "esutils": "^2.0.2",
             "optionator": "^0.8.1",
             "source-map": "~0.6.1"
           }
         },
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
         "levn": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2",
@@ -41120,19 +41089,13 @@
           }
         },
         "magic-string": {
-          "version": "0.22.5",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-          "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+          "version": "0.25.1",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
+          "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
           "dev": true,
           "requires": {
-            "vlq": "^0.2.2"
+            "sourcemap-codec": "^1.4.1"
           }
-        },
-        "object-inspect": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
-          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw==",
-          "dev": true
         },
         "optionator": {
           "version": "0.8.3",
@@ -41151,7 +41114,7 @@
         "prelude-ls": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
           "dev": true
         },
         "source-map": {
@@ -41179,12 +41142,6 @@
           "requires": {
             "prelude-ls": "~1.1.2"
           }
-        },
-        "vlq": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-          "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
-          "dev": true
         }
       }
     },
@@ -42377,7 +42334,7 @@
       "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21",
+        "lodash": "^4.7.0",
         "tr46": "^2.1.0",
         "webidl-conversions": "^6.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-html-parser": "^2.0.2",
     "react-live": "^2.4.1",
     "react-router-dom": "^6.3.0",
-    "react-to-typescript-definitions": "^3.1.0",
+    "react-to-typescript-definitions": "^3.1.1",
     "remark-emoji": "^2.2.0",
     "rimraf": "^3.0.2",
     "sass": "^1.49.11",
@@ -173,9 +173,6 @@
     "moment": "^2.29.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
-  },
-  "overrides": {
-    "lodash": "$lodash"
   },
   "engines": {
     "node": "^16"


### PR DESCRIPTION
## Description
I was able to do the required upgrades to react-to-typescript-definitions, so the lodash version should now be at `4.17.21`. https://github.com/KnisterPeter/react-to-typescript-definitions/pull/1405

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

