### PR TITLE
v33.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "33.0.2",
+  "version": "33.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "33.0.2",
+      "version": "33.0.3",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "33.0.2",
+  "version": "33.0.3",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [d368c5fbff0eae487cbf3dd9166eb8ad31256ae9] build(deps-dev): bump webpack from 5.75.0 to 5.76.0
 
	


	Bumps [webpack](https://github.com/webpack/webpack) from 5.75.0 to 5.76.0.


	- [Release notes](https://github.com/webpack/webpack/releases)


	- [Commits](https://github.com/webpack/webpack/compare/v5.75.0...v5.76.0)


	


	---


	updated-dependencies:


	- dependency-name: webpack


	  dependency-type: direct:development


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [310ecbcc43d9bb10230b3ac8d3dbb8eb556bc9a2] chore(deps): update dependency babel-loader to ^9.1.2
 
- [8aa960525d6bc8927be9399c2012cab51ea173d6] chore(deps): update dependency css-loader to ^6.7.3
 
- [ca2994cea24a5136a91ae1ee5262b2ea125c12ce] chore(deps): update dependency glob to ^8.1.0
 
- [6f83836955587a6b82ef06fc65c8b35c58114e4d] chore(deps): update dependency husky to ^8.0.3
 
- [1eaff8ec32ea8f8d1dc684649b83586156720541] chore(deps): update dependency prettier to ^2.8.7
 
- [5b270fb84ab14fe518fd8099bfb422519d122799] chore(deps): update dependency stylelint-config-prettier to ^9.0.5
 
- [87e49ae417535c13b788cbc911c4472bcae78304] chore(deps): update postcss
 
- [08442a42124334af9b74819db0cec43c25a004c1] chore(deps): update webpack
 
- [d80f5bd784f49ac31e9a98cfd5e426ed748cfeeb] fix(deps): update dependency react-toastify to ^9.1.2
 
- [d6b50c6d37894c5ab88804a645cb84578b44cc36] chore(deps): update babel monorepo
 
- [3a267eeb13a936a6a19f31f76ea6e7106970b0e0] chore(deps): update commitlint monorepo
 
- [18afc8e3428e63b2eca312262d2fd8c7a26c1cd0] chore(deps): update dependency axios to ^1.3.5
 
- [c31ebc7f7aac61cbe8ecca66fc41110a1dc61db7] chore(deps): update dependency react-router-dom to ^6.10.0
 
- [2388e76ee18a266c8c9a1615108c139bcee37670] fix(deps): update dependency @types/react-datepicker to ^4.10.0
 
- [092120deff8a74abe089ab8fceca7873e04bd6bd] fix(deps): update dependency react-datepicker to ^4.11.0
 
- [30438fe9af90d6201ab370f5deda98edb00e3a8b] chore(deps): update dependency lint-staged to ^13.2.1
 
- [7b322baf61224218960ff3d25d87ec987561b3fc] chore(deps): update dependency eslint to ^8.38.0
 
- [bfbe10bb0ebc7999ef931518fea51f20de2b03db] chore(deps): update dependency mini-css-extract-plugin to ^2.7.5
 
- [111d78774dfa62e07508b47beecd800bc7cdd8f5] chore(deps): update dependency commander to v10
 
- [2b7608d2a1dc159a5124b92e6b5de9098ba2083e] chore(deps): update dependency stylelint to ^14.16.1
 
- [0a36742bc0dc0fe02b6e8133c836629c12e06486] chore(deps): update dependency core-js to ^3.30.0
 
- [4c6c2f266fc0e2f4f8000bf8e11eb38605505dcd] chore(deps): update dependency style-loader to ^3.3.2
 
- [b58e7744a776336956bc653bff273acd47f5dcb6] chore(deps): update dependency babel-plugin-inline-react-svg to ^2.0.2
 
- [fc09c9f094e91cd744a64c5475a9b95a2cf02426] chore(deps): update dependency postcss-preset-env to v8
 
- [1c967b5474b2ad9debc67385ebdd16871cc5b471] chore(deps): update dependency style-dictionary to ^3.7.2
 
- [132e006fd1bca4a777d0586b3a76c34097862a79] chore: uninstall autoprefixer
 
- [f0276349877e211c634dc970c50c105ad90502c3] fix(deps): update dependency react-select to ^5.7.2
 
- [4df0a8cd21adabad579b042479df7d68f17500c6] chore(deps): update dependency eslint-config-adslot to ^1.5.1
 
- [9ddbc0536c879b2d2dbdb05764787f1453dde4a2] chore(deps): update dependency css-minimizer-webpack-plugin to v5
 
- [d8ec47a0b5ac10c30798d7c25afef1d46bef39c0] build: release patch version 33.0.3
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v33.0.2...v33.0.3