### PR TITLE
v35.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "35.0.0",
+  "version": "35.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "35.0.0",
+      "version": "35.0.1",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "35.0.0",
+  "version": "35.0.1",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [ff9fe31467a5096e8d48122077cbdc719ff3c247] build(deps): bump vite from 4.5.3 to 4.5.5 in the npm_and_yarn group
 
	


	Bumps the npm_and_yarn group with 1 update: [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite).


	


	


	Updates `vite` from 4.5.3 to 4.5.5


	- [Release notes](https://github.com/vitejs/vite/releases)


	- [Changelog](https://github.com/vitejs/vite/blob/v4.5.5/packages/vite/CHANGELOG.md)


	- [Commits](https://github.com/vitejs/vite/commits/v4.5.5/packages/vite)


	


	---


	updated-dependencies:


	- dependency-name: vite


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [5cc34bf959a37ee9ea7f8cbdbb1c396c5ebdce3c] build(deps): bump rollup from 3.29.4 to 3.29.5 in the npm_and_yarn group
 
	


	Bumps the npm_and_yarn group with 1 update: [rollup](https://github.com/rollup/rollup).


	


	


	Updates `rollup` from 3.29.4 to 3.29.5


	- [Release notes](https://github.com/rollup/rollup/releases)


	- [Changelog](https://github.com/rollup/rollup/blob/master/CHANGELOG.md)


	- [Commits](https://github.com/rollup/rollup/compare/v3.29.4...v3.29.5)


	


	---


	updated-dependencies:


	- dependency-name: rollup


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [d0edacd80162060297237435ed61a6b6c96acc2c] fix: resolve cookie dependabot alert
 
- [fd34c1f7dfdf073046efab7bea653b11408462f6] chore(deps): update dependency axios to ^1.7.7
 
- [852d4776e558f23a294db7cb7ecb30737ee50635] chore(deps): update dependency jest-fail-on-console to ^3.3.1
 
- [62311f233f79cfb4c181911f31de41ca04ac0ef5] chore(deps): update eslint
 
- [6e84f749f7b3159c172b08f1e631609b9af31175] chore(deps): update postcss
 
- [d647a4c0655152ccb1879c5fa7efb33c87ac36cf] fix(deps): update dependency react-select to ^5.8.1
 
- [a3c0a9b9f2a5d5339ef8078d148690650130e4f1] fix(deps): update typescript
 
- [c207836158f57cf6ba98e60facb475a0b8c5d61f] chore(deps): update babel monorepo to ^7.25.7
 
- [07a92c7c71f67126576896223ad0859e74f904c1] chore(deps): update dependency core-js to ^3.38.1
 
- [321646972296e60c9fd3ea60abddbccdf5d39215] chore(deps): update testing-library
 
- [21cf55aa346f2eb6a7e6296f351ba8df82395f47] chore(deps): update webpack
 
- [01716cd7cf162ac15f2e15d6003a4fc484e7a547] fix(deps): update dependency react-datepicker to ^7.4.0
 
- [8074035d4775f5dda74e1f0d233feaf56a8df8a0] chore(deps): update dependency rimraf to v6
 
- [5737f3103ce057d908e9a5dd85f9aecc06375f06] chore(deps): update dependency postcss-preset-env to v10
 
- [0f9f3ad57f2cb6c065da672a3ffc17aa52e27e2f] chore(deps): update devdeps
 
- [19fefa3f03ad49a6f9c15658c1acab957e573781] chore(deps): update dependency glob to v11
 
- [1693975754787bc81662c907106ec471fb184f1e] chore: remove babel-plugin-istanbul from top level dep
 
- [54064c2d094045f2930bd1386535c0c848c9cbce] fix(deps): update dependency ryze to ^0.1.5
 
- [c790355b3397bea62858935143744dd575572c71] build: release patch version 35.0.1
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v35.0.0...v35.0.1