### PR TITLE
feat: add unexpandable message support to treePicker pure node

### DIFF
--- a/src/components/TreePickerSimplePure/Grid/index.d.ts
+++ b/src/components/TreePickerSimplePure/Grid/index.d.ts
@@ -4,6 +4,7 @@ export interface TreePickerGridNodes {
   id?: any;
   label: string;
   isExpandable?: boolean;
+  unExpandableMessage?: string;
   path?: {
     id?: any;
     label: string;

--- a/src/components/TreePickerSimplePure/Node/index.jsx
+++ b/src/components/TreePickerSimplePure/Node/index.jsx
@@ -90,26 +90,36 @@ class TreePickerNode extends React.PureComponent {
               </ConditionalPopoverWrapper>
             </GridCell>
           ) : null}
+
           <GridCell stretch {...labelCellProps} dts="label">
-            <TextEllipsis
-              popoverProps={{
-                strategy: 'fixed',
-                placement: 'bottom',
-                modifiers: [
-                  { name: 'flip', enabled: false },
-                  { name: 'preventOverflow', enabled: false },
-                  { name: 'hide', enabled: false },
-                ],
-              }}
+            <ConditionalPopoverWrapper
+              condition={!isExpandable && !_.isNil(node.unExpandableMessage)}
+              wrapper={(children) => (
+                <Popover theme="dark" placement="top" trigger="hover" popoverContent={node.unExpandableMessage}>
+                  {children}
+                </Popover>
+              )}
             >
-              <span>{nodeRenderer(node)}</span>
-              {!_.isEmpty(pathElement) ? (
-                <span className={`${baseClass}-metadata`}>
-                  ({pathPrefix(node)}
-                  {pathElement})
-                </span>
-              ) : null}
-            </TextEllipsis>
+              <TextEllipsis
+                popoverProps={{
+                  strategy: 'fixed',
+                  placement: 'bottom',
+                  modifiers: [
+                    { name: 'flip', enabled: false },
+                    { name: 'preventOverflow', enabled: false },
+                    { name: 'hide', enabled: false },
+                  ],
+                }}
+              >
+                <span>{nodeRenderer(node)}</span>
+                {!_.isEmpty(pathElement) ? (
+                  <span className={`${baseClass}-metadata`}>
+                    ({pathPrefix(node)}
+                    {pathElement})
+                  </span>
+                ) : null}
+              </TextEllipsis>
+            </ConditionalPopoverWrapper>
           </GridCell>
 
           {isExpandable ? (

--- a/src/components/TreePickerSimplePure/Node/index.spec.jsx
+++ b/src/components/TreePickerSimplePure/Node/index.spec.jsx
@@ -7,7 +7,16 @@ import TreePickerMocks from '../mocks';
 
 jest.mock('../../../invariant');
 
-const { cbrNode, cbrNodeAlreadySelected, actNode, maleNode, itemType, nodeRenderer } = TreePickerMocks;
+const {
+  cbrNode,
+  cbrNodeAlreadySelected,
+  cbrNodeAlreadySelectedUnExpandable,
+  cbrNodeAlreadySelectedUnExpandableWithoutMessage,
+  actNode,
+  maleNode,
+  itemType,
+  nodeRenderer,
+} = TreePickerMocks;
 
 it('should render a node with defaults', () => {
   render(<TreePickerNode itemType={itemType} node={cbrNode} includeNode={jest.fn()} removeNode={jest.fn()} />);
@@ -44,6 +53,38 @@ it('should render metadata of nodes already selected containing ancestory data',
   expect(screen.getAllByClass('treepickernode-component-metadata')).toHaveLength(1);
   expect(screen.getByClass('treepickernode-component-metadata')).toHaveTextContent('(City in ACT, AU)');
   expect(screen.getByText('ACT, AU')).toHaveClass('treepickernode-component-path');
+});
+
+it('should render unExpandable message correctly', async () => {
+  render(
+    <TreePickerNode
+      itemType={itemType}
+      node={cbrNodeAlreadySelectedUnExpandable}
+      includeNode={jest.fn()}
+      removeNode={jest.fn()}
+    />
+  );
+
+  await user.hover(screen.getByText('Canberra'));
+
+  expect(screen.getAllByClass('treepickernode-component-metadata')).toHaveLength(1);
+  expect(screen.getByText('This node is unExpandable')).toBeInTheDocument();
+});
+
+it('should not fail when unExpandable message is not added for unExpandable node', async () => {
+  render(
+    <TreePickerNode
+      itemType={itemType}
+      node={cbrNodeAlreadySelectedUnExpandableWithoutMessage}
+      includeNode={jest.fn()}
+      removeNode={jest.fn()}
+    />
+  );
+
+  await user.hover(screen.getByText('Canberra'));
+
+  expect(screen.getAllByClass('treepickernode-component-metadata')).toHaveLength(1);
+  expect(screen.queryByText('This node is unExpandable')).not.toBeInTheDocument();
 });
 
 it('should render node via nodeRenderer', () => {

--- a/src/components/TreePickerSimplePure/index.d.ts
+++ b/src/components/TreePickerSimplePure/index.d.ts
@@ -9,6 +9,7 @@ export interface TreePickerSimplePureSelectedNodes {
   id?: any;
   label: string;
   isExpandable?: boolean;
+  unExpandableMessage?: string;
   path?: {
     id?: any;
     label: string;
@@ -26,6 +27,7 @@ export interface TreePickerSimplePureSubtree {
   id?: any;
   label: string;
   isExpandable?: boolean;
+  unExpandableMessage?: string;
   path?: {
     id?: any;
     label: string;

--- a/src/components/TreePickerSimplePure/mocks.js
+++ b/src/components/TreePickerSimplePure/mocks.js
@@ -64,6 +64,29 @@ const cbrNodeAlreadySelected = {
   isExpandable: true,
 };
 
+const cbrNodeAlreadySelectedUnExpandable = {
+  id: 'au-act-cbr',
+  label: 'Canberra',
+  type: 'City',
+  ancestors: [actPath, auPath],
+  path: [],
+  value: 2000,
+  rootTypeId: 'a',
+  isExpandable: false,
+  unExpandableMessage: 'This node is unExpandable',
+};
+
+const cbrNodeAlreadySelectedUnExpandableWithoutMessage = {
+  id: 'au-act-cbr',
+  label: 'Canberra',
+  type: 'City',
+  ancestors: [actPath, auPath],
+  path: [],
+  value: 2000,
+  rootTypeId: 'a',
+  isExpandable: false,
+};
+
 const maleNode = {
   id: 4,
   label: 'Males',
@@ -87,6 +110,8 @@ const TreePickerMocks = immutable({
   baseItem,
   cbrNode,
   cbrNodeAlreadySelected,
+  cbrNodeAlreadySelectedUnExpandable,
+  cbrNodeAlreadySelectedUnExpandableWithoutMessage,
   initialSelection,
   itemType,
   maleNode,

--- a/src/prop-types/TreePickerPropTypes.js
+++ b/src/prop-types/TreePickerPropTypes.js
@@ -6,6 +6,7 @@ export const TreePickerPropTypesNode = PropTypes.shape({
   id: idPropType.isRequired,
   label: PropTypes.string.isRequired,
   isExpandable: PropTypes.bool,
+  unExpandableMessage: PropTypes.string,
   path: PropTypes.arrayOf(
     PropTypes.shape({ id: idPropType.isRequired, label: PropTypes.string.isRequired }).isRequired
   ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
UnExpandable nodes should support popover text message which is currently not available.


## Does this PR introduce a breaking change?
<!--- If this PR contains a breaking change, please describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Manual testing step?
- Add `IsExpandable= false and unExpandableMessage={some_string}` to TreepickerPure node, and check the rendered value. 

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/6e1c0f55-37cd-48ea-930c-360ea19d7eb7)
