### PR TITLE
fix: rich text truncation

### DIFF
--- a/src/components/RichTextEditor/index.spec.jsx
+++ b/src/components/RichTextEditor/index.spec.jsx
@@ -468,5 +468,11 @@ describe('<RichTextEditor />', () => {
       const { getByTestId } = render(<Component briefCharCount={16} text="<p>abcdefghijklmnop</p><p>q</p>" />);
       expect(getByTestId('test').innerHTML).toEqual(`<p>abcdefghijklmnop...</p>`);
     });
+    it('should retain inline styles', () => {
+      const { getByTestId } = render(
+        <Component briefCharCount={16} text="<p>abcdefgh<strong>ijkl</strong>mnopq</p>" />
+      );
+      expect(getByTestId('test').innerHTML).toEqual(`<p>abcdefgh<strong>ijkl</strong>mnop...</p>`);
+    });
   });
 });


### PR DESCRIPTION
Fix RichText `useTruncateState` so it doesn't remove inline styles from the truncated block

## Description
Inline styles are removed from the block being truncated by the `removeRange` modifier, 
This PR retains the inline styles by setting the text on the block itself instead of using a Selection.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


Before:
![Kapture 2023-03-14 at 15 39 21](https://user-images.githubusercontent.com/13904763/224895005-ba028ef9-0851-4461-a6ad-ead7ab4d6605.gif)

After:
![Kapture 2023-03-14 at 15 40 01](https://user-images.githubusercontent.com/13904763/224894981-750f88af-52ae-4973-8f57-46698d5ee84e.gif)
