### PR TITLE
fix: fix sonarcloud flagged security hotspots

### DIFF
--- a/src/components/HoverDropdownMenu/index.spec.jsx
+++ b/src/components/HoverDropdownMenu/index.spec.jsx
@@ -27,7 +27,7 @@ describe('<HoverDropdownMenu />', () => {
       },
       {
         title: 'Logout',
-        url: 'http://www.google.com',
+        url: 'https://www.google.com',
         target: '_self',
         isEnabled: true,
       },

--- a/www/index.html
+++ b/www/index.html
@@ -24,9 +24,9 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="app"></div>
-    <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/moment@2.29.4/min/moment.min.js"></script>
-    <script crossorigin src="https://unpkg.com/lodash@4.17.21/lodash.min.js"></script>
+    <script src="https://unpkg.com/react@16/umd/react.production.min.js" integrity="sha384-N7y5SSAooNlIfb9H750GR82ufkn1JXJFaCjg8pmt+OZuKcZoTvTGfog4d4taG/cF" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js" integrity="sha384-j7WmMv3OO6n8pZRATOsaMVEdZcHpoaTBIika/l92YM2AkEex72QunlTQlgmu+pI8" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/moment@2.29.4/min/moment.min.js" integrity="sha384-2xoILS8hBHw+Atyv/qJLEdk8dFdW1hbGjfeQ3G0GU3pGNPlqck0chRqjMTZ5blGf" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lodash@4.17.21/lodash.min.js" integrity="sha384-H6KKS1H1WwuERMSm+54dYLzjg0fKqRK5ZRyASdbrI/lwrCc6bXEmtGYr5SwvP1pZ" crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
This PR fixes SonarCloud flagged security hotspots:
- Use `https` instead of `http` in link
- Use resource integrity in CDN scripts with hashes generated at https://www.srihash.org/

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
