### PR TITLE
v35.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "35.1.2",
+  "version": "35.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "35.1.2",
+      "version": "35.2.0",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "35.1.2",
+  "version": "35.2.0",
   "description": "Core component library. By Adslot",
   "type": "module",
   "main": "./dist/adslot-ui.cjs",


### PR DESCRIPTION
### Changes

- [f92b1c61314546e65c6d3645cc1540d06e3873b0] build(deps-dev): bump http-proxy-middleware
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware).


	


	


	Updates `http-proxy-middleware` from 2.0.7 to 2.0.9


	- [Release notes](https://github.com/chimurai/http-proxy-middleware/releases)


	- [Changelog](https://github.com/chimurai/http-proxy-middleware/blob/v2.0.9/CHANGELOG.md)


	- [Commits](https://github.com/chimurai/http-proxy-middleware/compare/v2.0.7...v2.0.9)


	


	---


	updated-dependencies:


	- dependency-name: http-proxy-middleware


	  dependency-version: 2.0.9


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [ad6dd7bcd88bfdf9602a057f52274376585fc7be] build(deps-dev): bump tar-fs
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [tar-fs](https://github.com/mafintosh/tar-fs).


	


	


	Updates `tar-fs` from 2.1.2 to 2.1.3


	- [Commits](https://github.com/mafintosh/tar-fs/commits)


	


	---


	updated-dependencies:


	- dependency-name: tar-fs


	  dependency-version: 2.1.3


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [c58e34314fda1efea8761da37ff9e1f9f799393c] build(deps): bump vite in the npm_and_yarn group across 1 directory
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite).


	


	


	Updates `vite` from 4.5.13 to 4.5.14


	- [Release notes](https://github.com/vitejs/vite/releases)


	- [Changelog](https://github.com/vitejs/vite/blob/v4.5.14/packages/vite/CHANGELOG.md)


	- [Commits](https://github.com/vitejs/vite/commits/v4.5.14/packages/vite)


	


	---


	updated-dependencies:


	- dependency-name: vite


	  dependency-version: 4.5.14


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [a72e8d2ca2dcfe8354b342c7546733906684207e] chore(deps): update dependency @testing-library/react to ^16.3.0
 
- [70075df3a5d4ff62aa877af608345306b3715740] chore(deps): update devdeps
 
- [c695ed95846bcc9d653a3fa61722472267852ed5] chore(deps): update postcss
 
- [f2eb049a4bbc14a5671ad0c1ea50ec8fdda923bf] chore(deps): update dependency core-js to ^3.43.0
 
- [bdccd45cd5fe618f7f6a943bd1aa0cc66a8e3a3b] chore(deps): update dependency globals to ^16.2.0
 
- [0c786734254cd5a338543899f594f150f5540f81] chore(deps): update eslint
 
- [dbd9425ef2bbe167c9c8f5a424610d54bee54601] chore(deps): update babel monorepo
 
- [fedb464a9ff569c2f60e3e04bf2bed038be9f0dd] chore(deps): update webpack
 
- [2eb9b59e49f0f9b28ee6d74ab65b8601f982cad7] fix(deps): update dependency react-datepicker to ^8.4.0
 
- [d84c38fe58b78405392f90df665c655a691c1231] chore(deps): update dependency babel-jest to v30
 
- [a6010d9ba1a231c9fa78aed9d2c831d369457e59] chore(deps): update dependency glob to ^11.0.3
 
- [9a562761462d7a3af01f0029ece8c2e65f56430d] chore(deps): update dependency commander to v14
 
- [28fb307333b2ef26e583c7a4b230a33054783e66] chore(deps): update dependency axios to ^1.10.0
 
- [d1afc6f68baeb921919eb961292762c38d281f19] chore(deps): update dependency lint-staged to v16
 
- [90216a59bf382a0d7b3c4fe9a6c0a39f8275aa7f] chore(deps): update dependency globals to ^16.3.0
 
- [d50bf98f43db41246424fd742af72805c1db95df] chore(deps): update jest to v30
 
- [55aac868ad4ee40eaf251db7e31a787146e968d6] chore(deps): update dependency svgo to v4
 
- [c5737223f49fc1fa66336e9fefa3bde8eba9cfa0] chore: eslint config changes
 
- [30ef40106d2705746142854fe2243af4df27a777] build(deps): bump the npm_and_yarn group across 1 directory with 2 updates
 
	


	Bumps the npm_and_yarn group with 2 updates in the / directory: [on-headers](https://github.com/jshttp/on-headers) and [compression](https://github.com/expressjs/compression).


	


	


	Updates `on-headers` from 1.0.2 to 1.1.0


	- [Release notes](https://github.com/jshttp/on-headers/releases)


	- [Changelog](https://github.com/jshttp/on-headers/blob/master/HISTORY.md)


	- [Commits](https://github.com/jshttp/on-headers/compare/v1.0.2...v1.1.0)


	


	Updates `compression` from 1.7.4 to 1.8.1


	- [Release notes](https://github.com/expressjs/compression/releases)


	- [Changelog](https://github.com/expressjs/compression/blob/master/HISTORY.md)


	- [Commits](https://github.com/expressjs/compression/compare/1.7.4...v1.8.1)


	


	---


	updated-dependencies:


	- dependency-name: on-headers


	  dependency-version: 1.1.0


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	- dependency-name: compression


	  dependency-version: 1.8.1


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [fd6a21f979dfd504fdb8d4e5b6ce67cd5def68f3] chore: dev deps upgrade
 
- [cdde901ef58c4d7f6b4451e62b160882fc1f9fe7] build(deps): bump the npm_and_yarn group across 1 directory with 1 update
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [form-data](https://github.com/form-data/form-data).


	


	


	Updates `form-data` from 3.0.1 to 4.0.4


	- [Release notes](https://github.com/form-data/form-data/releases)


	- [Changelog](https://github.com/form-data/form-data/blob/master/CHANGELOG.md)


	- [Commits](https://github.com/form-data/form-data/compare/v3.0.1...v4.0.4)


	


	Updates `form-data` from 4.0.0 to 4.0.4


	- [Release notes](https://github.com/form-data/form-data/releases)


	- [Changelog](https://github.com/form-data/form-data/blob/master/CHANGELOG.md)


	- [Commits](https://github.com/form-data/form-data/compare/v3.0.1...v4.0.4)


	


	---


	updated-dependencies:


	- dependency-name: form-data


	  dependency-version: 4.0.4


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	- dependency-name: form-data


	  dependency-version: 4.0.4


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [86bad03e9fd2714a497574aed7fe768358b86e6e] chore(deps): update dependency axios to ^1.11.0 [security]
 
- [482d9bca8daa703fc0742d88beb8a0f24e93ef86] chore: resolve code scan alert
 
- [fcd80a030489a8305048fe46c161a0b2030b5917] chore: storybook v9
 
- [159a162abcfc394e6450ba18b6daa63f7035a6d4] chore: vite
 
- [bbd0eac95f02adde319047ff128c1c60bd4b3b0e] build: release minor version 35.2.0
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v35.1.2...v35.2.0