### PR TITLE
v34.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "34.1.0",
+  "version": "34.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "34.1.0",
+      "version": "34.2.0",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "34.1.0",
+  "version": "34.2.0",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [a75d6d801018e0148c621f612ebb6022e60ab58f] feat: add new TreePicker
 
- [c266406d48f24557eb466e3331db597f450edb57] docs: fix tree picker docs
 
- [de8d7b6589ac1b5f640a16a92d16c8e2c4669e37] test: fix tests
 
- [dcbf667ddef64b083f18347a4e4516d9cfd09805] fix: add dts to tree picker
 
- [243336e4f3fe001aa1de3cf99c2be4a8ee9ffd75] build(deps): bump @babel/traverse from 7.23.0 to 7.23.2
 
	


	Bumps [@babel/traverse](https://github.com/babel/babel/tree/HEAD/packages/babel-traverse) from 7.23.0 to 7.23.2.


	- [Release notes](https://github.com/babel/babel/releases)


	- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)


	- [Commits](https://github.com/babel/babel/commits/v7.23.2/packages/babel-traverse)


	


	---


	updated-dependencies:


	- dependency-name: "@babel/traverse"


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [1dd7a3c2552ccaf3d58dc07fec8da50dd88290a2] build: release minor version 34.2.0
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v34.1.0...v34.2.0