### PR TITLE
Expose search props in searchable checklist

### DIFF
--- a/src/components/SearchableCheckList/index.d.ts
+++ b/src/components/SearchableCheckList/index.d.ts
@@ -31,7 +31,17 @@ export interface SearchableCheckListProps {
    * Number of checkbox items to render
    */
   displayCount?: number;
+  /**
+   * Hides the title
+   */
+  hideTitle?: boolean;
   onChange: (...args: any[]) => any;
+  /**
+   * Determines whether onSearch() will be fired on ENTER key press (Default behaviour is to fire onSearch() when the input changes)
+   */
+  searchOnEnter?: boolean;
+  onSearch?: (...args: any[]) => any;
+  onClear?: (...args: any[]) => any;
 }
 
 declare const SearchableCheckList: React.FC<SearchableCheckListProps>;

--- a/src/components/SearchableCheckList/index.jsx
+++ b/src/components/SearchableCheckList/index.jsx
@@ -6,7 +6,18 @@ import Checkbox from '../Checkbox';
 import CheckboxGroup from '../CheckboxGroup';
 import './styles.css';
 
-const SearchableCheckList = ({ context, items, selectedItemsKeys, displayCount, placeholder, onChange }) => {
+const SearchableCheckList = ({
+  context,
+  items,
+  selectedItemsKeys,
+  displayCount,
+  hideTitle,
+  placeholder,
+  onChange,
+  onSearch,
+  searchOnEnter,
+  onClear,
+}) => {
   const [searchText, setSearchText] = React.useState('');
 
   const eligibleItems = searchText
@@ -40,13 +51,21 @@ const SearchableCheckList = ({ context, items, selectedItemsKeys, displayCount, 
   return (
     <div className="aui--searchable-checklist">
       <div className="aui--searchable-list-container">
-        <div className="title" data-testid="searchable-list-title">
-          {pluralLabel}
-        </div>
+        {!hideTitle && (
+          <div className="title" data-testid="searchable-list-title">
+            {pluralLabel}
+          </div>
+        )}
         <div className="search-box">
           <Search
+            searchOnEnter={searchOnEnter}
+            onClear={onClear}
             onSearch={(value) => {
-              setSearchText(value);
+              if (_.isNil(onSearch)) {
+                setSearchText(value);
+              } else {
+                onSearch(value);
+              }
             }}
             placeholder={placeholder}
           />
@@ -116,13 +135,26 @@ SearchableCheckList.propTypes = {
    * 	Number of checkbox items to render
    */
   displayCount: PropTypes.number,
+  /**
+   * 	Hides the title
+   */
+  hideTitle: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
+  /**
+   * 	Determines whether onSearch() will be fired on ENTER key press (Default behaviour is to fire onSearch() when the input changes)
+   */
+  searchOnEnter: PropTypes.bool,
+  onSearch: PropTypes.func,
+  onClear: PropTypes.func,
 };
 
 SearchableCheckList.defaultProps = {
   selectedItemsKeys: [],
   displayCount: 6,
+  hideTitle: false,
   placeholder: 'Search',
+  searchOnEnter: false,
+  onClear: _.noOp,
 };
 
 export default SearchableCheckList;

--- a/src/components/SearchableCheckList/index.spec.jsx
+++ b/src/components/SearchableCheckList/index.spec.jsx
@@ -45,6 +45,13 @@ describe('<SearchableChecklist />', () => {
     expect(getByTestId('footer-section')).toHaveTextContent('3 more publishers');
   });
 
+  it('should not render title when hideTitle is false', () => {
+    const { queryByTestId } = render(
+      <SearchableCheckList context={context} items={items} onChange={_.noop} hideTitle={true} />
+    );
+    expect(queryByTestId('searchable-list-title')).not.toBeInTheDocument();
+  });
+
   it('should correctly render footer value with single hidden item', () => {
     const { getByTestId } = render(
       <SearchableCheckList context={context} items={items} displayCount={8} onChange={_.noop} />
@@ -184,20 +191,31 @@ describe('<SearchableChecklist />', () => {
     expect(onChange).toHaveBeenCalledWith(['01', '06', '03']);
   });
 
-  it('should correctly call onChange when main checkbox is checked', () => {
-    const onChange = jest.fn();
+  it('should correctly call onSearch and onClear when search input specified and then cleared', () => {
+    const callbacks = {
+      onClear: jest.fn(),
+      onSearch: jest.fn(),
+    };
 
-    const { queryAllByTestId } = render(<SearchableCheckList context={context} items={items} onChange={onChange} />);
+    const { getByTestId } = render(
+      <SearchableCheckList
+        context={context}
+        items={items}
+        onChange={_.noop}
+        onClear={callbacks.onClear}
+        onSearch={callbacks.onSearch}
+      />
+    );
 
-    const checkBoxesWrapper = queryAllByTestId('checkbox-input');
-    expect(checkBoxesWrapper).toHaveLength(7);
+    fireEvent.change(getByTestId('search-input'), { target: { value: 'new-value' } });
+    expect(callbacks.onSearch).toHaveBeenCalledTimes(1);
+    expect(callbacks.onSearch).toHaveBeenCalledWith('new-value');
 
-    expect(onChange).toHaveBeenCalledTimes(0);
-    fireEvent.click(checkBoxesWrapper[0]);
-    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(getByTestId('search-icon-wrapper')).toHaveClass('aui--search-component-icon');
+    fireEvent.click(getByTestId('search-icon-wrapper'));
 
-    // All items checked
-    expect(onChange).toHaveBeenCalledWith(_.map(items, 'value'));
+    expect(callbacks.onClear).toHaveBeenCalledTimes(1);
+    expect(callbacks.onClear).toHaveBeenCalledWith('');
   });
 
   it('should correctly call onChange when main checkbox is checked', () => {


### PR DESCRIPTION
## Description

- Expose `<Search>` child component props in `<SearchableChecklist>` to support populating the checkable items from server side search.
  - `searchOnEnter`
  - `onSearch`
  - `onClear`
- Added props `hideTitle` to allow alternative design requirement


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
