### PR TITLE
v35.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "35.0.2",
+  "version": "35.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "35.0.2",
+      "version": "35.1.0",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "35.0.2",
+  "version": "35.1.0",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [8bde1bc2d4c79f3f11a5d4acf81d71b9a2e560f0] chore: upgrade to node 22
 
- [9145c800e1f32177aab669a64ab431558a0825ae] chore: run npm audit fix
 
- [ef632c8df93c106f25159b84a6439c4b66e53b84] chore: upgrade eslint-config-adslot to 1.9.0
 
- [e8f0c97204deeff4adc9287ed3de87e195e96f4e] build: release minor version 35.1.0
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v35.0.2...v35.1.0