### PR TITLE
fix: catch type change errors

### DIFF
--- a/scripts/generate-types/checkTypeChanges.js
+++ b/scripts/generate-types/checkTypeChanges.js
@@ -1,0 +1,48 @@
+const _ = require('lodash');
+const chalk = require('chalk');
+const { replacements } = require('./typesPostFixes');
+/**
+ * @param {string[]} filePaths
+ */
+
+module.exports = async function checkTypeChanges(filePaths) {
+  try {
+    const customTypesFixComponents = _.keys(replacements());
+    for (const component of customTypesFixComponents) {
+      // [Component]/index.d.ts
+      // Component/[SubComponent].d.ts
+      // Component/[SubComponent]/index.d.ts
+      const expectedPathMatches = [`${component}/index.d.ts$`, `/[A-Z]{1}[a-z]+/${component}.d.ts$`];
+      const matchedArg = filePaths.find((p) => {
+        let matched = false;
+        expectedPathMatches.forEach((r) => {
+          const match = p.match(new RegExp(r, 'g'));
+          if (match?.[0]) {
+            matched = true;
+          }
+        });
+        return matched;
+      });
+
+      if (matchedArg) {
+        console.log(
+          chalk.yellow(
+            `${chalk.bold('WARNING')}: Detected type changes in a component (${chalk.bold(
+              component
+            )}) with custom type fixes.\n`
+          ),
+          chalk.yellow(
+            `Please check the new changes are compatible with those in ${chalk.bold(
+              `scripts/generate-types/typesPostFixes.js`
+            )}
+
+            `
+          )
+        );
+      }
+    }
+  } catch (err) {
+    console.log(err);
+    console.log(chalk.red('Failed to check type changes.\n'));
+  }
+};

--- a/scripts/generate-types/typesPostFixes.js
+++ b/scripts/generate-types/typesPostFixes.js
@@ -1,166 +1,245 @@
+const _ = require('lodash');
+const chalk = require('chalk');
+
 // some additional fixes for components that
 // have unparseable prop types, or 3rd party typing requirements beyond PropTypes
 // Note: `result` is pre-prettier formatting
 
-module.exports = function typesPostFixes(componentName, result) {
-  switch (componentName) {
-    case 'ImageCropper':
-      return `import type Cropper from 'cropperjs';
-      ${result.replace(`onCrop: (...args: any[])=>any;`, `onCrop: (data: Cropper.Data)=>any;`).replace(
-        `declare const ImageCropper: React.FC<ImageCropperProps>;`,
-        `
-        declare const ImageCropper: ${withForwardRef('ImageCropperProps')};`
-      )}`;
-
-    case 'Search':
-      return result.replace(
-        `declare const Search: React.FC<SearchProps>;`,
-        `
-          declare const Search: ${withForwardRef('SearchProps')};`
-      );
-
-    case 'Button':
-      return result.replace(
-        'export interface ButtonProps {',
-        'export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {'
-      );
-
-    case 'Anchor':
-      return result.replace(
+exports.replacements = (componentName) => ({
+  Accordion: {
+    replacements: [
+      [
+        `import * as React from 'react';`,
+        `import * as React from 'react';
+    import Panel from '../Panel'`,
+      ],
+      [
+        `declare const Accordion: React.FC<AccordionProps>;`,
+        `declare const Accordion: React.FC<AccordionProps> & {
+      Panel: typeof Panel;
+    };
+    `,
+      ],
+    ],
+  },
+  Anchor: {
+    replacements: [
+      [
         'export interface AnchorProps {',
-        'export interface AnchorProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {'
-      );
-
-    case 'TextEllipsis':
-      return result
-        .replace(
-          `import * as React from 'react';`,
-          `
-      import * as React from 'react';
-      import { PopoverProps } from '../Popover';`
-        )
-        .replace(`popoverProps?: any;`, `popoverProps?: PopoverProps;`);
-
-    case 'Popover':
-      return popperTyping(result, 'Popover')
-        .replace(
-          `import * as React from 'react';`,
-          `
-          import * as React from 'react';
-          import WithRef from './WithRef';`
-        )
-        .replace(
-          `declare const Popover: <M>(props: PopoverProps<M>) => React.ReactElement<any, any> | null;`,
-          `declare const Popover: (<M>(props: PopoverProps<M>) => React.ReactElement<any, any> | null) & {
-            WithRef: typeof WithRef;
-          };`
-        );
-
-    case 'WithRef':
-      return popperTyping(result, 'WithRef');
-
-    case 'Popper':
-      return popperTyping(result, 'Popper');
-
-    case 'Accordion':
-      return result
-        .replace(
-          `import * as React from 'react';`,
-          `import * as React from 'react';
-      import Panel from '../Panel'`
-        )
-        .replace(
-          `declare const Accordion: React.FC<AccordionProps>;`,
-          `declare const Accordion: React.FC<AccordionProps> & {
-        Panel: typeof Panel;
-      };
-      `
-        );
-
-    case 'Carousel':
-      return `import type { Settings } from 'react-slick';
-      ${result.replace(
+        'export interface AnchorProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {',
+      ],
+    ],
+  },
+  Button: {
+    replacements: [
+      [
+        'export interface ButtonProps {',
+        'export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {',
+      ],
+    ],
+  },
+  Carousel: {
+    replacements: [
+      [
+        `import * as React from 'react';`,
+        `import * as React from 'react';
+      import type { Settings } from 'react-slick';`,
+      ],
+      [
         'declare const Carousel: React.FC<CarouselProps>;',
         `declare const usePreventCarouselSwipeClicks: () => {
-          onMouseDownCapture: (e: any) => void;
-          onClickCapture: (e: any) => void;
-        };
+        onMouseDownCapture: (e: any) => void;
+        onClickCapture: (e: any) => void;
+      };
 
-        declare const Carousel: ${withForwardRef('CarouselProps & Settings')} & {
-          usePreventSwipeClicks: typeof usePreventCarouselSwipeClicks;
-        };`
-      )}`;
-
-    case 'RichTextEditor':
-      return `import { EditorState, ContentState, RawDraftContentState } from 'draft-js';
-      import { createEditorStateWithText } from '@draft-js-plugins/editor';
-      ${result.replace(
-        `declare const RichTextEditor: React.FC<RichTextEditorProps>`,
-        `declare const RichTextEditor: React.FC<RichTextEditorProps> & {
-          createEmpty: typeof EditorState.createEmpty;
-          createWithText: typeof createEditorStateWithText;
-          stateToHTML: (input: ContentState) => string;
-          stateFromHTML: (input: string) => EditorState;
-          stateToPlainText: (input: ContentState) => string;
-          stateToEntityList: (input: ContentState) => RawDraftContentState['entityMap'];
-        };`
-      )}
-      `;
-
-    // select doesn't get picked up at all due to its compositional nature
-    case 'Select':
-      return `
-      import * as React from 'react';
-      import { Props,  components, createFilter } from 'react-select';
-      import CreatableSelect from 'react-select/creatable';
-      import AsyncSelect from 'react-select/async';
-      import AsyncCreatableSelect from 'react-select/async-creatable';
-
-      export interface SelectProps {
-        dts?: string;
-        isInModal?: boolean;
-      }
-
-      declare const Select: (<OptionType extends unknown = { label: string; value: string }, IsMulti extends boolean = false>(
-        props: SelectProps & Props<OptionType, IsMulti>
-      ) => React.ReactElement<any, any> | null) & {
-        components: typeof components;
-        Creatable: typeof CreatableSelect;
-        Async: typeof AsyncSelect;
-        AsyncCreatable: typeof AsyncCreatableSelect;
-        createFilter: typeof createFilter;
-      };      
-
-      export default Select;
-      `;
-
-    case 'DatePicker':
-      return `
-    import { ReactDatePickerProps } from "react-datepicker";
-    import { Moment } from "moment";
-
-    ${result
-      .replace(
+      declare const Carousel: ${withForwardRef('CarouselProps & Settings')} & {
+        usePreventSwipeClicks: typeof usePreventCarouselSwipeClicks;
+      };`,
+      ],
+    ],
+  },
+  DatePicker: {
+    replacements: [
+      [
+        `import * as React from 'react';`,
+        `import * as React from 'react';
+       import { ReactDatePickerProps } from "react-datepicker";
+  import { Moment } from "moment";`,
+      ],
+      [
         `export interface DatePickerProps {`,
         `
-        export interface DatePickerProps {
-        selected?: Moment | Date | null;
-        onChange?(date: Moment | Date | null): void;
-        startDate?: Moment | Date | null;
-        endDate?: Moment | Date | null;
-        minDate?: Moment | Date | null;
-        maxDate?: Moment | Date | null;`
-      )
-      .replace(
+      export interface DatePickerProps {
+      selected?: Moment | Date | null;
+      onChange?(date: Moment | Date | null): void;
+      startDate?: Moment | Date | null;
+      endDate?: Moment | Date | null;
+      minDate?: Moment | Date | null;
+      maxDate?: Moment | Date | null;`,
+      ],
+      [
         `declare const DatePicker: React.FC<DatePickerProps>;`,
         `declare const DatePicker: ${withForwardRef(
           'DatePickerProps & Omit<ReactDatePickerProps, keyof DatePickerProps>'
-        )};`
-      )}`;
-    default:
-      return result;
+        )};`,
+      ],
+    ],
+  },
+  ImageCropper: {
+    replacements: [
+      [
+        `import * as React from 'react';`,
+        `import * as React from 'react';
+      import type Cropper from 'cropperjs';`,
+      ],
+      [`onCrop: (...args: any[])=>any;`, `onCrop: (data: Cropper.Data)=>any;`],
+      [
+        `declare const ImageCropper: React.FC<ImageCropperProps>;`,
+        `
+      declare const ImageCropper: ${withForwardRef('ImageCropperProps')};`,
+      ],
+    ],
+  },
+  Popover: {
+    replacements: [
+      ...popperTypingReplacements(componentName),
+      [
+        `import * as React from 'react';`,
+        `
+        import * as React from 'react';
+        import WithRef from './WithRef';`,
+      ],
+      [
+        `declare const Popover: <M>(props: PopoverProps<M>) => React.ReactElement<any, any> | null;`,
+        `declare const Popover: (<M>(props: PopoverProps<M>) => React.ReactElement<any, any> | null) & {
+          WithRef: typeof WithRef;
+        };`,
+      ],
+    ],
+  },
+  Popper: {
+    replacements: popperTypingReplacements(componentName),
+  },
+  Search: {
+    replacements: [
+      [
+        `declare const Search: React.FC<SearchProps>;`,
+        `
+        declare const Search: ${withForwardRef('SearchProps')};`,
+      ],
+    ],
+  },
+  Select: {
+    // select doesn't get picked up at all due to its compositional nature
+    replacements: [
+      [
+        `import * as React from 'react';`,
+        `
+    import * as React from 'react';
+    import { Props,  components, createFilter } from 'react-select';
+    import CreatableSelect from 'react-select/creatable';
+    import AsyncSelect from 'react-select/async';
+    import AsyncCreatableSelect from 'react-select/async-creatable';
+
+    export interface SelectProps {
+      dts?: string;
+      isInModal?: boolean;
+    }
+
+    declare const Select: (<OptionType extends unknown = { label: string; value: string }, IsMulti extends boolean = false>(
+      props: SelectProps & Props<OptionType, IsMulti>
+    ) => React.ReactElement<any, any> | null) & {
+      components: typeof components;
+      Creatable: typeof CreatableSelect;
+      Async: typeof AsyncSelect;
+      AsyncCreatable: typeof AsyncCreatableSelect;
+      createFilter: typeof createFilter;
+    };      
+
+    export default Select;
+    `,
+      ],
+    ],
+  },
+  RichTextEditor: {
+    replacements: [
+      [
+        `import * as React from 'react';`,
+        `import * as React from 'react';
+        import { EditorState, ContentState, RawDraftContentState } from 'draft-js';
+        import { createEditorStateWithText } from '@draft-js-plugins/editor';`,
+      ],
+      [
+        `declare const RichTextEditor: React.FC<RichTextEditorProps>`,
+        `declare const RichTextEditor: React.FC<RichTextEditorProps> & {
+        createEmpty: typeof EditorState.createEmpty;
+        createWithText: typeof createEditorStateWithText;
+        stateToHTML: (input: ContentState) => string;
+        stateFromHTML: (input: string) => EditorState;
+        stateToPlainText: (input: ContentState) => string;
+        stateToEntityList: (input: ContentState) => RawDraftContentState['entityMap'];
+      };`,
+      ],
+    ],
+  },
+  TextEllipsis: {
+    replacements: [
+      [
+        `import * as React from 'react';`,
+        `
+    import * as React from 'react';
+    import { PopoverProps } from '../Popover';`,
+      ],
+      [`popoverProps?: any;`, `popoverProps?: PopoverProps;`],
+    ],
+  },
+
+  WithRef: {
+    replacements: popperTypingReplacements(componentName),
+  },
+});
+
+exports.typesPostFixes = (componentName, result) => {
+  function fix() {
+    module.exports.replacements(componentName)[componentName].replacements?.forEach(([pattern, replacement]) => {
+      if (typeof pattern === 'string' ? result.indexOf(pattern) < 0 : !result.match(pattern)?.[0]) {
+        throw new Error(
+          chalk.red(
+            `Failed to fix types for ${chalk.bold(componentName)}.
+Please check ${chalk.bold(`scripts/generate-types/typesPostFixes.js`)} and/or the component definition.
+Pattern ${chalk.bold(`"${pattern}"`)} not found in definition file.`
+          )
+        );
+      }
+      result = result.replace(pattern, replacement);
+    });
+    return result;
   }
+
+  if (_.keys(module.exports.replacements()).includes(componentName)) {
+    return fix();
+  }
+
+  return result;
 };
+
+function popperTypingReplacements(name) {
+  return [
+    [
+      `import * as React from 'react';`,
+      `
+    import * as React from 'react';
+    import type { PopperModifiers } from './ReactPopper';`,
+    ],
+    [/^.+type \w+Modifiers.+$/m, ''],
+    [/^.+modifiers\?:.+$/m, ''],
+    [`export interface ${name}Props {`, `export interface ${name}Props<M = ''> extends PopperModifiers<M> {`],
+    [
+      `declare const ${name}: React.FC<${name}Props>;`,
+      `declare const ${name}: <M>(props: ${name}Props<M>) => React.ReactElement<any, any> | null;`,
+    ],
+  ];
+}
 
 // adding the ref types via PropTypes works for type generation but will cause a
 // `ref` is not a prop error due to ref being a 'special' prop
@@ -168,22 +247,4 @@ function withForwardRef(props) {
   return `React.ForwardRefExoticComponent<
   React.PropsWithoutRef<${props}> & React.RefAttributes<((...args: any[]) => any) | Element>
 >`;
-}
-
-// replace modifiers with correct types
-function popperTyping(result, name) {
-  return result
-    .replace(
-      `import * as React from 'react';`,
-      `
-    import * as React from 'react';
-    import type { PopperModifiers } from './ReactPopper';`
-    )
-    .replace(/^.+type \w+Modifiers.+$/m, '')
-    .replace(/^.+modifiers\?:.+$/m, '')
-    .replace(`export interface ${name}Props {`, `export interface ${name}Props<M = ''> extends PopperModifiers<M> {`)
-    .replace(
-      `declare const ${name}: React.FC<${name}Props>;`,
-      `declare const ${name}: <M>(props: ${name}Props<M>) => React.ReactElement<any, any> | null;`
-    );
 }

--- a/src/components/Carousel/index.d.ts
+++ b/src/components/Carousel/index.d.ts
@@ -1,5 +1,5 @@
-import type { Settings } from 'react-slick';
 import * as React from 'react';
+import type { Settings } from 'react-slick';
 
 export interface CarouselProps {
   className?: string;

--- a/src/components/DatePicker/index.d.ts
+++ b/src/components/DatePicker/index.d.ts
@@ -1,7 +1,6 @@
+import * as React from 'react';
 import { ReactDatePickerProps } from 'react-datepicker';
 import { Moment } from 'moment';
-
-import * as React from 'react';
 
 export interface DatePickerProps {
   selected?: Moment | Date | null;

--- a/src/components/ImageCropper/index.d.ts
+++ b/src/components/ImageCropper/index.d.ts
@@ -1,5 +1,5 @@
-import type Cropper from 'cropperjs';
 import * as React from 'react';
+import type Cropper from 'cropperjs';
 
 export interface ImageCropperProps {
   title?: string;

--- a/src/components/RichTextEditor/index.d.ts
+++ b/src/components/RichTextEditor/index.d.ts
@@ -1,6 +1,6 @@
+import * as React from 'react';
 import { EditorState, ContentState, RawDraftContentState } from 'draft-js';
 import { createEditorStateWithText } from '@draft-js-plugins/editor';
-import * as React from 'react';
 
 export interface RichTextEditorMentions {
   name: string;


### PR DESCRIPTION
## Description
- add a warning on type def changes for components with post-fixes
- add an error if a type post-fix doesn't work 
- fix glob path on windows
- reduce console spam unless `--debug` is used


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):

failure:
![Screen Shot 2022-10-24 at 10 24 16 am](https://user-images.githubusercontent.com/13904763/197426433-01a06bb5-81a2-4580-956f-d0fbfd861567.png)

warning:
![Screen Shot 2022-10-24 at 10 24 36 am](https://user-images.githubusercontent.com/13904763/197426426-f4dbc1ac-b633-4889-a8ea-0efd4b8b9597.png)
