### PR TITLE
fix: disable cssnano value conversion

### DIFF
--- a/config/webpack.config.dist.js
+++ b/config/webpack.config.dist.js
@@ -142,7 +142,14 @@ module.exports = webpackMerge(commonConfig, {
             parser: safe,
           };
 
-          return cssnano()
+          return cssnano({
+            preset: [
+              'default',
+              {
+                convertValues: false,
+              },
+            ],
+          })
             .process(input, postcssOptions)
             .then((result) => {
               return {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -143,7 +143,14 @@ module.exports = webpackMerge(commonConfig, {
             parser: safe,
           };
 
-          return cssnano()
+          return cssnano({
+            preset: [
+              'default',
+              {
+                convertValues: false,
+              },
+            ],
+          })
             .process(input, postcssOptions)
             .then((result) => {
               return {


### PR DESCRIPTION

## Description
mainly due to the difference between `height: 0%` and `height: 0 (in`Button`), disable cssnano value conversion.

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):
before/after diff of dist css (unminified after minification for better visibility)
![Screen Shot 2022-07-01 at 12 15 55 pm](https://user-images.githubusercontent.com/13904763/176810917-69a220a2-5fdd-45b4-89d6-819903982f67.png)

