### PR TITLE
v35.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adslot-ui",
-  "version": "35.4.2",
+  "version": "35.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adslot-ui",
-      "version": "35.4.2",
+      "version": "35.5.0",
       "license": "MIT",
       "dependencies": {
         "@lexical/clipboard": "0.44.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adslot-ui",
-  "version": "35.4.2",
+  "version": "35.5.0",
   "description": "Core component library. By Adslot",
   "type": "module",
   "main": "./dist/adslot-ui.cjs",


### PR DESCRIPTION
### Changes

- [26698d12094a378c062a595a01c98a401bf45ce1] build(deps-dev): bump storybook
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [storybook](https://github.com/storybookjs/storybook/tree/HEAD/code/core).


	


	


	Updates `storybook` from 9.1.10 to 9.1.17


	- [Release notes](https://github.com/storybookjs/storybook/releases)


	- [Changelog](https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md)


	- [Commits](https://github.com/storybookjs/storybook/commits/v9.1.17/code/core)


	


	---


	updated-dependencies:


	- dependency-name: storybook


	  dependency-version: 9.1.17


	  dependency-type: direct:development


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [d115fcaaf7d78c7932b33071673045a57ab0fadc] chore: npm run audit to fix lodash dependabot alerts
 
- [4b46a4466cd0c4e5912f933b284492dc98eb1c99] chore(deps): update storybook monorepo to ^9.1.20
 
- [a0c8c1baed1475466fd3e8943809a7bcc7b6becd] chore: update storybook to 9.1.20
 
- [8c0f04dc3ea415fb6f7b01b3df12ba09b590b7f2] build(deps-dev): bump flatted
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [flatted](https://github.com/WebReflection/flatted).


	


	


	Updates `flatted` from 3.3.3 to 3.4.2


	- [Commits](https://github.com/WebReflection/flatted/compare/v3.3.3...v3.4.2)


	


	---


	updated-dependencies:


	- dependency-name: flatted


	  dependency-version: 3.4.2


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [24ec4f926c35962ed2556a7fd0e93ed7f08c86b6] build(deps): bump the npm_and_yarn group across 1 directory with 1 update
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [yaml](https://github.com/eemeli/yaml).


	


	


	Updates `yaml` from 1.10.2 to 1.10.3


	- [Release notes](https://github.com/eemeli/yaml/releases)


	- [Commits](https://github.com/eemeli/yaml/compare/v1.10.2...v1.10.3)


	


	Updates `yaml` from 2.8.1 to 2.8.3


	- [Release notes](https://github.com/eemeli/yaml/releases)


	- [Commits](https://github.com/eemeli/yaml/compare/v1.10.2...v1.10.3)


	


	---


	updated-dependencies:


	- dependency-name: yaml


	  dependency-version: 1.10.3


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	- dependency-name: yaml


	  dependency-version: 2.8.3


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [b3c796cb4d1dc5cac1d8e5389efb6df8313470c9] build(deps-dev): bump picomatch
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [picomatch](https://github.com/micromatch/picomatch).


	


	


	Updates `picomatch` from 2.3.1 to 2.3.2


	- [Release notes](https://github.com/micromatch/picomatch/releases)


	- [Changelog](https://github.com/micromatch/picomatch/blob/master/CHANGELOG.md)


	- [Commits](https://github.com/micromatch/picomatch/compare/2.3.1...2.3.2)


	


	---


	updated-dependencies:


	- dependency-name: picomatch


	  dependency-version: 2.3.2


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [8b2a1bee5ce1482f1e859a059090038febfe6623] chore(deps): update dependency @testing-library/react to ^16.3.2
 
- [a1e2976871e523f7505ec144841863cf54d2b0fc] chore(deps): update dependency svgo to ^4.0.1
 
- [f59bbb60978cfb927ff842b9e0be1961e874ef61] chore(deps): update eslint
 
- [71faaa2425ad6da9e59e5dbad1a4161db63dff9d] chore(deps): update postcss
 
- [2af2e6df532bf6d2d9e433ad0b46a7bf3749719b] fix(deps): update dependency @types/react to ^18.3.28
 
- [078c73fd3b1ac18429f9f53937f94bbb346475e6] chore(deps): update dependency @vitejs/plugin-react-swc to ^4.3.0
 
- [6c97e75e20bcca827783e04e99562f778194fb72] chore(deps): update dependency rimraf to ^6.1.3
 
- [9bf7dd0ae5e6030377efaf3c5552bca7a1df69be] chore(deps): update dependency vite to ^7.3.2 [security]
 
- [70aff1b0ceab2df7e82fc6e86003b25573f40a67] chore(deps): update dependency lodash to ^4.18.1 [security]
 
- [1affb7563e9ffc5101c094eea9174e8c6a42f4f0] chore(deps): update devdeps
 
- [1efb7d9b04673d8b6f3e10085296fe593d89680e] chore(deps): update actions/checkout action to v6
 
- [197c8a45707d62705091a2f0470bee062995d911] chore(deps): update actions/setup-node action to v6
 
- [44678a0917a9b826315f93aa89ad47dc1ee00935] chore(deps): update codecov/codecov-action action to v6
 
- [1af2fffc6b8b653f1f2abe7ccfe094c822d57f94] chore(deps): update jest
 
- [52bcec0dbcb163bdb91c54902e71efb57a13b54a] build(deps): bump lodash-es in the npm_and_yarn group across 1 directory
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [lodash-es](https://github.com/lodash/lodash).


	


	


	Updates `lodash-es` from 4.17.23 to 4.18.1


	- [Release notes](https://github.com/lodash/lodash/releases)


	- [Commits](https://github.com/lodash/lodash/compare/4.17.23...4.18.1)


	


	---


	updated-dependencies:


	- dependency-name: lodash-es


	  dependency-version: 4.18.1


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [c2c4f496479eb59c78cb5c0ae6f4567f56e040d3] chore(deps): update github/codeql-action action to v4
 
- [dc1b81b154b4d388936691d9acc8b2af0ca3a08b] chore(deps): update mcr.microsoft.com/vscode/devcontainers/javascript-node docker tag to v24
 
- [c2859adb7ba26912d2bc14312143f8c67964ef7d] chore(deps): update devdeps
 
- [f6ae7ceab6edb455cde0f8eb628fee2ef9b80e37] fix: fix stylelint errors after upgrade
 
- [604b66862f2c60805de6ad37ff6d885b7473c189] build(deps-dev): bump axios in the npm_and_yarn group across 1 directory
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [axios](https://github.com/axios/axios).


	


	


	Updates `axios` from 1.13.6 to 1.15.0


	- [Release notes](https://github.com/axios/axios/releases)


	- [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)


	- [Commits](https://github.com/axios/axios/compare/v1.13.6...v1.15.0)


	


	---


	updated-dependencies:


	- dependency-name: axios


	  dependency-version: 1.15.0


	  dependency-type: direct:development


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [13157f5d54cac37c4f8dbd4e5f2e113e5e556db5] build(deps-dev): bump follow-redirects
 
	


	Bumps the npm_and_yarn group with 1 update in the / directory: [follow-redirects](https://github.com/follow-redirects/follow-redirects).


	


	


	Updates `follow-redirects` from 1.15.11 to 1.16.0


	- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)


	- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.11...v1.16.0)


	


	---


	updated-dependencies:


	- dependency-name: follow-redirects


	  dependency-version: 1.16.0


	  dependency-type: indirect


	  dependency-group: npm_and_yarn


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [e1d2fd667419a5c76ce941b5f662fed62475d192] chore(deps): update dependency axios to ^1.15.2 [security]
 
- [4daf757fafdaa484b77c84eeb7fabacdd76b1887] chore(deps): update dependency postcss to ^8.5.10 [security]
 
- [1a87a4c43bdb10ffa63f8fa3a3e3657d649d9f8a] chore: migrate axios to whatwg fetch api
 
- [d4868050498ea1e488a3d24f045e52148caa5a38] refactor: replace draft-js with lexical in richTextEditor
 
- [0d52c7ee6b72a1fc3241e3f3cf0baf68f791c05e] build: release minor version 35.5.0
 

### Comparison
https://github.com/Adslot/adslot-ui/compare/v35.4.2...v35.5.0