### PR TITLE
v34.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "34.0.4",
+  "version": "34.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "34.0.4",
+      "version": "34.0.5",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "34.0.4",
+  "version": "34.0.5",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [de356628e10cc39021cfd48694f2897eceaf5164] chore: npm audit fix
 
- [ff77766b654e359a5090a10f0321f08aa61945dd] docs: fix docs font
 
- [868f93e243be20d824bf8eef92711661d03b2f43] chore: upgrade eslint config
 
- [721553b7d173feac15ff3216f2a03282a408a736] fix(deps): update dependency react-toastify to ^9.1.3
 
- [ea0b62e77197242d9cec1f06bfdd9a75ae0a4c2c] build: release patch version 34.0.5
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v34.0.4...v34.0.5