### PR TITLE
[ASC-165] refactor: add dts support to toast message and confirm modal

### DIFF
--- a/src/components/ConfirmModal/index.d.ts
+++ b/src/components/ConfirmModal/index.d.ts
@@ -29,6 +29,7 @@ export interface ConfirmModalProps {
    * determines if the modal needs to be shown or not
    */
   show?: boolean;
+  dts?: string;
 }
 
 declare const ConfirmModal: React.FC<ConfirmModalProps>;

--- a/src/components/ConfirmModal/index.jsx
+++ b/src/components/ConfirmModal/index.jsx
@@ -11,6 +11,7 @@ const ConfirmModal = ({
   modalDescription,
   modalTitle,
   show,
+  dts,
 }) => {
   const cancelAction = () => {
     modalClose();
@@ -26,6 +27,7 @@ const ConfirmModal = ({
       <ActionPanel
         isModal
         data-testid="confirm-modal-wrapper"
+        dts={dts}
         className="confirm-modal-component"
         size="small"
         title={modalTitle}
@@ -81,6 +83,7 @@ ConfirmModal.propTypes = {
    * determines if the modal needs to be shown or not
    */
   show: PropTypes.bool,
+  dts: PropTypes.string,
 };
 
 ConfirmModal.defaultProps = {

--- a/src/components/Toast/index.d.ts
+++ b/src/components/Toast/index.d.ts
@@ -49,6 +49,7 @@ export interface ToastNotificationProps {
   title?: string;
   theme?: ToastNotificationTheme;
   message: React.ReactNode;
+  dts?: string;
 }
 
 declare const ToastNotification: React.FC<ToastNotificationProps>;
@@ -59,6 +60,7 @@ export interface notifyProps {
   title?: string;
   theme?: notifyTheme;
   message: React.ReactNode;
+  dts?: string;
 }
 
 declare const notify: React.FC<notifyProps>;

--- a/src/components/Toast/index.jsx
+++ b/src/components/Toast/index.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { toast, ToastContainer as ReactToastContainer } from 'react-toastify';
 import PropTypes from 'prop-types';
 import { toastPlacements } from './constants';
+import { expandDts } from '../../utils';
 import 'react-toastify/dist/ReactToastify.css';
 import './styles.css';
 
@@ -42,9 +43,9 @@ ToastContainer.defaultProps = {
 
 const getToastClass = (theme) => classnames('aui--toast-title', { [`aui--toast-title-${theme}`]: theme });
 
-export const ToastMessage = ({ toastClass, title = '', message }) => (
+export const ToastMessage = ({ toastClass, title = '', message, dts }) => (
   <React.Fragment>
-    <span className="aui--toast-body-message">
+    <span className="aui--toast-body-message" {...expandDts(dts)}>
       <span className={toastClass}>{title}</span>
       <span>{message}</span>
     </span>
@@ -59,17 +60,17 @@ const withDefaultOptions = (options) => ({
   ...options,
 });
 
-const ToastNotification = ({ theme = 'info', title = '', message, ...options }) => {
+const ToastNotification = ({ theme = 'info', title = '', message, dts, ...options }) => {
   const toastClass = getToastClass(theme);
-  const toastMessage = <ToastMessage toastClass={toastClass} title={title} message={message} />;
+  const toastMessage = <ToastMessage toastClass={toastClass} title={title} message={message} dts={dts} />;
 
   toast.info(toastMessage, withDefaultOptions({ theme, ...options }));
   return null;
 };
 
-const notify = ({ theme = 'info', title, message, ...options }) => {
+const notify = ({ theme = 'info', title, message, dts, ...options }) => {
   toast.info(
-    <ToastMessage toastClass={getToastClass(theme)} title={title} message={message} />,
+    <ToastMessage toastClass={getToastClass(theme)} title={title} message={message} dts={dts} />,
     withDefaultOptions({ theme, ...options })
   );
   return;
@@ -80,6 +81,7 @@ notify.propTypes = {
   title: PropTypes.string,
   theme: PropTypes.oneOf(['success', 'info', 'alert', 'attention']),
   message: PropTypes.node.isRequired,
+  dts: PropTypes.string,
 };
 
 ToastNotification.propTypes = {
@@ -92,6 +94,7 @@ ToastNotification.propTypes = {
   title: PropTypes.string,
   theme: PropTypes.oneOf(['success', 'info', 'alert', 'attention']),
   message: PropTypes.node.isRequired,
+  dts: PropTypes.string,
 };
 
 const dismiss = toast.dismiss;

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -1626,6 +1626,13 @@
             "value": "false",
             "computed": false
           }
+        },
+        "dts": {
+          "type": {
+            "name": "string"
+          },
+          "required": false,
+          "description": ""
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Add dts to toast message
- it could use as Toast.notify({dts: 'toast-message'}) or <Toast.Notification dts="toast-message" />

Add dts to confirm modal

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
<img width="1383" alt="Screen Shot 2023-05-02 at 1 25 35 pm" src="https://user-images.githubusercontent.com/13281771/236372899-71ef10cf-91cf-443a-a228-cc3246f18025.png">
<img width="1387" alt="Screen Shot 2023-05-02 at 1 28 25 pm" src="https://user-images.githubusercontent.com/13281771/236372908-331e05b0-85e8-4082-9276-1a190a509c17.png">

