### PR TITLE
v34.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "34.0.5",
+  "version": "34.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "34.0.5",
+      "version": "34.1.0",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "34.0.5",
+  "version": "34.1.0",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [bb60201530c45caf104ec4538cb8549d3e8d1a10] ci: update missed warnings/errors check for coverage
 
- [583fd02743e72bfb10ecc4c1f8d95fda4d46950b] ci: use jest-fail-on-console to catch console warnings/errors in coverage
 
- [85a45285cea1601cab5982f43954c1d7eba4664b] fix: breadcrumb node prop type id
 
- [df2183be0ecea5d5b4b16672192fa96ead7ea64c] chore(deps): update storybook monorepo to ^7.4.2
 
- [036a8574bdbe6f2cfe30cecdbd1ec855f029d5d7] ci: add --update-notifier=false for npm ci
 
- [40567dbfb2ea3daeb17037a603345246d92eaf7d] chore(deps): update dependency babel-loader to ^9.1.3
 
- [661976c1d437166bb8ed89d52a15e05099e63839] chore(deps): update dependency rimraf to ^5.0.5
 
- [419be3a43880194f79a16188b867eaa99104cbc4] chore(deps): update dependency stylelint to ^15.10.3
 
- [76c8dd90f38d2a9bb27a769cad73d7686fb86667] chore(deps): update dependency webpack to ^5.88.2
 
- [78953c31af80ef4b665d59b221d1e93977e2005d] chore(deps): update postcss
 
- [b71981ac7e3de151df3ecb445765327022618bc4] fix(deps): update typescript
 
- [22b04befe821a87cc5ef730ab3be200ef0ec3e99] chore(deps): update commitlint monorepo
 
- [af54613b2eb0d896da60a2f629810ecca865416a] chore(deps): update dependency axios to ^1.5.1
 
- [2064b6bfd8d9809ed09a1032d729f37f7c0852f5] chore(deps): update dependency core-js to ^3.33.0
 
- [e5b283c773a89012904bda64141289018282a47a] chore(deps): update dependency react-router-dom to ^6.16.0
 
- [485aad42900d7a75e45db8e820eca2ca3ac39610] fix(deps): update dependency cropperjs to ^1.6.1
 
- [7acf66841a3703d085980e10b87136c8a0741af5] fix(deps): update dependency react-datepicker to ^4.18.0
 
- [521d48655c6b0e82802ca5279943b14e6f5ece12] chore(deps): update actions/checkout action to v4
 
- [2194860a8c8c7c67f2cc919914d9a2ec6c2265c7] chore(deps): update dependency lint-staged to v14
 
- [3cf4ae53429507d20aa6083a1450b10466ba630f] chore(deps): update dependency stylelint-config-standard to v34
 
- [03bd478235705d99b9016528b7399b5d73a0307e] chore(deps): update storybook monorepo to ^7.4.5
 
- [6558e48ce113c3067aeb51b452bd98662f9ceb6e] chore(deps): update babel monorepo
 
- [3caf67d890c8dadffe569d01442a06e39eade2eb] chore(deps): update testing-library
 
- [15347387e16651b8dc132925e07fb16b43c07ae1] chore(deps): update jest
 
- [4fd061fe6ba9bf701d5293ece3fe99c8a4ff9fff] chore(deps): update dependency @storybook/testing-library to ^0.2.2
 
- [3fea12e0b8291546c85e3a2fc88dd459f3212197] chore(deps): update dependency prettier to v3
 
- [b691440cca735b91d2e729abbcbc5bbce849ed95] chore: npm audit fix @adobe/css-tools
 
- [13d9762189063f1b6da9425f3fd0834a59b0dfc7] chore(deps): update eslint
 
- [74467c402afba72a2d7c213fc347369b0f09d3df] chore(deps): update dependency @testing-library/jest-dom to v6
 
- [6e93523d851960bc5816ebb83ae1ce2de628e812] chore(deps): update dependency vite-plugin-svgr to v4
 
- [b4fbe85d19fe0d0074d5df6807cdf72bd14afa09] fix(deps): update dependency react-select to ^5.7.7
 
- [46ed195f94baeb85827fc9639f44ea0b85652682] chore: remove url-search-params-polyfill
 
- [6bd20cff6c81a71608e85d3bc690a66ad61c3ec2] fix(deps): update draft-js
 
- [55acd30b1a456661c4fdb4f70598a8665b59ee9f] build: release minor version 34.1.0
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v34.0.5...v34.1.0