### PR TITLE
fix: babel transpile jsx extension

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -40,6 +40,7 @@ const env = {
       'jsx-remove-data-test-id',
       inlineSvgPlugin,
       ['transform-remove-imports', { test: '\\.css$' }],
+      ['replace-import-extension',{ "extMapping": { ".jsx": ".js" }}]
     ],
   },
   cjs: {
@@ -49,6 +50,7 @@ const env = {
       'jsx-remove-data-test-id',
       inlineSvgPlugin,
       ['transform-remove-imports', { test: '\\.css$' }],
+      ['replace-import-extension',{ "extMapping": { ".jsx": ".js" }}]
     ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "babel-plugin-inline-react-svg": "^2.0.1",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-plugin-jsx-remove-data-test-id": "^3.0.0",
+        "babel-plugin-replace-import-extension": "^1.1.3",
         "babel-plugin-transform-remove-imports": "^1.7.0",
         "buffer": "^6.0.3",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
@@ -7889,6 +7890,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/babel-plugin-replace-import-extension": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-replace-import-extension/-/babel-plugin-replace-import-extension-1.1.3.tgz",
+      "integrity": "sha512-NmHOpGOLqSnZgefu/rmCviGIlp51WLGk8OY9CiQmp9qrpBy6jFVNvxIP4jR9WXZlNOPfBdGpuhPJe8upV4DTGw==",
+      "dev": true
     },
     "node_modules/babel-plugin-transform-remove-imports": {
       "version": "1.7.0",
@@ -31673,6 +31680,12 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.3"
       }
+    },
+    "babel-plugin-replace-import-extension": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-replace-import-extension/-/babel-plugin-replace-import-extension-1.1.3.tgz",
+      "integrity": "sha512-NmHOpGOLqSnZgefu/rmCviGIlp51WLGk8OY9CiQmp9qrpBy6jFVNvxIP4jR9WXZlNOPfBdGpuhPJe8upV4DTGw==",
+      "dev": true
     },
     "babel-plugin-transform-remove-imports": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "babel-plugin-inline-react-svg": "^2.0.1",
     "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-jsx-remove-data-test-id": "^3.0.0",
+    "babel-plugin-replace-import-extension": "^1.1.3",
     "babel-plugin-transform-remove-imports": "^1.7.0",
     "buffer": "^6.0.3",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
replace `jsx` extension using `babel-plugin-replace-import-extension` which doesn't seem to be a popular plugin.
or maybe can just rename all jsx files in the repo

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
