### PR TITLE
fix: allow checkbox item to be partial

### DIFF
--- a/src/components/Checkbox/index.jsx
+++ b/src/components/Checkbox/index.jsx
@@ -7,7 +7,7 @@ import './styles.css';
 const SELECTION_KEYS = ['Enter', ' '];
 
 const getNextState = (checked) => {
-  if (checked === 'partial') return false;
+  if (checked === 'partial') return true;
   return !checked;
 };
 

--- a/src/components/CheckboxGroup/CheckboxGroupContext.jsx
+++ b/src/components/CheckboxGroup/CheckboxGroupContext.jsx
@@ -28,10 +28,12 @@ const CheckboxGroupProvider = ({
     };
 
     const getIsAllChecked = (values) => {
-      const hasUnchecked = values.some((item) => !getIsItemChecked(item));
-      const hasChecked = values.some((item) => getIsItemChecked(item));
+      const result = _(values)
+        .map((item) => getIsItemChecked(item))
+        .uniq()
+        .value();
 
-      return hasUnchecked && hasChecked ? 'partial' : !hasUnchecked && hasChecked;
+      return result.length === 1 ? result[0] : 'partial';
     };
 
     const onItemChange = (checkboxValue) => {

--- a/src/components/CheckboxGroup/index.spec.jsx
+++ b/src/components/CheckboxGroup/index.spec.jsx
@@ -54,11 +54,17 @@ describe('<CheckboxGroup />', () => {
 
     const { container } = render(
       <CheckboxGroup {...props} value={['checkbox-value-1']} getIsChecked={getIsChecked} onChange={mockoOnChange}>
+        <CheckboxGroup.All
+          values={['checkbox-value-1', 'checkbox-value-2', 'checkbox-value-3']}
+          label="Checkbox Parent"
+          dts="test-p"
+        />
         <CheckboxGroup.Item value="checkbox-value-1" label="Checkbox 1" dts="test-1" />
         <CheckboxGroup.Item value="checkbox-value-2" label="Checkbox 2" dts="test-2" />
         <CheckboxGroup.Item value="checkbox-value-3" label="Checkbox 3" dts="test-3" />
       </CheckboxGroup>
     );
+    expect(getByDts(container, 'test-p')).toBePartiallyChecked();
 
     const checkbox2 = getByDts(container, 'test-2');
 

--- a/src/components/SearchableCheckList/index.spec.jsx
+++ b/src/components/SearchableCheckList/index.spec.jsx
@@ -268,7 +268,7 @@ describe('<SearchableChecklist />', () => {
     expect(onChange).toHaveBeenCalledWith(_.map(items, 'value'));
   });
 
-  it('should call onChange with `[]` when selected items are fixed', () => {
+  it('should call onChange with all items when selected items are fixed', () => {
     const onChange = jest.fn();
 
     const { queryAllByTestId } = render(
@@ -281,6 +281,6 @@ describe('<SearchableChecklist />', () => {
     expect(onChange).toHaveBeenCalledTimes(0);
     fireEvent.click(checkBoxesWrapper[0]);
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith([]);
+    expect(onChange).toHaveBeenCalledWith(items.map((entry) => entry.value));
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- A few sentences describing the overall goals of the pull request's commit. -->

- when a child checkbox is `partial`, the parent checkbox should be `partial` as well
- change the toggle order to partial checkbox. in master it goes `partial -> false -> true -> partial`, now it is changed to `partial -> true -> false -> partial`

## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
<!--- Include details of your testing environment, and the tests you ran to -->

## Screenshots (if appropriate):
