### PR TITLE
v34.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "34.3.3",
+  "version": "34.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "34.3.3",
+      "version": "34.3.4",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "34.3.3",
+  "version": "34.3.4",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [ec6be54c621ab5b8bd10e565dce0a301de5d5f5d] chore(deps): update dependency commander to v12
 
- [318a579b5e95f9acaad9e120b5552b3bb9f22c93] fix: fix deprecated commander usage
 
- [39bdb1b296cc7292c29db2c9b63b4696e0cbbf28] build(deps-dev): bump ejs from 3.1.9 to 3.1.10
 
	


	Bumps [ejs](https://github.com/mde/ejs) from 3.1.9 to 3.1.10.


	- [Release notes](https://github.com/mde/ejs/releases)


	- [Commits](https://github.com/mde/ejs/compare/v3.1.9...v3.1.10)


	


	---


	updated-dependencies:


	- dependency-name: ejs


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [2560d5d17af9e43009914c2cc14ae23554bf02b6] fix: radio group prop types
 
- [07ed5676507f57a4e8057f61560d0c2c21f18ced] build: release patch version 34.3.4
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v34.3.3...v34.3.4