### PR TITLE
[ADS-7249] feat: nested checkbox group

### DIFF
--- a/src/components/Checkbox/index.d.ts
+++ b/src/components/Checkbox/index.d.ts
@@ -8,38 +8,13 @@ export type CheckboxChecked = boolean | 'partial';
 
 export interface CheckboxProps {
   /**
-   * id for the checkbox input
-   */
-  id?: string;
-  className?: string;
-  /**
    * name for the checkbox input
    */
   name?: string;
   /**
-   * checkBox label for the checkbox input
-   */
-  label?: React.ReactNode;
-  /**
-   * additional text description to display below the label
-   */
-  text?: React.ReactNode;
-  /**
-   * icon to display beside the label when  parent group's `variant="box"`
-   */
-  icon?: React.ReactNode;
-  /**
    * checkBox input value
    */
   value?: CheckboxValue;
-  /**
-   * data-test-selector for the checkbox component
-   */
-  dts?: string;
-  /**
-   * determines if the checkbox is disabled
-   */
-  disabled?: boolean;
   variant?: CheckboxVariant;
   /**
    * @function onChange called when checkBox onChange event is fired
@@ -61,6 +36,31 @@ export interface CheckboxProps {
    * @deprecated
    */
   inline?: boolean;
+  /**
+   * id for the checkbox input
+   */
+  id?: string;
+  className?: string;
+  /**
+   * checkBox label for the checkbox input
+   */
+  label?: React.ReactNode;
+  /**
+   * additional text description to display below the label
+   */
+  text?: React.ReactNode;
+  /**
+   * icon to display beside the label when  parent group's `variant="box"`
+   */
+  icon?: React.ReactNode;
+  /**
+   * data-test-selector for the checkbox component
+   */
+  dts?: string;
+  /**
+   * determines if the checkbox is disabled
+   */
+  disabled?: boolean;
 }
 
 declare const Checkbox: React.FC<CheckboxProps>;

--- a/src/components/Checkbox/index.jsx
+++ b/src/components/Checkbox/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { expandDts, invariant } from '../../lib/utils';
-import { useCheckboxGroup } from '../CheckboxGroup';
 import './styles.css';
 
 const SELECTION_KEYS = ['Enter', ' '];
@@ -13,15 +12,15 @@ const getNextState = (checked) => {
 };
 
 const Checkbox = ({
-  name: itemName,
+  name,
   value,
   label,
   dts,
   disabled = false,
-  checked: itemChecked = false,
+  checked = false,
   id,
   className,
-  variant: itemVariant = 'default',
+  variant = 'default',
   text,
   icon,
   onChange,
@@ -32,19 +31,9 @@ const Checkbox = ({
 }) => {
   invariant(!size, 'Checkbox size prop has been deprecated.');
   invariant(!inline, 'Checkbox inline prop has been deprecated.');
-
-  const { onCheckboxChange, isCheckedHandler, name: groupName, variant: groupVariant } = useCheckboxGroup();
-
-  const name = groupName || itemName;
-  const variant = groupVariant || itemVariant;
-  const checked = isCheckedHandler ? isCheckedHandler(value) : itemChecked;
-
   invariant(!((icon || text) && variant !== 'box'), 'Checkbox with icon or text must use box variant.');
-  invariant(!(onChange && onCheckboxChange), 'Checkbox should not have onChange when used in a CheckboxGroup');
-  invariant(!(isCheckedHandler && itemChecked), 'Checkbox checked state is handled by CheckboxGroup.');
 
   const handleChange = () => {
-    if (onCheckboxChange) return onCheckboxChange(value);
     onChange(getNextState(checked), name, value);
   };
 
@@ -113,16 +102,12 @@ const Checkbox = ({
   );
 };
 
-Checkbox.propTypes = {
+export const shareCheckboxPropTypes = {
   /**
    * id for the checkbox input
    */
   id: PropTypes.string,
   className: PropTypes.string,
-  /**
-   * name for the checkbox input
-   */
-  name: PropTypes.string,
   /**
    * checkBox label for the checkbox input
    */
@@ -136,10 +121,6 @@ Checkbox.propTypes = {
    */
   icon: PropTypes.node,
   /**
-   * checkBox input value
-   */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /**
    * data-test-selector for the checkbox component
    */
   dts: PropTypes.string,
@@ -147,6 +128,18 @@ Checkbox.propTypes = {
    * determines if the checkbox is disabled
    */
   disabled: PropTypes.bool,
+};
+
+Checkbox.propTypes = {
+  ...shareCheckboxPropTypes,
+  /**
+   * name for the checkbox input
+   */
+  name: PropTypes.string,
+  /**
+   * checkBox input value
+   */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   variant: PropTypes.oneOf(['default', 'box']),
   /**
    * @function onChange called when checkBox onChange event is fired

--- a/src/components/CheckboxGroup/CheckboxGroupContext.jsx
+++ b/src/components/CheckboxGroup/CheckboxGroupContext.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+
+const CheckboxGroupContext = React.createContext({});
+
+export const useCheckboxGroup = () => React.useContext(CheckboxGroupContext);
+
+const CheckboxGroupProvider = ({
+  children,
+  name: nameProp,
+  value: valueProp,
+  onChange: onChangeProp,
+  getIsChecked,
+  variant,
+}) => {
+  const parentCtx = useCheckboxGroup();
+
+  const valuesRef = React.useRef([]);
+  React.useLayoutEffect(() => {
+    return () => {
+      valuesRef.current = [];
+    };
+  });
+
+  const onChange = parentCtx.onChange || onChangeProp;
+  const name = parentCtx.name || nameProp;
+  const value = parentCtx.value || valueProp;
+
+  const context = React.useMemo(() => {
+    const getIsItemChecked = (checkboxValue) => {
+      if (getIsChecked) return getIsChecked(checkboxValue, value);
+
+      return value.includes(checkboxValue);
+    };
+
+    const getIsAllChecked = () => {
+      const hasUnchecked = valuesRef.current.some((item) => !getIsItemChecked(item));
+      const hasChecked = valuesRef.current.some((item) => getIsItemChecked(item));
+
+      return hasUnchecked && hasChecked ? 'partial' : !hasUnchecked && hasChecked;
+    };
+
+    const onItemChange = (checkboxValue) => {
+      const newValues = value.includes(checkboxValue)
+        ? value.filter((item) => item !== checkboxValue)
+        : [...value, checkboxValue];
+
+      onChange(newValues, name, checkboxValue);
+    };
+
+    const onAllChange = () => {
+      const isAllChecked = getIsAllChecked();
+      if (isAllChecked === true) {
+        const newValues = value.filter((item) => !valuesRef.current.includes(item));
+        onChange(newValues, name);
+      } else {
+        onChange(_(value).concat(valuesRef.current).uniq().value(), name);
+      }
+    };
+
+    const recordValue = (checkboxValue) => {
+      valuesRef.current.push(checkboxValue);
+      parentCtx.recordValue?.(checkboxValue);
+    };
+
+    return {
+      variant,
+      value,
+      name,
+      onChange,
+
+      getIsItemChecked,
+      getIsAllChecked,
+      onItemChange,
+      onAllChange,
+      valuesRef,
+      recordValue,
+    };
+  }, [getIsChecked, value, name, onChange, variant, parentCtx]);
+
+  return <CheckboxGroupContext.Provider value={context}>{children}</CheckboxGroupContext.Provider>;
+};
+
+CheckboxGroupProvider.propTypes = {
+  value: PropTypes.array,
+  name: PropTypes.string,
+  /**
+   * @function onChange
+   * @param {array} newValue - the new checkboxGroup value
+   * @param {string} name - the checkbox name
+   * @param {string|number} value - the changed checkbox's value
+   */
+  onChange: PropTypes.func,
+  /**
+   * @function getIsChecked overrides the default checked state behaviour
+   * @param {string|number} itemValue - the checkbox's value
+   * @param {array} value - the checkbox group's value
+   */
+  getIsChecked: PropTypes.func,
+  variant: PropTypes.oneOf(['default', 'box']),
+  children: PropTypes.node.isRequired,
+};
+
+export default CheckboxGroupProvider;

--- a/src/components/CheckboxGroup/index.d.ts
+++ b/src/components/CheckboxGroup/index.d.ts
@@ -1,19 +1,56 @@
 import * as React from 'react';
 
+export interface CheckboxGroupItemProps {
+  /**
+   * id for the checkbox input
+   */
+  id?: string;
+  className?: string;
+  /**
+   * checkBox label for the checkbox input
+   */
+  label?: React.ReactNode;
+  /**
+   * additional text description to display below the label
+   */
+  text?: React.ReactNode;
+  /**
+   * icon to display beside the label when  parent group's `variant="box"`
+   */
+  icon?: React.ReactNode;
+  /**
+   * data-test-selector for the checkbox component
+   */
+  dts?: string;
+  /**
+   * determines if the checkbox is disabled
+   */
+  disabled?: boolean;
+}
+
+declare const CheckboxGroupItem: React.FC<CheckboxGroupItemProps>;
+
+export interface CheckboxGroupAllProps {
+  label?: React.ReactNode;
+  className?: string;
+}
+
+declare const CheckboxGroupAll: React.FC<CheckboxGroupAllProps>;
+
 export type CheckboxGroupOrientation = 'vertical' | 'horizontal';
 
 export type CheckboxGroupVariant = 'default' | 'box';
 
 export interface CheckboxGroupProps {
-  value: any[];
-  name: string;
+  value?: any[];
+  name?: string;
   /**
    * @function onChange
    * @param {array} newValue - the new checkboxGroup value
    * @param {string} name - the checkbox name
    * @param {string|number} value - the changed checkbox's value
    */
-  onChange: (...args: any[]) => any;
+  onChange?: (...args: any[]) => any;
   /**
    * @function getIsChecked overrides the default checked state behaviour
    * @param {string|number} itemValue - the checkbox's value
@@ -26,12 +63,16 @@ export interface CheckboxGroupProps {
   dts?: string;
   variant?: CheckboxGroupVariant;
   id?: string;
+  indent?: boolean;
   /**
    * @deprecated use orientation="horizontal" instead
    */
   inline?: boolean;
 }
 
-declare const CheckboxGroup: React.FC<CheckboxGroupProps>;
+declare const CheckboxGroup: React.FC<CheckboxGroupProps> & {
+  Item: typeof CheckboxGroupItem;
+  All: typeof CheckboxGroupAll;
+};
 
 export default CheckboxGroup;

--- a/src/components/CheckboxGroup/index.spec.jsx
+++ b/src/components/CheckboxGroup/index.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { render, cleanup, fireEvent, queryByAttribute } from '@testing-library/react';
+import { render, cleanup, fireEvent, queryByAttribute, getByTestId as getByTestIdGlobal } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Checkbox from '../Checkbox';
 import CheckboxGroup from '.';
 
 afterEach(cleanup);
@@ -23,9 +22,9 @@ describe('<CheckboxGroup />', () => {
 
   it('should trigger `props.onChange` when the checkbox is clicked', () => {
     const { getAllByTestId } = render(
-      <CheckboxGroup {...props} type="checkbox" value={['checkbox-value-1']}>
-        <Checkbox value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
-        <Checkbox value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
+      <CheckboxGroup {...props} value={['checkbox-value-1']}>
+        <CheckboxGroup.Item value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
+        <CheckboxGroup.Item value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
       </CheckboxGroup>
     );
     fireEvent.click(getAllByTestId('checkbox-input')[1]);
@@ -35,10 +34,10 @@ describe('<CheckboxGroup />', () => {
   it('should use getIsChecked function', () => {
     const getIsCheckedMock = jest.fn();
     const { getAllByTestId } = render(
-      <CheckboxGroup {...props} type="checkbox" value={['checkbox-value-1']} getIsChecked={getIsCheckedMock}>
-        <Checkbox value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
-        <Checkbox value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
-        <Checkbox value="checkbox-value-3" label="Checkbox 3" dts="test-3" />
+      <CheckboxGroup {...props} value={['checkbox-value-1']} getIsChecked={getIsCheckedMock}>
+        <CheckboxGroup.Item value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
+        <CheckboxGroup.Item value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
+        <CheckboxGroup.Item value="checkbox-value-3" label="Checkbox 3" dts="test-3" />
       </CheckboxGroup>
     );
 
@@ -54,16 +53,10 @@ describe('<CheckboxGroup />', () => {
     };
 
     const { container } = render(
-      <CheckboxGroup
-        {...props}
-        type="checkbox"
-        value={['checkbox-value-1']}
-        getIsChecked={getIsChecked}
-        onChange={mockoOnChange}
-      >
-        <Checkbox value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
-        <Checkbox value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
-        <Checkbox value="checkbox-value-3" label="Checkbox 3" dts="test-3" />
+      <CheckboxGroup {...props} value={['checkbox-value-1']} getIsChecked={getIsChecked} onChange={mockoOnChange}>
+        <CheckboxGroup.Item value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
+        <CheckboxGroup.Item value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
+        <CheckboxGroup.Item value="checkbox-value-3" label="Checkbox 3" dts="test-3" />
       </CheckboxGroup>
     );
 
@@ -83,10 +76,10 @@ describe('<CheckboxGroup />', () => {
 
   it('should trigger onChange with checkbox type', () => {
     const { container } = render(
-      <CheckboxGroup {...props} type="checkbox" value={['checkbox-value-1']}>
-        <Checkbox value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
-        <Checkbox value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
-        <Checkbox value="checkbox-value-3" label="Checkbox 3" dts="test-3" />
+      <CheckboxGroup {...props} value={['checkbox-value-1']}>
+        <CheckboxGroup.Item value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
+        <CheckboxGroup.Item value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
+        <CheckboxGroup.Item value="checkbox-value-3" label="Checkbox 3" dts="test-3" />
       </CheckboxGroup>
     );
     const checkbox1 = getByDts(container, 'test-1');
@@ -101,8 +94,8 @@ describe('<CheckboxGroup />', () => {
   it('should render checkbox group with props', () => {
     const { container, getAllByTestId } = render(
       <CheckboxGroup {...props} value={['checkbox-value-1']}>
-        <Checkbox disabled value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
-        <Checkbox value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
+        <CheckboxGroup.Item disabled value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
+        <CheckboxGroup.Item value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
       </CheckboxGroup>
     );
     expect(getByDts(container, 'test-1')).toHaveTextContent('Checkbox 1');
@@ -116,9 +109,9 @@ describe('<CheckboxGroup />', () => {
   it('should render with props', () => {
     const { getByTestId, queryAllByTestId } = render(
       <CheckboxGroup name="movies" value={['terminator', 'predator']} className="custom-class" onChange={jest.fn()}>
-        <Checkbox label="The Terminator" value="terminator" />
-        <Checkbox label="Predator" value="predator" />
-        <Checkbox label="The Sound of Music" value="soundofmusic" />
+        <CheckboxGroup.Item label="The Terminator" value="terminator" />
+        <CheckboxGroup.Item label="Predator" value="predator" />
+        <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
       </CheckboxGroup>
     );
 
@@ -135,8 +128,8 @@ describe('<CheckboxGroup />', () => {
         className="custom-class"
         onChange={jest.fn()}
       >
-        <Checkbox value="value" label="label" icon="Icon" />
-        <Checkbox value="value-2" label="label" text="text description" />
+        <CheckboxGroup.Item value="value" label="label" icon="Icon" />
+        <CheckboxGroup.Item value="value-2" label="label" text="text description" />
       </CheckboxGroup>
     );
     expect(getByText('text description')).toBeInTheDocument();
@@ -144,22 +137,23 @@ describe('<CheckboxGroup />', () => {
   });
 
   it('should override checkbox items prop', () => {
-    const { getByTestId } = render(
-      <CheckboxGroup variant="box" name="movies" value={['terminator', 'predator']} onChange={jest.fn()}>
-        <Checkbox value="value" label="label" variant="default" />
-      </CheckboxGroup>
-    );
-    expect(getByTestId('checkbox')).toHaveClass('aui--checkbox-box');
-    expect(getByTestId('checkbox')).not.toHaveClass('aui--checkbox-default');
+    jest.spyOn(console, 'error').mockReturnValue();
+    expect(() =>
+      render(
+        <CheckboxGroup variant="box" name="movies" value={['terminator', 'predator']} onChange={jest.fn()}>
+          <CheckboxGroup.Item value="value" label="label" variant="default" />
+        </CheckboxGroup>
+      )
+    ).toThrow('AdslotUI CheckboxGroup.Item: variant will be overridden by CheckboxGroup variant');
   });
 
   it('should handle checkbox change events when adding selection', () => {
     const onChangeGroup = jest.fn();
     const { queryAllByTestId } = render(
       <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={onChangeGroup}>
-        <Checkbox label="The Terminator" value="terminator" />
-        <Checkbox label="Predator" value="predator" />
-        <Checkbox label="The Sound of Music" value="soundofmusic" />
+        <CheckboxGroup.Item label="The Terminator" value="terminator" />
+        <CheckboxGroup.Item label="Predator" value="predator" />
+        <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
       </CheckboxGroup>
     );
 
@@ -172,9 +166,9 @@ describe('<CheckboxGroup />', () => {
     const onChangeGroup = jest.fn();
     const { queryAllByTestId } = render(
       <CheckboxGroup name="movies" value={['terminator', 'predator']} onChange={onChangeGroup}>
-        <Checkbox label="The Terminator" value="terminator" />
-        <Checkbox label="Predator" value="predator" />
-        <Checkbox label="The Sound of Music" value="soundofmusic" />
+        <CheckboxGroup.Item label="The Terminator" value="terminator" />
+        <CheckboxGroup.Item label="Predator" value="predator" />
+        <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
       </CheckboxGroup>
     );
 
@@ -187,12 +181,106 @@ describe('<CheckboxGroup />', () => {
     console.error = jest.fn();
     const { queryByTestId } = render(
       <CheckboxGroup name="movies" value={['test']} onChange={jest.fn()}>
-        {false && <Checkbox label="The Terminator" value="terminator" />}
-        <Checkbox label="Predator" value="predator" />
+        {false && <CheckboxGroup.Item label="The Terminator" value="terminator" />}
+        <CheckboxGroup.Item label="Predator" value="predator" />
       </CheckboxGroup>
     );
 
     expect(queryByTestId('checkbox-group')).toBeInTheDocument();
     expect(console.error).toHaveBeenCalledTimes(0);
+  });
+
+  it('should be able to check all options when none is checked', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <CheckboxGroup name="movies" value={[]} onChange={onChange}>
+        <CheckboxGroup.All label="All" dts="target" />
+        <CheckboxGroup.Item label="The Terminator" value="terminator" />
+        <CheckboxGroup.Item label="Predator" value="predator" />
+        <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
+      </CheckboxGroup>
+    );
+
+    const checkbox = getByTestIdGlobal(getByDts(container, 'target'), 'checkbox-input');
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(['terminator', 'predator', 'soundofmusic'], 'movies');
+  });
+
+  it('should be able to uncheck all options when all are checked', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <CheckboxGroup name="movies" value={['terminator', 'predator', 'soundofmusic']} onChange={onChange}>
+        <CheckboxGroup.All label="All" dts="target" />
+        <CheckboxGroup.Item label="The Terminator" value="terminator" />
+        <CheckboxGroup.Item label="Predator" value="predator" />
+        <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
+      </CheckboxGroup>
+    );
+
+    const checkbox = getByTestIdGlobal(getByDts(container, 'target'), 'checkbox-input');
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([], 'movies');
+  });
+
+  it('should be able to uncheck all options when some is checked', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <CheckboxGroup name="movies" value={['terminator']} onChange={onChange}>
+        <CheckboxGroup.All label="All" dts="target" />
+        <CheckboxGroup.Item label="The Terminator" value="terminator" />
+        <CheckboxGroup.Item label="Predator" value="predator" />
+        <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
+      </CheckboxGroup>
+    );
+
+    const checkbox = getByTestIdGlobal(getByDts(container, 'target'), 'checkbox-input');
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(['terminator', 'predator', 'soundofmusic'], 'movies');
+  });
+
+  it('should work with nested checkbox group', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <CheckboxGroup name="movies" value={[]} onChange={onChange}>
+        <CheckboxGroup.Item label="The Terminator" value="terminator" />
+        <CheckboxGroup.Item label="Predator" value="predator" />
+        <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
+
+        <CheckboxGroup>
+          <CheckboxGroup.Item label="Lung Cancer Late" dts="target" value="Lung Cancer Late" />
+          <CheckboxGroup.Item label="Lung Cancer Early" value="Lung Cancer Early" />
+        </CheckboxGroup>
+      </CheckboxGroup>
+    );
+
+    const checkbox = getByTestIdGlobal(getByDts(container, 'target'), 'checkbox-input');
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(['Lung Cancer Late'], 'movies', 'Lung Cancer Late');
+  });
+
+  it('should be able to select nested all', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <CheckboxGroup name="movies" value={[]} onChange={onChange}>
+        <CheckboxGroup.Item label="The Terminator" value="terminator" />
+        <CheckboxGroup.Item label="Predator" value="predator" />
+        <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
+
+        <CheckboxGroup>
+          <CheckboxGroup.All label="All" dts="target" />
+          <CheckboxGroup.Item label="Lung Cancer Late" value="Lung Cancer Late" />
+          <CheckboxGroup.Item label="Lung Cancer Early" value="Lung Cancer Early" />
+        </CheckboxGroup>
+      </CheckboxGroup>
+    );
+
+    const checkbox = getByTestIdGlobal(getByDts(container, 'target'), 'checkbox-input');
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(['Lung Cancer Late', 'Lung Cancer Early'], 'movies');
   });
 });

--- a/src/components/CheckboxGroup/styles.css
+++ b/src/components/CheckboxGroup/styles.css
@@ -1,0 +1,19 @@
+@import '../../styles/variable';
+
+$spacing: 24px;
+
+.aui--checkbox-group {
+  position: relative;
+
+  &.is-indented {
+    left: $spacing;
+
+    & .aui--checkbox {
+      left: $spacing;
+    }
+
+    & .aui--checkbox.is-all {
+      margin-left: calc($spacing * -1);
+    }
+  }
+}

--- a/src/components/SearchableCheckList/index.jsx
+++ b/src/components/SearchableCheckList/index.jsx
@@ -93,7 +93,7 @@ const SearchableCheckList = ({
             }}
           >
             {_.map(itemsToRender, ({ value, label }) => (
-              <Checkbox key={`${value}-key`} label={label} value={value} dts={`${value}-dts`} />
+              <CheckboxGroup.Item key={`${value}-key`} label={label} value={value} dts={`${value}-dts`} />
             ))}
           </CheckboxGroup>
         </div>

--- a/www/containers/Props.jsx
+++ b/www/containers/Props.jsx
@@ -55,7 +55,7 @@ const Props = ({ componentName, customMapper }) => {
             </tbody>
           </table>
         </div>
-        {componentProps.methods && componentProps.methods.length > 0 && (
+        {componentName !== 'CheckboxGroup' && componentProps.methods && componentProps.methods.length > 0 && (
           <>
             <h3>Methods</h3>
             {_.map(componentProps.methods, (method) => {

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -1166,13 +1166,6 @@
           "required": false,
           "description": ""
         },
-        "name": {
-          "type": {
-            "name": "string"
-          },
-          "required": false,
-          "description": "name for the checkbox input"
-        },
         "label": {
           "type": {
             "name": "node"
@@ -1194,6 +1187,31 @@
           "required": false,
           "description": "icon to display beside the label when  parent group's `variant=\"box\"`"
         },
+        "dts": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "data-test-selector for the checkbox component"
+        },
+        "disabled": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "determines if the checkbox is disabled",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
+        },
+        "name": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": "name for the checkbox input"
+        },
         "value": {
           "type": {
             "name": "union",
@@ -1209,25 +1227,24 @@
           "required": false,
           "description": "checkBox input value"
         },
-        "dts": {
+        "variant": {
           "type": {
-            "name": "string"
+            "name": "enum",
+            "value": [
+              {
+                "value": "'default'",
+                "computed": false
+              },
+              {
+                "value": "'box'",
+                "computed": false
+              }
+            ]
           },
           "required": false,
-          "description": "data-test-selector for the checkbox component",
+          "description": "",
           "defaultValue": {
-            "value": "''",
-            "computed": false
-          }
-        },
-        "disabled": {
-          "type": {
-            "name": "bool"
-          },
-          "required": false,
-          "description": "determines if the checkbox is disabled",
-          "defaultValue": {
-            "value": "false",
+            "value": "'default'",
             "computed": false
           }
         },
@@ -1237,6 +1254,13 @@
           },
           "required": false,
           "description": "@function onChange called when checkBox onChange event is fired\n@param {string|boolean} nextState - the checked state\n@param {string} name - the checkbox name\n@param {string|number} value - the checkbox value"
+        },
+        "onKeyDown": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": ""
         },
         "checked": {
           "type": {
@@ -1280,36 +1304,154 @@
       }
     }
   ],
-  "src/components/CheckboxGroup/index.jsx": [
+  "src/components/CheckboxGroup/CheckboxGroupContext.jsx": [
     {
       "description": "",
       "displayName": "CheckboxGroupProvider",
-      "methods": []
-    },
-    {
-      "description": "",
-      "displayName": "CheckboxGroup",
       "methods": [],
       "props": {
         "value": {
           "type": {
             "name": "array"
           },
-          "required": true,
+          "required": false,
           "description": ""
         },
         "name": {
           "type": {
             "name": "string"
           },
-          "required": true,
+          "required": false,
           "description": ""
         },
         "onChange": {
           "type": {
             "name": "func"
           },
+          "required": false,
+          "description": "@function onChange\n@param {array} newValue - the new checkboxGroup value\n@param {string} name - the checkbox name\n@param {string|number} value - the changed checkbox's value"
+        },
+        "getIsChecked": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
+          "description": "@function getIsChecked overrides the default checked state behaviour\n@param {string|number} itemValue - the checkbox's value\n@param {array} value - the checkbox group's value"
+        },
+        "variant": {
+          "type": {
+            "name": "enum",
+            "value": [
+              {
+                "value": "'default'",
+                "computed": false
+              },
+              {
+                "value": "'box'",
+                "computed": false
+              }
+            ]
+          },
+          "required": false,
+          "description": ""
+        },
+        "children": {
+          "type": {
+            "name": "node"
+          },
           "required": true,
+          "description": ""
+        }
+      }
+    }
+  ],
+  "src/components/CheckboxGroup/index.jsx": [
+    {
+      "description": "",
+      "displayName": "CheckboxGroupItem",
+      "methods": [],
+      "composes": [
+        "../Checkbox"
+      ]
+    },
+    {
+      "description": "",
+      "displayName": "CheckboxGroupAll",
+      "methods": [],
+      "props": {
+        "label": {
+          "type": {
+            "name": "node"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "'All'",
+            "computed": false
+          }
+        },
+        "className": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
+        }
+      }
+    },
+    {
+      "description": "",
+      "displayName": "CheckboxGroup",
+      "methods": [
+        {
+          "name": "Item",
+          "docblock": null,
+          "modifiers": [
+            "static"
+          ],
+          "params": [
+            {
+              "name": "{ value, ...rest }",
+              "type": null
+            }
+          ],
+          "returns": null
+        },
+        {
+          "name": "All",
+          "docblock": null,
+          "modifiers": [
+            "static"
+          ],
+          "params": [
+            {
+              "name": "{ className, label = 'All', ...rest }",
+              "type": null
+            }
+          ],
+          "returns": null
+        }
+      ],
+      "props": {
+        "value": {
+          "type": {
+            "name": "array"
+          },
+          "required": false,
+          "description": ""
+        },
+        "name": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
+        },
+        "onChange": {
+          "type": {
+            "name": "func"
+          },
+          "required": false,
           "description": "@function onChange\n@param {array} newValue - the new checkboxGroup value\n@param {string} name - the checkbox name\n@param {string|number} value - the changed checkbox's value"
         },
         "getIsChecked": {
@@ -1388,6 +1530,17 @@
           },
           "required": false,
           "description": ""
+        },
+        "indent": {
+          "type": {
+            "name": "bool"
+          },
+          "required": false,
+          "description": "",
+          "defaultValue": {
+            "value": "false",
+            "computed": false
+          }
         },
         "inline": {
           "type": {

--- a/www/examples/CheckboxGroup.mdx
+++ b/www/examples/CheckboxGroup.mdx
@@ -28,9 +28,9 @@ class CheckboxGroupExample extends React.PureComponent {
         </h4>
         <br />
         <CheckboxGroup name="movies" value={this.state.movies} onChange={this.handleGroupChange.bind(this)}>
-          <Checkbox label="The Terminator" value="terminator" />
-          <Checkbox label="Predator" value="predator" />
-          <Checkbox label="The Sound of Music" value="soundofmusic" />
+          <CheckboxGroup.Item label="The Terminator" value="terminator" />
+          <CheckboxGroup.Item label="Predator" value="predator" />
+          <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
         </CheckboxGroup>
         <br />
         <h4>Horizontal orientation</h4>
@@ -40,9 +40,9 @@ class CheckboxGroupExample extends React.PureComponent {
           onChange={this.handleGroupChange.bind(this)}
           orientation="horizontal"
         >
-          <Checkbox label="The Terminator" value="terminator" />
-          <Checkbox label="Predator" value="predator" />
-          <Checkbox label="The Sound of Music" value="soundofmusic" />
+          <CheckboxGroup.Item label="The Terminator" value="terminator" />
+          <CheckboxGroup.Item label="Predator" value="predator" />
+          <CheckboxGroup.Item label="The Sound of Music" value="soundofmusic" />
         </CheckboxGroup>
       </>
     );
@@ -69,20 +69,20 @@ const Example = () => {
         dts="radio-group-dts"
         style={{ width: 300 }}
       >
-        <Checkbox
+        <CheckboxGroup.Item
           value="swimming"
           label="Swimming"
           dts="radio-dts"
           icon={<SvgSymbol href="./assets/svg-symbols.svg#list" />}
           text="this is a text description"
         />
-        <Checkbox
+        <CheckboxGroup.Item
           value="soccer"
           label="Soccer"
           icon={<SvgSymbol href="./assets/svg-symbols.svg#list" />}
           text="this is a text description"
         />
-        <Checkbox
+        <CheckboxGroup.Item
           value="badminton"
           label="Badminton"
           icon={<SvgSymbol href="./assets/svg-symbols.svg#list" />}
@@ -101,9 +101,9 @@ const Example = () => {
         dts="radio-group-dts"
         style={{ width: 600 }}
       >
-        <Checkbox value="swimming" label="Swimming" dts="radio-dts" />
-        <Checkbox value="soccer" label="Soccer" />
-        <Checkbox value="badminton" label="Badminton" />
+        <CheckboxGroup.Item value="swimming" label="Swimming" dts="radio-dts" />
+        <CheckboxGroup.Item value="soccer" label="Soccer" />
+        <CheckboxGroup.Item value="badminton" label="Badminton" />
       </CheckboxGroup>
       <pre>hobbies: {JSON.stringify(hobbies)}</pre>
     </>
@@ -113,64 +113,38 @@ const Example = () => {
 render(Example);
 ```
 
-## Advanced checkbox logic
+## Nested checkboxes
 
-Checkbox button group with partial states, per-item onChange override
+Nested checkbox group with partial states, an default "All" option.
 
 ```jsx live=true
+const allHobbies = { sports: ['swimming', 'soccer', 'badminton'], other: ['stamps'] };
+
 const Example = () => {
-  const allHobbies = { sports: ['swimming', 'soccer', 'badminton'], other: ['stamps'] };
-
   const [hobbies, setHobbies] = React.useState([]);
-  const handleGroupChange = (newValues, name, checkboxValue) => {
-    const isHeader = Object.keys(allHobbies).includes(checkboxValue);
-    !isHeader ? setHobbies(newValues) : onHeaderChange(checkboxValue, newValues);
-  };
-
-  const onHeaderChange = (group, newValues) => {
-    const groupValues = allHobbies[group];
-    const selectedGroupValues = newValues.filter((v) => groupValues.includes(v));
-    const checked = getIsChecked(group, selectedGroupValues);
-    !checked ? setHobbies([...hobbies, ...groupValues]) : setHobbies(hobbies.filter((h) => !groupValues.includes(h)));
-  };
-
-  const getIsChecked = (value, selectedValues) => {
-    if (Object.keys(allHobbies).includes(value)) {
-      const current = allHobbies[value];
-      if (current.every((v) => selectedValues.includes(v))) {
-        return true;
-      }
-      if (current.some((v) => selectedValues.includes(v))) {
-        return 'partial';
-      }
-      if (hobbies.length === 0) return false;
-    }
-    return selectedValues.includes(value);
-  };
 
   return (
     <>
-      <style>
-        {`.checkbox-advanced .aui--checkbox:not(.header) label {
-      padding-left: 20px;
-    }`}
-      </style>
       <CheckboxGroup
         name="hobbies"
         variant="default"
         value={hobbies}
-        onChange={handleGroupChange}
+        onChange={setHobbies}
         dts="checkbox-group-dts"
-        getIsChecked={getIsChecked}
         className="checkbox-advanced"
       >
-        <Checkbox className="header" value="sports" label="Sports" dts="checkbox-dts" />
-        <Checkbox value="swimming" label="Swimming" />
-        <Checkbox value="soccer" label="Soccer" />
-        <Checkbox value="badminton" label="Badminton" />
-        <div />
-        <Checkbox className="header" value="other" label="Other" />
-        <Checkbox value="stamps" label="Collecting stamps" />
+        <CheckboxGroup indent>
+          <CheckboxGroup.All label="Sports" />
+          {allHobbies.sports.map((item) => (
+            <CheckboxGroup.Item value={item} label={_.capitalize(item)} />
+          ))}
+        </CheckboxGroup>
+        <CheckboxGroup indent>
+          <CheckboxGroup.All label="Other" />
+          {allHobbies.other.map((item) => (
+            <CheckboxGroup.Item value={item} label={_.capitalize(item)} />
+          ))}
+        </CheckboxGroup>
       </CheckboxGroup>
       <pre>hobbies: {JSON.stringify(hobbies)}</pre>
     </>
@@ -181,3 +155,12 @@ render(Example);
 ```
 
 <Props componentName="CheckboxGroup" />
+
+### CheckboxGroup.Item
+
+<Props customMapper={(props) => [props[`src/components/Card/index.jsx`][0]]} />
+<br />
+
+### CheckboxGroup.All
+
+<Props customMapper={(props) => [props[`src/components/Card/index.jsx`][1]]} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

- Allow nested checkbox group.
- Introduce a default `CheckboxGroup.All` checkbox item, as we want the `All` behaviour to be the consistent in different features.
- As a result, create a alias `CheckboxGroup.Item` for `Checkbox` when it is used under `CheckboxGroup`




## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
