### PR TITLE
docs: add storybook addons for accessibility

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,7 +4,12 @@ import svgr from 'vite-plugin-svgr';
 
 const config: StorybookConfig = {
   stories: ['../www/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    '@storybook/addon-a11y',
+  ],
   framework: {
     name: '@storybook/react-vite',
     options: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@babel/preset-react": "^7.22.5",
         "@commitlint/cli": "^17.6.6",
         "@commitlint/config-conventional": "^17.6.6",
+        "@storybook/addon-a11y": "^7.0.27",
         "@storybook/addon-essentials": "^7.0.27",
         "@storybook/addon-interactions": "^7.0.27",
         "@storybook/addon-links": "^7.0.27",
@@ -6489,6 +6490,43 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.0.27.tgz",
+      "integrity": "sha512-S26bgFMhKa6AxyPqVyO51SOfO5MStzInHebOcqUtHYs1Npz1MMM80A4YuF8KVvcu4WAFdvdIA4gI/47djrN+sA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addon-highlight": "7.0.27",
+        "@storybook/channels": "7.0.27",
+        "@storybook/client-logger": "7.0.27",
+        "@storybook/components": "7.0.27",
+        "@storybook/core-events": "7.0.27",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "7.0.27",
+        "@storybook/preview-api": "7.0.27",
+        "@storybook/theming": "7.0.27",
+        "@storybook/types": "7.0.27",
+        "axe-core": "^4.2.0",
+        "lodash": "^4.17.21",
+        "react-resize-detector": "^7.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@storybook/addon-actions": {
@@ -26040,6 +26078,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-resize-detector": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
+      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.10.0.tgz",
@@ -35459,6 +35510,27 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "@storybook/addon-a11y": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.0.27.tgz",
+      "integrity": "sha512-S26bgFMhKa6AxyPqVyO51SOfO5MStzInHebOcqUtHYs1Npz1MMM80A4YuF8KVvcu4WAFdvdIA4gI/47djrN+sA==",
+      "dev": true,
+      "requires": {
+        "@storybook/addon-highlight": "7.0.27",
+        "@storybook/channels": "7.0.27",
+        "@storybook/client-logger": "7.0.27",
+        "@storybook/components": "7.0.27",
+        "@storybook/core-events": "7.0.27",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "7.0.27",
+        "@storybook/preview-api": "7.0.27",
+        "@storybook/theming": "7.0.27",
+        "@storybook/types": "7.0.27",
+        "axe-core": "^4.2.0",
+        "lodash": "^4.17.21",
+        "react-resize-detector": "^7.1.2"
       }
     },
     "@storybook/addon-actions": {
@@ -49749,6 +49821,15 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "react-resize-detector": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
+      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      }
     },
     "react-router": {
       "version": "6.10.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@babel/preset-react": "^7.22.5",
     "@commitlint/cli": "^17.6.6",
     "@commitlint/config-conventional": "^17.6.6",
+    "@storybook/addon-a11y": "^7.0.27",
     "@storybook/addon-essentials": "^7.0.27",
     "@storybook/addon-interactions": "^7.0.27",
     "@storybook/addon-links": "^7.0.27",


### PR DESCRIPTION
Adding new addons to the Storybook documentation

## Description
Installed several addons into Storybook.:

- Accessibility (provides a tab that analyses how accessible a component is)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Manual testing step?

## Screenshots (if appropriate):
### Accessibility
![image](https://github.com/Adslot/adslot-ui/assets/51687375/e9a06c29-8c84-4327-ad80-c7953264919d)
