### PR TITLE
v35.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "35.0.1",
+  "version": "35.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "35.0.1",
+      "version": "35.0.2",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "35.0.1",
+  "version": "35.0.2",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [de6f45bed71d6dafb4153a10159d4a1c42c5abb9] fix: add readOnly rte state
 
- [38b7d17266403e27dfd61663f1e2c00355824ecb] build(deps): bump markdown-to-jsx in the npm_and_yarn group
 
	


	Bumps the npm_and_yarn group with 1 update: [markdown-to-jsx](https://github.com/quantizor/markdown-to-jsx).


	


	


	Updates `markdown-to-jsx` from 7.2.1 to 7.5.0


	- [Release notes](https://github.com/quantizor/markdown-to-jsx/releases)


	- [Changelog](https://github.com/quantizor/markdown-to-jsx/blob/main/CHANGELOG.md)


	- [Commits](https://github.com/quantizor/markdown-to-jsx/compare/v7.2.1...v7.5.0)


	


	---


	updated-dependencies:


	- dependency-name: markdown-to-jsx


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [a55114f774e1095a5c622ea64fd8587f9602eec7] build: release patch version 35.0.2
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v35.0.1...v35.0.2