### PR TITLE
[ADS-6836] fix: allow null as Tabs children

### DIFF
--- a/src/components/Tab/index.jsx
+++ b/src/components/Tab/index.jsx
@@ -14,8 +14,6 @@ const Tab = ({ children, show }) => (
   </div>
 );
 
-Tab.innerName = 'au_tab';
-
 Tab.propTypes = {
   children: PropTypes.node.isRequired,
   /**

--- a/src/components/Tabs/index.jsx
+++ b/src/components/Tabs/index.jsx
@@ -23,26 +23,23 @@ const Tabs = ({ id, children, defaultActiveKey, activeKey, onSelect }) => {
     };
   };
 
-  const tabs = [];
-  const content = React.Children.map(children, (child) => {
-    if (_.get(child, 'type.innerName') !== Tab.innerName) {
+  const tabs = React.Children.map(children, (child) => {
+    if (!child) return;
+    if (child.type !== Tab) {
       console.error('<Tabs /> children must be instances of <Tab />');
-      return null;
+      return;
     }
 
     // child must be a Tab instance at this point
-    const tab = React.cloneElement(child, {
+    return React.cloneElement(child, {
       show: actualActiveKey === child.props.eventKey,
     });
-    tabs.push(tab);
-
-    return tab;
   });
 
   return (
     <div data-testid="tablist-wrapper" id={id}>
       <ul role="tablist" className="nav nav-tabs">
-        {tabs.map((tab) => (
+        {React.Children.map(tabs, (tab) => (
           <li
             data-testid="tablist-item"
             role="presentation"
@@ -63,7 +60,7 @@ const Tabs = ({ id, children, defaultActiveKey, activeKey, onSelect }) => {
           </li>
         ))}
       </ul>
-      <div className="tab-content">{content}</div>
+      <div className="tab-content">{tabs}</div>
     </div>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

- allow falsy values as `Tabs` children
- updated the type check

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
