### PR TITLE
v33.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "32.6.4",
+  "version": "33.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "32.6.4",
+      "version": "33.0.0",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "32.6.4",
+  "version": "33.0.0",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [2411c4d18e62d6fb64dabf800db1994781afa08e] refactor: update rich text editor
 
- [5d524db5ffa5899c02f797da3eb53f576d5e2af9] fix: allow checkbox group within radio group
 
- [1dfebcf0c9ce8571230d4dddcf1760118863ad5e] fix: use cancelButton prop on action panel
 
- [f30ba8a8b3543d97d3c9382eaf578923a68ecd44] build(deps): bump dns-packet from 5.3.1 to 5.4.0
 
	


	Bumps [dns-packet](https://github.com/mafintosh/dns-packet) from 5.3.1 to 5.4.0.


	- [Release notes](https://github.com/mafintosh/dns-packet/releases)


	- [Changelog](https://github.com/mafintosh/dns-packet/blob/master/CHANGELOG.md)


	- [Commits](https://github.com/mafintosh/dns-packet/compare/v5.3.1...5.4.0)


	


	---


	updated-dependencies:


	- dependency-name: dns-packet


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [558173b7c6ddad74a28160ee357484c4332b6a54] feat: rewrite Paragraph to use RichTextEditor methods
 
- [8bb60a0ffb45a1eac288c9b454983f1c974ce238] chore: remove src/lib folder
 
- [367f7b28881949f50a9c72945c8c051036bdec01] build: release major version 33.0.0
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v32.6.4...v33.0.0