### PR TITLE
feat: searchable checklist refactor

### DIFF
--- a/src/components/SearchableCheckList/styles.css
+++ b/src/components/SearchableCheckList/styles.css
@@ -16,11 +16,26 @@
 }
 
 .aui--searchable-checklist .aui--searchable-list-container .items-container {
-  max-height: 125px;
+  max-height: 250px;
   overflow-y: auto;
   margin-bottom: 10px;
 }
 
 .aui--searchable-checklist .aui--searchable-list-container .footer {
   color: #ababab;
+}
+
+.aui--searchable-checklist .aui--searchable-list-container .items-container .aui--checkbox-group .aui--checkbox {
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.aui--searchable-checklist
+  .aui--searchable-list-container
+  .items-container
+  .aui--checkbox-group
+  .aui--checkbox
+  .aui--checkbox-label {
+  max-width: calc(100% - 20px);
 }

--- a/www/examples/SearchableCheckList.mdx
+++ b/www/examples/SearchableCheckList.mdx
@@ -6,7 +6,10 @@ import DesignNotes from '../containers/DesignNotes.jsx';
 
 ```jsx live=true
 const items = [
-  { value: 'absolute-power', label: 'Absolute Power' },
+  {
+    value: 'absolute-power',
+    label: 'Absolute Power',
+  },
   { value: 'almost-famous', label: 'Almost Famous' },
   { value: '25th-hour', label: '25th Hour' },
   { value: '12-angry-men', label: '12 Angry Men' },
@@ -20,6 +23,11 @@ const items = [
   { value: 'madagascar', label: 'Madagascar' },
   { value: 'meatballs', label: 'Meatballs' },
   { value: 'moon-child', label: 'Moon Child' },
+  {
+    // all-value is a reserved checkbox value, hence this option will not be rendered
+    value: 'all-option',
+    label: 'Custom All',
+  },
 ];
 
 class SearchableCheckListExample extends React.PureComponent {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Searchable checklist currently has `All` option that selects all options, we need to change that to have it as an independent option.
- Handle use-case when user add `All` option key

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
The `All` option is confusing in instances where the options are loaded async. Since the loaded items are not all items. Hence we are changing it to be an independent option. However, if any other option is selected the `All` option is unselected

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->
- SearchableChecklist `All` should not select all options
- Selecting other option should un-select `All`

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/3688957/190937688-bfb4b55f-47f8-4fc9-902d-22e0d3a941ec.mov

