### PR TITLE
fix: debug interval not working in Search component

### DIFF
--- a/src/components/Search/index.jsx
+++ b/src/components/Search/index.jsx
@@ -59,10 +59,10 @@ const Search = React.forwardRef(
       }
     };
 
-    const onInputSearch = (searchValue) => {
-      const search = debounceInterval ? _.debounce(onSearch, debounceInterval) : onSearch;
-      search(searchValue);
-    };
+    const onInputSearch = React.useMemo(
+      () => _.debounce((searchValue) => onSearch(searchValue), debounceInterval),
+      [debounceInterval, onSearch]
+    );
 
     const onSearchButtonClick = (event) => {
       event.preventDefault();

--- a/src/components/Search/index.spec.jsx
+++ b/src/components/Search/index.spec.jsx
@@ -190,17 +190,34 @@ describe('Value Changed', () => {
     expect(callbacks.onSearch).toHaveBeenCalledWith('v');
   });
 
-  it('should fire onSearch after debounceInterval', async () => {
+  it('should fire onSearch immediately when debounceInterval is not set', async () => {
     const callbacks = {
       onSearch: jest.fn(),
     };
-    render(<Search {...callbacks} debounceInterval={500} />);
+    render(<Search {...callbacks} />);
 
     await user.type(screen.getByTestId('search-input'), 'new-value');
-    expect(callbacks.onSearch).not.toHaveBeenCalledWith('new-value');
 
-    await sleep(500);
     expect(callbacks.onSearch).toHaveBeenCalledWith('new-value');
+  });
+
+  it('should debounce onSearch calls when debounceInterval is set', async () => {
+    const callbacks = {
+      onSearch: jest.fn(),
+    };
+    render(<Search {...callbacks} debounceInterval={200} />);
+
+    await user.type(screen.getByTestId('search-input'), 'n');
+    await user.type(screen.getByTestId('search-input'), 'e');
+    await user.type(screen.getByTestId('search-input'), 'w');
+    expect(callbacks.onSearch).not.toHaveBeenCalledWith('n');
+    expect(callbacks.onSearch).not.toHaveBeenCalledWith('ne');
+    expect(callbacks.onSearch).not.toHaveBeenCalledWith('new');
+
+    await sleep(200);
+    expect(callbacks.onSearch).not.toHaveBeenCalledWith('n');
+    expect(callbacks.onSearch).not.toHaveBeenCalledWith('ne');
+    expect(callbacks.onSearch).toHaveBeenCalledWith('new');
   });
 
   it('should not fire onSearch when value changed if searchOnEnter is true', async () => {


### PR DESCRIPTION
## Description

Noticed that debounce interval is not working in Search Component while i was investigating E2E error in Adslot platform ([ADS-8876](https://adslot.atlassian.net/browse/ADS-8876) and https://github.com/Adslot/direct-web/pull/15879)

Seems like it has been broken for a few years since [Adslot/adslot-ui#1048](https://github.com/Adslot/adslot-ui/pull/1048/files#diff-2b51c00387be99bb8a5d2b1edd3ad7ea5f5f65748eba2994f390b6c3e72439b7R57)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Manual testing step?

## Screenshots (if appropriate):


[ADS-8876]: https://adslot.atlassian.net/browse/ADS-8876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ