### PR TITLE
v34.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "34.3.0",
+  "version": "34.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "34.3.0",
+      "version": "34.3.1",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "34.3.0",
+  "version": "34.3.1",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [125e86946e8787beb49c7cbded4ec93a0bfded3e] fix: fix icons on rich text editor component
 
- [1f509ce7586d3aa7a1016f70ca1fe380d11ece2f] chore(deps): update dependency axios to ^1.6.0 [security]
 
- [e0c0e5728d2037611d9e605f4b12b28b989a616b] chore(deps): update dependency axios to ^1.6.1
 
- [a79b770b7c28fe113d8a0dd4016b76eed67e4d44] chore(deps): update actions/setup-node action to v4
 
- [c95728dafd95487d21127f9303474d5cd9c673fa] build(deps-dev): bump @adobe/css-tools from 4.3.1 to 4.3.2
 
	


	Bumps [@adobe/css-tools](https://github.com/adobe/css-tools) from 4.3.1 to 4.3.2.


	- [Changelog](https://github.com/adobe/css-tools/blob/main/History.md)


	- [Commits](https://github.com/adobe/css-tools/commits)


	


	---


	updated-dependencies:


	- dependency-name: "@adobe/css-tools"


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [c9822e468eda947769a1cd6f8d42e704983def98] build(deps-dev): bump vite from 4.4.3 to 4.5.1
 
	


	Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 4.4.3 to 4.5.1.


	- [Release notes](https://github.com/vitejs/vite/releases)


	- [Changelog](https://github.com/vitejs/vite/blob/v4.5.1/packages/vite/CHANGELOG.md)


	- [Commits](https://github.com/vitejs/vite/commits/v4.5.1/packages/vite)


	


	---


	updated-dependencies:


	- dependency-name: vite


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [32471f3ba03ee4ee31f17b193c9be333bc0cc72b] chore(deps): update dependency axios to ^1.6.2
 
- [041d9fba8b676665c1627b08fe5a438b404e9758] chore(deps): update dependency lint-staged to v15
 
- [6925a28da47a34895ab1b7fb052426c8c426ffab] chore(deps): update dependency commander to ^11.1.0
 
- [4221ff36575ce992a901615adc847c2b531239a7] chore(deps): update dependency prettier to ^3.1.0
 
- [41fc2ea0b8d6155cdbc854aaac84551ad1bbf26d] chore(deps): update dependency stylelint to ^15.11.0
 
- [50cc1559eb80cf84de24d2c0bdf67d12bf24e08c] chore(deps): update commitlint monorepo to v18
 
- [62cc35e7cf8b4d4f2423dd2426da0e72693891e7] chore(deps): update babel monorepo
 
- [ab9324cc916b1370cabb4d54f5f0154bfa176b53] chore(deps): update dependency babel-plugin-transform-remove-imports to ^1.7.1
 
- [05ff29f3b5e17ad17295bbf83dd434aa4a583717] chore(deps): update dependency core-js to ^3.33.3
 
- [c3ed4404af52b3366d322068eb206362e712ac40] chore(deps): update postcss
 
- [caf01f8476b603a89cbe75e142a93568a3edf14e] chore(deps): update testing-library
 
- [53d94acfbd901ab196e82bdb3afa46d7480ace3d] chore(deps): update jest
 
- [891165b0a4b45b5a49e3d83caa9a3a45f8ca8a1f] chore(deps): update webpack
 
- [6156848469157fa3f33854ed0e691ca0519dfd93] fix(deps): update typescript
 
- [ba8582899b0f8d5df93442d68e3155ac806769a4] chore(deps): update dependency style-dictionary to ^3.9.0
 
- [eb23b5c29387483d9739f49907fc84d8d65b4e93] chore(deps): update dependency postcss-safe-parser to v7
 
- [113ad5c586909df0206a79325b575a8bd05a5271] build(deps-dev): bump follow-redirects from 1.15.2 to 1.15.4
 
	


	Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.15.2 to 1.15.4.


	- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)


	- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.4)


	


	---


	updated-dependencies:


	- dependency-name: follow-redirects


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [9dbe023367184e0b5c2ee8b3babe073084f1a67c] chore: upgrade eslint config
 
- [c8899a37052118102742321618caa326f9829893] build: release patch version 34.3.1
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v34.3.0...v34.3.1