### PR TITLE
v35.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "35.1.1",
+  "version": "35.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "35.1.1",
+      "version": "35.1.2",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "35.1.1",
+  "version": "35.1.2",
   "description": "Core component library. By Adslot",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Changes

- [28ef9e3327726bf4c3ae61dec05198a7bc2a67de] build(deps): bump the npm_and_yarn group across 1 directory with 2 updates
 
	


	Bumps the npm_and_yarn group with 2 updates in the / directory: [@babel/helpers](https://github.com/babel/babel/tree/HEAD/packages/babel-helpers) and [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime).


	


	


	Updates `@babel/helpers` from 7.25.7 to 7.26.10


	- [Release notes](https://github.com/babel/babel/releases)


	- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)


	- [Commits](https://github.com/babel/babel/commits/v7.26.10/packages/babel-helpers)


	


	Updates `@babel/runtime` from 7.23.8 to 7.26.10


	- [Release notes](https://github.com/babel/babel/releases)


	- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)


	- [Commits](https://github.com/babel/babel/commits/v7.26.10/packages/babel-runtime)


	


	---


	updated-dependencies:


	- dependency-name: "@babel/helpers"


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	- dependency-name: "@babel/runtime"


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [3d4d8df79bcfbfa1f1cbf2641a27f801b876ada1] chore: npm audit fix
 
- [bb608ccf5226e62b6792c5d55d57e079f025f18f] fix: add chalk dev dep to fix generateTypes script
 
- [083f129115916aad86bac98d30aa753672d72bb0] build(deps-dev): bump tar-fs
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [tar-fs](https://github.com/mafintosh/tar-fs).


	


	


	Updates `tar-fs` from 2.1.1 to 2.1.2


	- [Commits](https://github.com/mafintosh/tar-fs/compare/v2.1.1...v2.1.2)


	


	---


	updated-dependencies:


	- dependency-name: tar-fs


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [9ee3ec852b935b116be6ef7dcc92c655db831c56] fix: npx update-browserslist-db@latest
 
- [ccd3ee6a9452851431da8510ef6fb978eb6867af] build(deps): bump vite in the npm_and_yarn group across 1 directory
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite).


	


	


	Updates `vite` from 4.5.9 to 4.5.10


	- [Release notes](https://github.com/vitejs/vite/releases)


	- [Changelog](https://github.com/vitejs/vite/blob/v4.5.10/packages/vite/CHANGELOG.md)


	- [Commits](https://github.com/vitejs/vite/commits/v4.5.10/packages/vite)


	


	---


	updated-dependencies:


	- dependency-name: vite


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [a3f5e6101083a74277df06494daaf25f84fd1a2b] chore(deps): update dependency glob to ^11.0.1
 
- [5eccd5d70fabb84815281a84b9e2c5f5c0bd3276] chore(deps): update dependency vite-plugin-svgr to ^4.3.0
 
- [c53c8aa82762d4029290e3c79dd4268cca75f47b] chore(deps): update dependency core-js to ^3.41.0
 
- [843e70a7f7cdff3949654c57c9297457789dfc5f] chore(deps): update devdeps
 
- [aa0637dcc008dfe9410c8bf49368050364891070] chore(deps): update eslint
 
- [b90025d3ddfc7ca186ac2d907bc0e01ca611a9f3] chore(deps): update postcss
 
- [e201cb3873248f68ab6444013d155c1aa0b8d9ab] chore(deps): update babel monorepo
 
- [557b22754cb92ffa1c91d48669d3cb952d636b59] chore(deps): update testing-library
 
- [e654e4f988d4bde21adb442239cbdbf49819a934] fix(deps): update dependency react-select to ^5.10.1
 
- [b41935eaea1e90e5114a9c457b60087a9825c62e] fix: remove unneeded eslint compat deps
 
- [6ef47e5cd8ca1f4bc264734e14674d5a0bda1606] chore(deps): update webpack
 
- [b7f56510a83f9f1efd5af497673e89c114b5c178] chore(deps): update dependency axios to ^1.8.4
 
- [dfaee369b013ffe3e6b4069bfd7b121aa8251c71] chore(deps): update dependency commander to v13
 
- [27fbb7b05439b4bb75220e6f4f9c8a442cbe2026] build(deps): bump vite in the npm_and_yarn group across 1 directory
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite).


	


	


	Updates `vite` from 4.5.10 to 4.5.12


	- [Release notes](https://github.com/vitejs/vite/releases)


	- [Changelog](https://github.com/vitejs/vite/blob/v4.5.12/packages/vite/CHANGELOG.md)


	- [Commits](https://github.com/vitejs/vite/commits/v4.5.12/packages/vite)


	


	---


	updated-dependencies:


	- dependency-name: vite


	  dependency-version: 4.5.12


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [7d7f0908e6185833d5e38bc0bfb0536fc6d4d81a] chore(deps): update dependency globals to v16
 
- [0f7361ff68e12c384cc97799a0c0ec2f8086d528] chore(deps): update webpack
 
- [329f383e8bd9113c303d97add88a2c0d4b67b2b1] fix: fix missing commander from package lock
 
- [dbb8616d23eb7422b7e4e56e9aa23378bd62f8c5] chore(deps): update dependency stylelint-config-standard to v38
 
- [182663bb49953306f63abcc94150d01083ea1764] fix(deps): update dependency react-datepicker to v8
 
- [76e9f77a515a3f904dee2721711c2cf0438fda45] fix: stylelint upgrade fixes
 
- [45c740937abc6595c5e91fb7212eb9c16f83e41f] fix(deps): update dependency react-toastify to v11
 
- [5e4b9438874fe6deedf1ab87036e7330d359e153] fix: update toast styles
 
- [7c65672dcfdd7432aa732f456dee3a7f85a6a71f] fix(deps): update dependency react-slick to ^0.30.3
 
- [e88cc95af78a0827176ebd98c86ad47c09956c88] build(deps): bump vite in the npm_and_yarn group across 1 directory
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite).


	


	


	Updates `vite` from 4.5.12 to 4.5.13


	- [Release notes](https://github.com/vitejs/vite/releases)


	- [Changelog](https://github.com/vitejs/vite/blob/v4.5.13/packages/vite/CHANGELOG.md)


	- [Commits](https://github.com/vitejs/vite/commits/v4.5.13/packages/vite)


	


	---


	updated-dependencies:


	- dependency-name: vite


	  dependency-version: 4.5.13


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [3c3650caf6c8c21def33ea7bb26bbac98cc3cd57] build: release patch version 35.1.2
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v35.1.1...v35.1.2