### PR TITLE
[ASC-133] fix: use cancelButton prop on action panel

### DIFF
--- a/src/components/ActionPanel/index.d.ts
+++ b/src/components/ActionPanel/index.d.ts
@@ -9,9 +9,8 @@ export interface ActionPanelProps {
   onClose: (...args: any[]) => any;
   children: React.ReactNode;
   actionButton?: React.ReactNode;
-  closeIcon?: React.ReactNode;
+  cancelButton?: React.ReactNode;
   isModal?: boolean;
-  cancelText?: string;
   /**
    * Hides the modal with css, but keeps it mounted.
    * This should only be used if you need to launch an ActionPanel

--- a/src/components/ActionPanel/index.jsx
+++ b/src/components/ActionPanel/index.jsx
@@ -7,19 +7,7 @@ import Button from '../Button';
 import './styles.css';
 
 const ActionPanel = React.forwardRef((props, ref) => {
-  const {
-    title,
-    className,
-    size,
-    onClose,
-    children,
-    visuallyHidden,
-    actionButton,
-    isModal,
-    closeIcon,
-    cancelText,
-    dts,
-  } = props;
+  const { title, className, size, onClose, children, visuallyHidden, actionButton, isModal, cancelButton, dts } = props;
 
   const addBodyClass = (classname) => document.body.classList.add(classname);
   const removeBodyClass = (classname) => document.body.classList.remove(classname);
@@ -32,6 +20,24 @@ const ActionPanel = React.forwardRef((props, ref) => {
       if (isModal) removeBodyClass('modal-open');
     };
   }, [isModal, visuallyHidden]);
+
+  const defaultCancelButton = (
+    <>
+      {actionButton ? (
+        <Button onClick={onClose} className="close-button" dts="header-close-button">
+          Cancel
+        </Button>
+      ) : (
+        <Button
+          onClick={onClose}
+          className={classNames('close-button', 'close-svg-icon')}
+          dts="header-close-button"
+          icon={<div className="close-icon" />}
+          aria-label={'Close'}
+        />
+      )}
+    </>
+  );
 
   const actionPanel = (
     <div ref={ref}>
@@ -58,19 +64,7 @@ const ActionPanel = React.forwardRef((props, ref) => {
               {title}
             </div>
             <span className="actions">
-              {actionButton ? (
-                <Button onClick={onClose} className="close-button" dts="header-close-button">
-                  {cancelText}
-                </Button>
-              ) : (
-                <Button
-                  onClick={onClose}
-                  className={classNames('close-button', 'close-svg-icon')}
-                  dts="header-close-button"
-                  icon={closeIcon}
-                  aria-label={'Close'}
-                />
-              )}
+              {cancelButton ? cancelButton : defaultCancelButton}
               {actionButton}
             </span>
           </div>
@@ -93,9 +87,8 @@ ActionPanel.propTypes = {
   onClose: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
   actionButton: PropTypes.node,
-  closeIcon: PropTypes.node,
+  cancelButton: PropTypes.node,
   isModal: PropTypes.bool,
-  cancelText: PropTypes.string,
   /**
    * Hides the modal with css, but keeps it mounted.
    * This should only be used if you need to launch an ActionPanel
@@ -109,8 +102,7 @@ ActionPanel.defaultProps = {
   size: 'large',
   actionButton: null,
   isModal: false,
-  closeIcon: <div className="close-icon" />,
-  cancelText: 'Cancel',
+  cancelButton: null,
 };
 
 export default ActionPanel;

--- a/src/components/ActionPanel/index.spec.jsx
+++ b/src/components/ActionPanel/index.spec.jsx
@@ -75,7 +75,7 @@ describe('<ActionPanel />', () => {
             isModal: true,
             size: 'large',
             actionButton: <Button>Action</Button>,
-            cancelText: 'This is a cancel text',
+            cancelButton: <Button>This is a cancel text</Button>,
           })}
         />
       );

--- a/src/components/ConfirmModal/index.jsx
+++ b/src/components/ConfirmModal/index.jsx
@@ -30,7 +30,11 @@ const ConfirmModal = ({
         size="small"
         title={modalTitle}
         onClose={cancelAction}
-        closeIcon={buttonCancelLabel}
+        cancelButton={
+          <Button onClick={cancelAction} className="close-button" dts="header-close-button">
+            {buttonCancelLabel}
+          </Button>
+        }
         actionButton={
           <Button
             data-testid="confirm-modal-confirm"

--- a/www/containers/props.json
+++ b/www/containers/props.json
@@ -138,17 +138,6 @@
             "computed": false
           }
         },
-        "closeIcon": {
-          "type": {
-            "name": "node"
-          },
-          "required": false,
-          "description": "",
-          "defaultValue": {
-            "value": "<div className=\"close-icon\" />",
-            "computed": false
-          }
-        },
         "isModal": {
           "type": {
             "name": "bool"
@@ -160,14 +149,14 @@
             "computed": false
           }
         },
-        "cancelText": {
+        "cancelButton": {
           "type": {
-            "name": "string"
+            "name": "node"
           },
           "required": false,
           "description": "",
           "defaultValue": {
-            "value": "'Cancel'",
+            "value": "null",
             "computed": false
           }
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->
Use `cancelButton` prop to replace both `closeIcon` (not being used) and `cancelText`
NB: `cancelText` is not being used in direct-web, but pretty sure it is being used by Symphony team

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [x] Yes
- [ ] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
