### PR TITLE
v34.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "34.3.1",
+  "version": "34.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "34.3.1",
+      "version": "34.3.2",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "34.3.1",
+  "version": "34.3.2",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [266ee59f84de3df4e4b9c4f934d6570740ff1e8a] build(deps-dev): bump vite from 4.5.1 to 4.5.2
 
	


	Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 4.5.1 to 4.5.2.


	- [Release notes](https://github.com/vitejs/vite/releases)


	- [Changelog](https://github.com/vitejs/vite/blob/v4.5.2/packages/vite/CHANGELOG.md)


	- [Commits](https://github.com/vitejs/vite/commits/v4.5.2/packages/vite)


	


	---


	updated-dependencies:


	- dependency-name: vite


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [aefacab86ca002d2b3d6ec013e2d07056835eeb4] fix: debug interval not working in Search component
 
- [86e6e05ccc313b22c5a696d240df903f04261dd6] build: release patch version 34.3.2
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v34.3.1...v34.3.2