### PR TITLE
v34.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "34.3.4",
+  "version": "34.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "34.3.4",
+      "version": "34.3.5",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "34.3.4",
+  "version": "34.3.5",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [9ae6cffc651cb26374a6d00d5ce5a747f0596efb] build(deps-dev): bump braces from 3.0.2 to 3.0.3
 
	


	Bumps [braces](https://github.com/micromatch/braces) from 3.0.2 to 3.0.3.


	- [Changelog](https://github.com/micromatch/braces/blob/master/CHANGELOG.md)


	- [Commits](https://github.com/micromatch/braces/compare/3.0.2...3.0.3)


	


	---


	updated-dependencies:


	- dependency-name: braces


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [ffe5540a7c692705d335f8fa21e9a130589a682f] build(deps-dev): bump ws from 6.2.2 to 6.2.3
 
	


	Bumps [ws](https://github.com/websockets/ws) from 6.2.2 to 6.2.3.


	- [Release notes](https://github.com/websockets/ws/releases)


	- [Commits](https://github.com/websockets/ws/compare/6.2.2...6.2.3)


	


	---


	updated-dependencies:


	- dependency-name: ws


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [7058bcd269e3099008b3dd88ce8bc40cca95d6cf] fix: upgrade react-datepicker
 
- [39fe4204b148acd6a17a1094a869cc2c7217605b] chore: remove types no longer used
 
- [b64ae7baac8768d9788723d7e8f5fa69f6e10ea1] build: release patch version 34.3.5
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v34.3.4...v34.3.5