### PR TITLE
v35.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "35.2.0",
+  "version": "35.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "35.2.0",
+      "version": "35.2.1",
       "license": "MIT",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "35.2.0",
+  "version": "35.2.1",
   "description": "Core component library. By Adslot",
   "type": "module",
   "main": "./dist/adslot-ui.cjs",


### PR DESCRIPTION
### Changes

- [8aa98bf32e6783baa4a45dde37a64e74f70fc645] fix: command for version
 
- [d252c50b2739048a2b9ed092b093ef47f9f2fe1e] chore(deps): update storybook monorepo to ^9.1.2
 
- [8abf926f216eb6b0185208355fed2a47193bd8a3] chore: rm commander pkg
 
- [c497750c19580c3fe07e2a0fc1a9359da0498c49] build: release patch version 35.2.1
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v35.2.0...v35.2.1