### PR TITLE
v32.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "32.6.0",
+  "version": "32.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "32.6.0",
+      "version": "32.6.1",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "32.6.0",
+  "version": "32.6.1",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [76aab9ffdcbaf417a7b3105d1f579b5b07b66661] build(deps): bump json5 from 1.0.1 to 1.0.2
 
	


	Bumps [json5](https://github.com/json5/json5) from 1.0.1 to 1.0.2.


	- [Release notes](https://github.com/json5/json5/releases)


	- [Changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md)


	- [Commits](https://github.com/json5/json5/compare/v1.0.1...v1.0.2)


	


	---


	updated-dependencies:


	- dependency-name: json5


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [58e34acd426a7d06aacc4523dee3d3cc74032140] build(deps): bump ua-parser-js from 0.7.31 to 0.7.33
 
	


	Bumps [ua-parser-js](https://github.com/faisalman/ua-parser-js) from 0.7.31 to 0.7.33.


	- [Release notes](https://github.com/faisalman/ua-parser-js/releases)


	- [Changelog](https://github.com/faisalman/ua-parser-js/blob/master/changelog.md)


	- [Commits](https://github.com/faisalman/ua-parser-js/compare/0.7.31...0.7.33)


	


	---


	updated-dependencies:


	- dependency-name: ua-parser-js


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [a11f2c3da8b319eafc01d637ffdcf21931081f8b] build: release patch version 32.6.1
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v32.6.0...v32.6.1