### PR TITLE
v35.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "35.1.0",
+  "version": "35.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "35.1.0",
+      "version": "35.1.1",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "35.1.0",
+  "version": "35.1.1",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [2c8e3ff82342c6a9493aaeb6bd6906297cabafad] chore(deps): update devdeps
 
- [fb64717e35049b022619fd7f5794c19a77cddc0e] chore(deps): update testing-library
 
- [d56a37ad9e03c32828cb9e2c114d170f312f62e6] chore(deps): update codecov/codecov-action action to v5
 
- [dac726277751282aa53e587ca45e22b19937571a] chore(deps): update dependency axios to ^1.7.9
 
- [a63811345b887e66044b8fb41e3d532f1455b974] fix: resolve punycode deprecation warning from jest-environment-jsdom
 
- [4e2aac95272481df32b98dd4b6dcc96ec5067328] build(deps): bump the npm_and_yarn group with 2 updates
 
	


	Bumps the npm_and_yarn group with 2 updates: [store2](https://github.com/nbubna/store) and [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite).


	


	


	Updates `store2` from 2.14.3 to 2.14.4


	- [Commits](https://github.com/nbubna/store/compare/2.14.3...2.14.4)


	


	Updates `vite` from 4.5.5 to 4.5.9


	- [Release notes](https://github.com/vitejs/vite/releases)


	- [Changelog](https://github.com/vitejs/vite/blob/v4.5.9/packages/vite/CHANGELOG.md)


	- [Commits](https://github.com/vitejs/vite/commits/v4.5.9/packages/vite)


	


	---


	updated-dependencies:


	- dependency-name: store2


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	- dependency-name: vite


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [e8b45b4c1aee38f2da98f498353826cfdbfb1b74] chore: upgrade eslint to v9
 
- [9a5501b5a11541110fb597f9cbe6978eb58d1427] chore(deps): update dependency eslint-config-adslot to ^2.0.1
 
- [daaf0890ae0dca4cc2b8534d3499a3e6747bf28d] chore(deps): update dependency eslint-config-adslot to ^2.0.2
 
- [4d1f556a06513d84f0bd368f7780cfc9abf6c4e5] fix: remove defaultprops
 
- [c69315385ef1709dfbef5f0cc7b02ea2a7d3bfd8] chore(deps): update dependency axios to ^1.8.2
 
- [3f056facec90dc8f1854896b6099a6a172d3057a] feat: add unexpandable message support to treePicker pure node
 
- [aff96de5605f5563669894521e9fb11f7a0ca8e9] build: release patch version 35.1.1
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v35.1.0...v35.1.1