### PR TITLE
fix: rich text editor btn aria label

### DIFF
--- a/src/components/RichTextEditor/BlockStyleButtons.jsx
+++ b/src/components/RichTextEditor/BlockStyleButtons.jsx
@@ -5,8 +5,8 @@ import BulletIcon from '../../styles/icons/bullet.svg';
 import NumberIcon from '../../styles/icons/number.svg';
 
 const BLOCK_TYPES = [
-  { label: <BulletIcon data-testid="bullet" />, style: 'unordered-list-item' },
-  { label: <NumberIcon data-testid="number" />, style: 'ordered-list-item' },
+  { label: <BulletIcon data-testid="bullet" />, style: 'unordered-list-item', ariaLabel: 'Unordered list' },
+  { label: <NumberIcon data-testid="number" />, style: 'ordered-list-item', ariaLabel: 'Ordered list' },
 ];
 
 const BlockStyleButtons = (props) => {
@@ -24,7 +24,7 @@ const BlockStyleButtons = (props) => {
       active={type.style === blockType}
       label={type.label}
       onToggle={() => onToggle(type.style)}
-      style={type.style}
+      aria-label={type.ariaLabel}
     />
   ));
 };

--- a/src/components/RichTextEditor/FileUploadAction.jsx
+++ b/src/components/RichTextEditor/FileUploadAction.jsx
@@ -17,6 +17,7 @@ const FileUploadAction = ({ onFileUpload, fileFilter }) => {
           fileInputRef.current.value = '';
           fileInputRef.current.click();
         }}
+        aria-label="Download file"
       />
       <input
         data-testid="file-download-input"

--- a/src/components/RichTextEditor/InlineStyleButtons.jsx
+++ b/src/components/RichTextEditor/InlineStyleButtons.jsx
@@ -6,9 +6,13 @@ import ItalicIcon from '../../styles/icons/italic.svg';
 import UnderlineIcon from '../../styles/icons/underline.svg';
 
 const INLINE_STYLES = [
-  { label: <BoldIcon data-testid="bold" />, style: 'BOLD' },
-  { label: <ItalicIcon data-testid="italics" />, style: 'ITALIC' },
-  { label: <UnderlineIcon data-testid="underline" />, style: 'UNDERLINE' },
+  { label: <BoldIcon data-testid="bold" />, style: 'BOLD', ariaLabel: 'Bold' },
+  { label: <ItalicIcon data-testid="italics" aria-label="italic" />, style: 'ITALIC', ariaLabel: 'Italic' },
+  {
+    label: <UnderlineIcon data-testid="underline" aria-label="Underline" />,
+    style: 'UNDERLINE',
+    ariaLabel: 'Underline',
+  },
 ];
 
 const InlineStyleButtons = (props) => {
@@ -24,7 +28,7 @@ const InlineStyleButtons = (props) => {
       active={currentStyle.has(type.style)}
       label={type.label}
       onToggle={() => onToggle(type.style)}
-      style={type.style}
+      aria-label={type.ariaLabel}
     />
   ));
 };

--- a/src/components/RichTextEditor/MentionAction.jsx
+++ b/src/components/RichTextEditor/MentionAction.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ToolbarButton from './ToolbarButton';
 
 const MentionAction = ({ onToggle }) => (
-  <ToolbarButton label={<div className="mention-button">@</div>} onToggle={onToggle} />
+  <ToolbarButton label={<div className="mention-button">@</div>} onToggle={onToggle} aria-label="Mention" />
 );
 
 export default MentionAction;

--- a/src/components/RichTextEditor/ToolbarButton.jsx
+++ b/src/components/RichTextEditor/ToolbarButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Button from '../Button';
 
-const ToolbarButton = ({ onToggle, label, active }) => {
+const ToolbarButton = ({ onToggle, label, active, ...rest }) => {
   const className = classnames('aui--toolbar-button', {
     active,
   });
@@ -18,7 +18,7 @@ const ToolbarButton = ({ onToggle, label, active }) => {
   );
 
   return (
-    <Button className={className} onMouseDown={mouseDownHandler}>
+    <Button className={className} onMouseDown={mouseDownHandler} {...rest}>
       {label}
     </Button>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

Fix the `rich text editor` missing button aria-label to improve direct-web accessibility.
Associated pr: https://github.com/Adslot/direct-web/pull/14209


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
before:
<img width="1241" alt="Screen Shot 2022-09-05 at 9 59 06 pm" src="https://user-images.githubusercontent.com/29013781/188517162-43041bdf-285d-4706-9d0a-85e20e10ec6e.png">


after
<img width="1176" alt="Screen Shot 2022-09-05 at 10 06 01 pm" src="https://user-images.githubusercontent.com/29013781/188517173-80fcd0d9-6213-4325-b760-dfa02f73d1a0.png">
